### PR TITLE
Debounces inline completion until user stopped typing

### DIFF
--- a/src/activationHelpers/contextAware/tsLanguageServer.ts
+++ b/src/activationHelpers/contextAware/tsLanguageServer.ts
@@ -3,6 +3,7 @@
 import * as vscode from "vscode";
 import {
     triggerInlineCompletion,
+    disableInlineCompletion,
     provideInlineCompletionItems,
 } from "../../providers/translationSuggestions/inlineCompletionsProvider";
 
@@ -21,11 +22,22 @@ export async function langugeServerTS (context: vscode.ExtensionContext){
         triggerInlineCompletion,
     );
 
+    // debounce timer for sending completion request
+    let debounceTimer = setTimeout(() => {}, 0);
+
     vscode.workspace.onDidChangeTextDocument((e) => {
-        const shouldTriggerInlineCompletion = e.contentChanges.length > 0;
-        if (shouldTriggerInlineCompletion) {
-            triggerInlineCompletion();
-        }
+         // Clear previous debounce timer
+         clearTimeout(debounceTimer);
+         disableInlineCompletion();
+ 
+         // Set new debounce timer
+         debounceTimer = setTimeout(() => {
+             // Handle the event that the user has stopped editing the document
+             const shouldTriggerInlineCompletion = e.contentChanges.length > 0;
+             if (shouldTriggerInlineCompletion) {
+                 triggerInlineCompletion();
+             }
+         }, 500);
     });
 
     context.subscriptions.push(commandDisposable);

--- a/src/providers/translationSuggestions/inlineCompletionsProvider.ts
+++ b/src/providers/translationSuggestions/inlineCompletionsProvider.ts
@@ -250,5 +250,5 @@ export function triggerInlineCompletion() {
 }
 
 export function disableInlineCompletion() {
-    shouldProvideCompletion = true;
+    shouldProvideCompletion = false;
 }

--- a/src/providers/translationSuggestions/inlineCompletionsProvider.ts
+++ b/src/providers/translationSuggestions/inlineCompletionsProvider.ts
@@ -248,3 +248,7 @@ export function triggerInlineCompletion() {
     shouldProvideCompletion = true;
     vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
 }
+
+export function disableInlineCompletion() {
+    shouldProvideCompletion = true;
+}


### PR DESCRIPTION
Uses a timer to prevent flooding the text-completion processor. This results in faster response from the model as there are fewer unused queries.

Feel free to make changes as I was using Windows to run it.