### PR TITLE
Show percentages of validated cells in a page range in the header menu

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/utils/progressUtils.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/progressUtils.ts
@@ -105,22 +105,14 @@ export function getProgressTitle(
 ): string {
     const completedLevels = getCompletedValidationLevels(validationLevels, requiredValidations);
     const validationLevelText = completedLevels > 0
-        ? `\n${completedLevels} level${completedLevels === 1 ? '' : 's'} of validation complete.`
+        ? `; ${completedLevels} level${completedLevels === 1 ? '' : 's'} of validation complete`
         : '';
 
-    if (validatedPercent >= 100) {
-        return `${label} fully validated${validationLevelText}`;
-    }
-    if (completedPercent >= 100) {
-        return `${label} fully translated${validationLevelText}`;
-    }
-    if (validatedPercent > 0) {
-        return `${label} partially validated${validationLevelText}`;
-    }
-    if (completedPercent > 0) {
-        return `${label} present${validationLevelText}`;
-    }
-    return `No ${label.toLowerCase()} progress${validationLevelText}`;
+    // Round percentages to whole numbers (they should already be integers, but ensure consistency)
+    const translationPercent = Math.round(completedPercent);
+    const validationPercent = Math.round(validatedPercent);
+
+    return `Translation: ${translationPercent}%\nValidation: ${validationPercent}%${validationLevelText}`;
 }
 
 export function getProgressDisplay(


### PR DESCRIPTION
- Change validation tooltips to only show validation percentage and levels of completed validation on hover.
- Show Translation percentage instead of text.

<img width="784" height="520" alt="Screenshot 2026-01-05 at 6 56 26 AM" src="https://github.com/user-attachments/assets/3c8aa6d3-ea91-4a0e-ae64-c6d1e12a2ff6" />
