### PR TITLE
Use delete flag for cell metadata

### DIFF
--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -536,10 +536,10 @@ async function exportCodexContentAsPlaintext(
                     let currentChapter = "";
                     let chapterContent = "";
 
-                    // Filter out merged cells before processing
+                    // Filter out merged and deleted cells before processing
                     const activeCells = cells.filter((cell) => {
                         const metadata = cell.metadata;
-                        return !metadata?.data?.merged;
+                        return !metadata?.data?.merged && !metadata?.data?.deleted;
                     });
 
                     for (const cell of activeCells) {
@@ -825,7 +825,8 @@ async function exportCodexContentAsUsfm(
                                 return cell.kind === 2 && // vscode.NotebookCellKind.Code
                                     cell.metadata?.type &&
                                     cell.value.trim().length > 0 &&
-                                    !metadata?.merged; // Exclude merged cells
+                                    !metadata?.merged && // Exclude merged cells
+                                    !metadata?.deleted; // Exclude deleted cells
                             }
                         );
 
@@ -1210,10 +1211,10 @@ async function exportCodexContentAsHtml(
                     const bookCode = basename(file.fsPath).split(".")[0] || "";
                     const chapters: { [key: string]: string; } = {};
 
-                    // Filter out merged cells before processing
+                    // Filter out merged and deleted cells before processing
                     const activeCells = cells.filter((cell) => {
                         const metadata = cell.metadata;
-                        return !metadata?.data?.merged;
+                        return !metadata?.data?.merged && !metadata?.data?.deleted;
                     });
 
                     // First pass: Organize content by chapters

--- a/src/exportHandler/subtitleUtils.ts
+++ b/src/exportHandler/subtitleUtils.ts
@@ -39,10 +39,10 @@ export function generateSrtData(
     let output = "";
     let index = 1;
 
-    // Filter out merged cells before processing
+    // Filter out merged and deleted cells before processing
     const activeCells = cells.filter((unit) => {
         const metadata = unit.metadata;
-        return !metadata?.data?.merged;
+        return !metadata?.data?.merged && !metadata?.data?.deleted;
     });
 
     activeCells.forEach((unit) => {

--- a/src/exportHandler/vttUtils.ts
+++ b/src/exportHandler/vttUtils.ts
@@ -66,10 +66,10 @@ export const generateVttData = (
     };
 
     const cues = cells
-        // Filter out merged cells before processing
+        // Filter out merged and deleted cells before processing
         .filter((unit) => {
             const metadata = unit.metadata;
-            return !metadata?.data?.merged && !!unit.metadata?.data?.startTime;
+            return !metadata?.data?.merged && !metadata?.data?.deleted && !!unit.metadata?.data?.startTime;
         })
         .map((unit, index) => {
             const startTime = unit.metadata?.data?.startTime ?? index;

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -561,7 +561,12 @@ export async function resolveCodexCustomMerge(
                 value: finalValue,
                 metadata: {
                     ...{ ...theirCell.metadata, ...ourCell.metadata, }, // Fixme: this needs to be triangulated based on the last common commit
-                    data: { ...theirCell.metadata?.data, ...ourCell.metadata?.data, },
+                    data: { 
+                        ...theirCell.metadata?.data, 
+                        ...ourCell.metadata?.data,
+                        // Handle deleted flag: if either version marks the cell as deleted, keep it deleted
+                        deleted: (ourCell.metadata?.data?.deleted || theirCell.metadata?.data?.deleted) || false,
+                    },
                     cellLabel: cellLabelToUse,
                     id: cellId,
                     edits: finalEdits,

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -401,6 +401,12 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         document.deleteCell(typedEvent.content.cellId);
     },
 
+    restoreCell: ({ event, document }) => {
+        const typedEvent = event as Extract<EditorPostMessages, { command: "restoreCell"; }>;
+        console.log("restoreCell message received", { event });
+        document.restoreCell(typedEvent.content.cellId);
+    },
+
     updateCellTimestamps: ({ event, document }) => {
         const typedEvent = event as Extract<EditorPostMessages, { command: "updateCellTimestamps"; }>;
         console.log("updateCellTimestamps message received", { event });

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -1446,6 +1446,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
             timestamps: cell.metadata?.data, // FIXME: add strong types because this is where the timestamps are and it's not clear
             cellLabel: cell.metadata?.cellLabel,
             merged: cell.metadata?.data?.merged,
+            deleted: cell.metadata?.data?.deleted || false,
+            data: cell.metadata?.data,
         }));
         debug("Translation units:", translationUnits);
 
@@ -1496,6 +1498,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                 timestamps: cell.timestamps,
                 cellLabel: cell.cellLabel,
                 merged: cell.merged,
+                deleted: cell.deleted,
+                data: cell.data,
             });
         });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -614,6 +614,7 @@ export type EditorPostMessages =
     | { command: "searchSimilarCellIds"; content: { cellId: string; }; }
     | { command: "updateCellTimestamps"; content: { cellId: string; timestamps: Timestamps; }; }
     | { command: "deleteCell"; content: { cellId: string; }; }
+    | { command: "restoreCell"; content: { cellId: string; }; }
     | { command: "addWord"; words: string[]; }
     | { command: "getAlertCodes"; content: GetAlertCodes; }
     | { command: "executeCommand"; content: { command: string; args: any[]; }; }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,4 +249,35 @@ const testConfig = {
     },
 };
 
-module.exports = [extensionConfig, serverConfig, testConfig];
+const runTestConfig = {
+    name: "runTest",
+    target: "node",
+    mode: "none",
+    entry: "./src/test/runTest.ts",
+    output: {
+        path: path.resolve(__dirname, "out", "test"),
+        filename: "runTest.js",
+        libraryTarget: "commonjs2",
+    },
+    externals: {
+        vscode: "commonjs vscode",
+    },
+    resolve: {
+        extensions: [".ts", ".js"],
+        alias: {
+            "@": path.resolve(__dirname, "src"),
+        },
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: "ts-loader",
+            },
+        ],
+    },
+    devtool: "nosources-source-map",
+};
+
+module.exports = [extensionConfig, serverConfig, testConfig, runTestConfig];

