### PR TITLE
Fix footnote deletion styling bug

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -518,7 +518,8 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                         if (quillRef.current && props.onChange) {
                             const content = quillRef.current.root.innerHTML;
                             const cleanedContents = getCleanedHtml(content);
-                            props.onChange({ html: cleanedContents });
+                            const processedContents = processHtmlContent(cleanedContents);
+                            props.onChange({ html: processedContents });
                         }
 
                         // Renumber remaining footnotes (now preserves cursor automatically)
@@ -659,9 +660,14 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                     setUnsavedChanges(true);
                     if (props.onChange) {
                         const contentIsEmpty = isQuillEmpty(quill);
+                        
+                        // Clean the content to remove VSCode selection styles and other unwanted formatting
+                        const cleanedContent = getCleanedHtml(content);
+                        const processedContent = processHtmlContent(cleanedContent);
+                        
                         const finalContent = contentIsEmpty
                             ? ""
-                            : processQuillContentForSaving(getCleanedHtml(content));
+                            : processQuillContentForSaving(processedContent);
 
                         debug("finalContent", { finalContent, contentIsEmpty });
 
@@ -803,7 +809,9 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                     // Validate that the completion is for the current cell
                     if (completionCellId === props.currentLineId) {
                         quill.root.innerHTML = completionText; // Clear existing content
-                        props.onChange?.({ html: quill.root.innerHTML });
+                        const cleanedContent = getCleanedHtml(quill.root.innerHTML);
+                        const processedContent = processHtmlContent(cleanedContent);
+                        props.onChange?.({ html: processedContent });
                         setUnsavedChanges(true);
                     } else {
                         console.warn(
@@ -1106,7 +1114,9 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
 
         // Trigger the onChange callback to notify the parent
         if (props.onChange) {
-            props.onChange({ html: quill.root.innerHTML });
+            const cleanedContent = getCleanedHtml(quill.root.innerHTML);
+            const processedContent = processHtmlContent(cleanedContent);
+            props.onChange({ html: processedContent });
         }
 
         // Reset editing state
@@ -1181,7 +1191,9 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
 
                 // Trigger the onChange callback to notify the parent
                 if (props.onChange) {
-                    props.onChange({ html: content });
+                    const cleanedContent = getCleanedHtml(content);
+                    const processedContent = processHtmlContent(cleanedContent);
+                    props.onChange({ html: processedContent });
                 }
 
                 // Update header label after content change
@@ -1194,7 +1206,9 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
             // Trigger change event and callback after renumbering
             setUnsavedChanges(true);
             if (props.onChange && quillRef.current) {
-                props.onChange({ html: quillRef.current.root.innerHTML });
+                const cleanedContent = getCleanedHtml(quillRef.current.root.innerHTML);
+                const processedContent = processHtmlContent(cleanedContent);
+                props.onChange({ html: processedContent });
             }
         },
     }));


### PR DESCRIPTION
Remove VSCode selection highlighting styles from saved content to prevent unwanted background colors.

When users pressed backspace near footnotes, temporary VSCode selection styles were incorrectly persisted in the saved cell content, leading to unwanted background highlighting. This PR introduces a new cleaning step in the content processing pipeline to strip these specific styles before saving.

---

[Open in Web](https://cursor.com/agents?id=bc-08949b29-38dd-48a7-b5bb-4c698ae71411) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-08949b29-38dd-48a7-b5bb-4c698ae71411) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)