### PR TITLE
Fix target search scope bug

### DIFF
--- a/src/activationHelpers/contextAware/contentIndexes/indexes/index.ts
+++ b/src/activationHelpers/contextAware/contentIndexes/indexes/index.ts
@@ -870,8 +870,9 @@ export async function createIndexWithContext(context: vscode.ExtensionContext) {
                     const searchScope = options?.searchScope || "both";
                     // Request more results if we need to filter by searchScope
                     const searchLimit = searchScope !== "both" ? k * 3 : k;
-                    // For UI search, search both source and target when searchScope is "both", otherwise source-only
-                    const searchSourceOnly = searchScope === "both" ? false : true;
+                    // For UI search, search source-only only when searchScope is "source"
+                    // For "target" and "both", search both source and target (then filter for target if needed)
+                    const searchSourceOnly = searchScope === "source";
                     const searchResults = await translationPairsIndex.searchCompleteTranslationPairsWithValidation(
                         query,
                         searchLimit,


### PR DESCRIPTION
Fixes incorrect `searchSourceOnly` logic to enable target-only searches in the parallel passages webview.

When `searchScope` was `"target"`, `searchSourceOnly` was incorrectly set to `true`, causing the database to search only source content. This prevented cells where only the target contained the query from being returned, breaking target-only searches.

---
<a href="https://cursor.com/background-agent?bcId=bc-c13eb12d-d4c8-461b-8177-ffa00073d2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c13eb12d-d4c8-461b-8177-ffa00073d2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

