### PR TITLE
Verify and fix LLM context retrieval from SQLite

### DIFF
--- a/src/activationHelpers/contextAware/contentIndexes/indexes/search.ts
+++ b/src/activationHelpers/contextAware/contentIndexes/indexes/search.ts
@@ -180,8 +180,8 @@ export async function getTranslationPairsFromSourceCellQuery(
         console.warn("[getTranslationPairsFromSourceCellQuery] SearchManager failed, falling back to legacy path:", error);
     }
 
-    // Legacy fallback
-    const initialLimit = Math.max(k * 6, 30);
+    // Legacy fallback - request more for better diversity
+    const initialLimit = Math.max(k * 10, 50);
     let results: any[] = [];
 
     if (translationPairsIndex instanceof SQLiteIndexManager) {
@@ -192,7 +192,8 @@ export async function getTranslationPairsFromSourceCellQuery(
     }
 
     if (results.length === 0 && translationPairsIndex instanceof SQLiteIndexManager) {
-        results = await translationPairsIndex.searchCompleteTranslationPairsWithValidation('', Math.max(k * 2, 10), false, onlyValidated);
+        // Get more diverse results when no query-specific results found
+        results = await translationPairsIndex.searchCompleteTranslationPairsWithValidation('', Math.max(k * 5, 20), false, onlyValidated);
     }
 
     const translationPairs: TranslationPair[] = [];

--- a/src/activationHelpers/contextAware/contentIndexes/indexes/sqliteIndex.ts
+++ b/src/activationHelpers/contextAware/contentIndexes/indexes/sqliteIndex.ts
@@ -3154,7 +3154,7 @@ export class SQLiteIndexManager {
 
 
 
-        // FTS5 query with validation filtering
+        // FTS5 query with validation filtering - search both source and target content
         const sql = `
             SELECT 
                 c.cell_id,
@@ -3168,7 +3168,6 @@ export class SQLiteIndexManager {
             LEFT JOIN files s_file ON c.s_file_id = s_file.id
             LEFT JOIN files t_file ON c.t_file_id = t_file.id
             WHERE cells_fts MATCH ?
-                AND cells_fts.content_type = 'source'
                 AND c.s_content IS NOT NULL 
                 AND c.s_content != ''
                 AND c.t_content IS NOT NULL 
@@ -3181,7 +3180,7 @@ export class SQLiteIndexManager {
         const results = [];
 
         try {
-            stmt.bind([cleanQuery, limit * 3]); // Get more results to account for validation filtering
+            stmt.bind([cleanQuery, limit * 5]); // Get more results for better diversity and validation filtering
 
             while (stmt.step()) {
                 const row = stmt.getAsObject();

--- a/src/activationHelpers/contextAware/contentIndexes/searchAlgorithms/searchManager.ts
+++ b/src/activationHelpers/contextAware/contentIndexes/searchAlgorithms/searchManager.ts
@@ -120,8 +120,8 @@ export class SearchManager {
         k: number = 5,
         onlyValidated: boolean = false
     ): Promise<TranslationPair[]> {
-        // Request more results for filtering (current behavior)
-        const initialLimit = Math.max(k * 6, 30);
+        // Request more results for filtering and better diversity
+        const initialLimit = Math.max(k * 10, 50);
         
         const options: Partial<SearchOptions> = {
             limit: k, // Final limit

--- a/src/copilotSettings/copilotSettings.ts
+++ b/src/copilotSettings/copilotSettings.ts
@@ -203,7 +203,7 @@ export async function openSystemMessageEditor() {
                                 sourceBookWhitelist: "",
                                 mainChatLanguage: "en",
                                 chatSystemMessage: "",
-                                numberOfFewShotExamples: 0,
+                                numberOfFewShotExamples: 30,
                                 debugMode: false,
                                 useOnlyValidatedExamples: false,
                                 abTestingEnabled: false,


### PR DESCRIPTION
Enable few-shot examples by default and enhance context retrieval by broadening FTS5 search, improving word overlap filtering, and increasing candidate diversity.

The default `numberOfFewShotExamples` was set to 0, preventing any few-shot examples from being used. Additionally, the FTS5 search was restricted to source content only, and word overlap filtering was too narrow. These changes ensure the LLM context is populated with more relevant and diverse examples from the entire SQLite database.

---
<a href="https://cursor.com/background-agent?bcId=bc-66a6926d-2e5a-47b5-8e75-ea1d3ff1ef14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66a6926d-2e5a-47b5-8e75-ea1d3ff1ef14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