--- a/webviews/codex-webviews/src/CodexCellEditor/ConfirmationButton.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/ConfirmationButton.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from "react";
 import { Button } from "../components/ui/button";
-import { Check, X, Trash2 } from "lucide-react";
+import { Check, X, Trash2, RotateCcw } from "lucide-react";
 
 interface ConfirmationButtonProps {
     onClick: () => void;
     disabled?: boolean;
     icon: string;
+    title?: string;
 }
 
 const ConfirmationButton: React.FC<ConfirmationButtonProps> = ({
     onClick,
     disabled = false,
     icon,
+    title,
 }) => {
     const [showConfirmation, setShowConfirmation] = useState(false);
 
@@ -32,8 +34,21 @@ const ConfirmationButton: React.FC<ConfirmationButtonProps> = ({
         switch (icon) {
             case "trash":
                 return <Trash2 className="h-4 w-4" />;
+            case "RotateCcw":
+                return <RotateCcw className="h-4 w-4" />;
             default:
                 return <Trash2 className="h-4 w-4" />;
+        }
+    };
+
+    const getDefaultTitle = () => {
+        switch (icon) {
+            case "trash":
+                return "Delete";
+            case "RotateCcw":
+                return "Restore";
+            default:
+                return "Delete";
         }
     };
 
@@ -66,7 +81,7 @@ const ConfirmationButton: React.FC<ConfirmationButtonProps> = ({
             disabled={disabled}
             variant="ghost"
             size="icon"
-            title="Delete"
+            title={title || getDefaultTitle()}
         >
             {getIcon()}
         </Button>

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -1274,11 +1274,28 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                     </Button>
                                 )}
                                 {!sourceCellContent && (
-                                    <ConfirmationButton
-                                        icon="trash"
-                                        onClick={deleteCell}
-                                        disabled={cellHasContent}
-                                    />
+                                    cell.data?.deleted ? (
+                                        <ConfirmationButton
+                                            icon="RotateCcw"
+                                            onClick={() => {
+                                                const messageContent: EditorPostMessages = {
+                                                    command: "restoreCell",
+                                                    content: {
+                                                        cellId: cellMarkers[0],
+                                                    },
+                                                };
+                                                window.vscodeApi.postMessage(messageContent);
+                                            }}
+                                            title="Restore Cell"
+                                        />
+                                    ) : (
+                                        <ConfirmationButton
+                                            icon="trash"
+                                            onClick={deleteCell}
+                                            disabled={cellHasContent}
+                                            title="Delete Cell"
+                                        />
+                                    )
                                 )}
                                 <Button
                                     onClick={handlePinCell}


### PR DESCRIPTION
Implement soft deletion for cells by setting a 'deleted' flag to prevent data loss during sync and enable restoration.

The previous cell deletion mechanism physically removed content, leading to data loss when syncing with other users who may have modified the same file. This PR introduces a 'deleted' flag in cell metadata, ensuring that deletions are preserved across syncs and allowing users to restore previously deleted cells. This also ensures deleted cells are excluded from exports while remaining visible for restoration in the editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-746032f4-eb3f-46ab-a715-136a9df4f2ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-746032f4-eb3f-46ab-a715-136a9df4f2ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

