### PR TITLE
Minimal UI settings for editor workspace

### DIFF
--- a/src/activationHelpers/contextUnaware/projectInitializers.ts
+++ b/src/activationHelpers/contextUnaware/projectInitializers.ts
@@ -361,6 +361,14 @@ export async function checkForMissingFiles(){
 export async function handleConfig(){
     const config = vscode.workspace.getConfiguration();
 
+    // simplify editor UI when lauching to avoid overwhelming the user
+    config.update('window.menuBarVisibility', 'toggle', vscode.ConfigurationTarget.Global);
+    config.update('window.commandCenter', false, vscode.ConfigurationTarget.Workspace);
+    config.update('workbench.layoutControl.enabled', false, vscode.ConfigurationTarget.Workspace);
+    config.update('workbench.statusBar.visible', false, vscode.ConfigurationTarget.Workspace);
+    config.update('workbench.editor.showTabs', 'single', vscode.ConfigurationTarget.Workspace);
+    config.update('breadcrumbs.enabled', false, vscode.ConfigurationTarget.Workspace);
+
     config.update(
         "editor.wordWrap",
         "on",


### PR DESCRIPTION
Toggles away some of the menus and panels to avoid overwhelming the user/translator 