### PR TITLE
Add disableUiMinification setting to allow developers to preserve VSCode UI elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -578,6 +578,12 @@
             {
                 "title": "Codex Extension",
                 "properties": {
+                    "codex-editor-extension.disableUiMinification": {
+                        "title": "Disable UI Minification",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When enabled, prevents the extension from hiding VSCode interface elements to provide a cleaner translation studio experience. Useful for developers who want to access VSCode features."
+                    },
                     "codex-editor-extension.api_key": {
                         "title": "API Key",
                         "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,9 +247,14 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
         // Configure editor layout
         const layoutStart = globalThis.performance.now();
-        // Use maximizeEditorHideSidebar directly to create a clean, focused editor experience on startup
-        // note: there may be no active editor yet, so we need to see if the welcome view is needed initially
-        await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
+        // Check if UI minification is disabled
+        const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
+
+        if (!disableUiMinification) {
+            // Use maximizeEditorHideSidebar directly to create a clean, focused editor experience on startup
+            // note: there may be no active editor yet, so we need to see if the welcome view is needed initially
+            await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
+        }
         stepStart = trackTiming("Configuring Editor Layout", layoutStart);
 
         // Setup pre-activation commands
@@ -605,24 +610,31 @@ async function watchForInitialization(context: vscode.ExtensionContext, metadata
 }
 
 async function executeCommandsBefore(context: vscode.ExtensionContext) {
+    // Check if UI minification is disabled
+    const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
+
     // Start status bar command non-blocking
     void vscode.commands.executeCommand("workbench.action.toggleStatusbarVisibility");
 
     // Batch all config updates with Promise.all instead of sequential awaits
     const config = vscode.workspace.getConfiguration();
-    await Promise.all([
-        config.update("workbench.statusBar.visible", false, true),
-        config.update("breadcrumbs.filePath", "last", true),
-        config.update("breadcrumbs.enabled", false, true), // hide breadcrumbs for now... it shows the file name which cannot be localized
-        config.update("workbench.editor.editorActionsLocation", "hidden", true),
-        config.update("workbench.editor.showTabs", "none", true), // Hide tabs during splash screen
-        config.update("window.autoDetectColorScheme", true, true),
-        config.update("workbench.editor.revealIfOpen", true, true),
-        config.update("workbench.layoutControl.enabled", false, true),
-        config.update("workbench.tips.enabled", false, true),
-        config.update("workbench.editor.limit.perEditorGroup", false, true),
-        config.update("workbench.editor.limit.value", 4, true),
-    ]);
+
+    if (!disableUiMinification) {
+        // Only hide UI elements if minification is enabled
+        await Promise.all([
+            config.update("workbench.statusBar.visible", false, true),
+            config.update("breadcrumbs.filePath", "last", true),
+            config.update("breadcrumbs.enabled", false, true), // hide breadcrumbs for now... it shows the file name which cannot be localized
+            config.update("workbench.editor.editorActionsLocation", "hidden", true),
+            config.update("workbench.editor.showTabs", "none", true), // Hide tabs during splash screen
+            config.update("workbench.layoutControl.enabled", false, true),
+            config.update("workbench.tips.enabled", false, true),
+            config.update("workbench.editor.limit.perEditorGroup", false, true),
+            config.update("workbench.editor.limit.value", 4, true),
+            config.update("window.autoDetectColorScheme", true, true),
+            config.update("workbench.editor.revealIfOpen", true, true),
+        ]);
+    }
 
     registerCommandsBefore(context);
 }
@@ -659,10 +671,18 @@ async function executeCommandsAfter(context: vscode.ExtensionContext) {
         debug(
             "[Extension] Splash screen closed, checking if welcome view needs to be shown"
         );
-        // Show tabs again after splash screen closes
-        await vscode.workspace
-            .getConfiguration()
-            .update("workbench.editor.showTabs", "multiple", true);
+
+        // Check if UI minification is disabled
+        const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
+
+        // Only show tabs again if minification is enabled (default behavior)
+        // If minification is disabled, tabs should already be visible
+        if (!disableUiMinification) {
+            // Show tabs again after splash screen closes
+            await vscode.workspace
+                .getConfiguration()
+                .update("workbench.editor.showTabs", "multiple", true);
+        }
         // Restore tab layout after splash screen closes
         await restoreTabLayout(context);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -613,8 +613,11 @@ async function executeCommandsBefore(context: vscode.ExtensionContext) {
     // Check if UI minification is disabled
     const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
 
-    // Start status bar command non-blocking
-    void vscode.commands.executeCommand("workbench.action.toggleStatusbarVisibility");
+    // Only toggle status bar visibility if minification is enabled
+    if (!disableUiMinification) {
+        // Start status bar command non-blocking
+        void vscode.commands.executeCommand("workbench.action.toggleStatusbarVisibility");
+    }
 
     // Batch all config updates with Promise.all instead of sequential awaits
     const config = vscode.workspace.getConfiguration();
@@ -651,17 +654,23 @@ async function executeCommandsAfter(context: vscode.ExtensionContext) {
         console.warn("Failed to set editor font, possibly due to network issues:", error);
     }
 
-    // Configure auto-save in settings
-    await vscode.workspace
-        .getConfiguration()
-        .update("files.autoSave", "afterDelay", vscode.ConfigurationTarget.Global);
-    await vscode.workspace
-        .getConfiguration()
-        .update("files.autoSaveDelay", 1000, vscode.ConfigurationTarget.Global);
+    // Check if UI minification is disabled
+    const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
 
-    await vscode.workspace
-        .getConfiguration()
-        .update("codex-project-manager.spellcheckIsEnabled", false, vscode.ConfigurationTarget.Global);
+    // Only apply opinionated global settings if UI minification is enabled (not disabled)
+    if (!disableUiMinification) {
+        // Configure auto-save in settings - only when minification is enabled
+        await vscode.workspace
+            .getConfiguration()
+            .update("files.autoSave", "afterDelay", vscode.ConfigurationTarget.Global);
+        await vscode.workspace
+            .getConfiguration()
+            .update("files.autoSaveDelay", 1000, vscode.ConfigurationTarget.Global);
+
+        await vscode.workspace
+            .getConfiguration()
+            .update("codex-project-manager.spellcheckIsEnabled", false, vscode.ConfigurationTarget.Global);
+    }
 
     // Final splash screen update and close
     updateSplashScreenSync(100, "Finalizing setup...");
@@ -678,7 +687,7 @@ async function executeCommandsAfter(context: vscode.ExtensionContext) {
         // Only show tabs again if minification is enabled (default behavior)
         // If minification is disabled, tabs should already be visible
         if (!disableUiMinification) {
-            // Show tabs again after splash screen closes
+            // Show tabs again after splash screen closes - only when minification was enabled
             await vscode.workspace
                 .getConfiguration()
                 .update("workbench.editor.showTabs", "multiple", true);

--- a/src/projectManager/projectInitializers.ts
+++ b/src/projectManager/projectInitializers.ts
@@ -55,19 +55,24 @@ export async function setTargetFont() {
                 );
             }
         }
-        const config = vscode.workspace.getConfiguration();
-        const fallbackFont = "serif";
-        // config.update(
-        //     "editor.fontFamily",
-        //     fallbackFont,
-        //     vscode.ConfigurationTarget.Workspace,
-        // );
-        config.update(
-            "editor.fontFamily",
-            `${defaultFontFamily} ${fallbackFont}`,
-            vscode.ConfigurationTarget.Workspace
-        );
-        console.log(`Font set to ${defaultFontFamily} with fallback to ${fallbackFont}`);
+        // Check if UI minification is disabled before setting font
+        const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
+        
+        if (!disableUiMinification) {
+            const config = vscode.workspace.getConfiguration();
+            const fallbackFont = "serif";
+            // config.update(
+            //     "editor.fontFamily",
+            //     fallbackFont,
+            //     vscode.ConfigurationTarget.Workspace,
+            // );
+            config.update(
+                "editor.fontFamily",
+                `${defaultFontFamily} ${fallbackFont}`,
+                vscode.ConfigurationTarget.Workspace
+            );
+            console.log(`Font set to ${defaultFontFamily} with fallback to ${fallbackFont}`);
+        }
     }
 }
 enum ConfirmationOptions {

--- a/src/providers/SplashScreen/SplashScreenProvider.ts
+++ b/src/providers/SplashScreen/SplashScreenProvider.ts
@@ -77,9 +77,14 @@ export class SplashScreenProvider {
         // Execute UI commands in background after splash is visible
         setTimeout(async () => {
             try {
-                // Maximize editor and hide tab bar after splash is shown
-                await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
-                debug("[SplashScreen] Maximized editor layout");
+                // Check if UI minification is disabled
+                const disableUiMinification = vscode.workspace.getConfiguration("codex-editor-extension").get("disableUiMinification", false);
+                
+                if (!disableUiMinification) {
+                    // Maximize editor and hide tab bar after splash is shown
+                    await vscode.commands.executeCommand("workbench.action.maximizeEditorHideSidebar");
+                    debug("[SplashScreen] Maximized editor layout");
+                }
             } catch (error) {
                 console.warn("Failed to execute maximize command:", error);
             }


### PR DESCRIPTION
This PR introduces a new configuration setting `codex-editor-extension.disableUiMinification` that allows developers to prevent the extension from hiding VSCode (or VSCodium) interface elements.

### Changes Made:

1. __Added new configuration setting__ in `package.json`:

   - `codex-editor-extension.disableUiMinification` (boolean, default: false)
   - When enabled, prevents hiding of VSCode interface elements like status bar, breadcrumbs, tabs, etc.

2. __Modified extension activation logic__ in `src/extension.ts`:

   - Added checks for the `disableUiMinification` setting before applying UI minification
   - Conditionally execute UI hiding commands only when minification is enabled
   - Updated `executeCommandsBefore` and `executeCommandsAfter` functions to respect the setting
   - Fixed status bar toggle to only execute when minification is enabled

3. __Updated SplashScreenProvider__ in `src/providers/SplashScreen/SplashScreenProvider.ts`:

   - Added conditional check for UI minification before maximizing editor layout

4. __Updated project initializers__ in `src/projectManager/projectInitializers.ts`:

   - Added checks to only set target font when UI minification is enabled

### Benefits:

- __Developer Experience__: Developers can now access full VSCode functionality while using the extension
- __Configurable UI__: Users can choose between a clean translation studio experience or full VSCode interface
- __Backward Compatibility__: Default behavior remains unchanged (minification enabled by default)

### Usage:

Add `"codex-editor-extension.disableUiMinification": true` to your VSCode settings.json to preserve all VSCode (or VSCodium) UI elements.
