### PR TITLE
Add webview tracking functionality and debug command

### DIFF
--- a/src/activationHelpers/contextAware/contentIndexes/indexes/index.ts
+++ b/src/activationHelpers/contextAware/contentIndexes/indexes/index.ts
@@ -1,5 +1,6 @@
 "use strict";
 import * as vscode from "vscode";
+import { trackWebviewPanel } from "../../../../utils/webviewTracker";
 import { getWorkSpaceFolder, getWorkSpaceUri } from "../../../../utils";
 import { IndexingStatusBarHandler } from "../statusBarHandler";
 
@@ -1013,6 +1014,7 @@ export async function createIndexWithContext(context: vscode.ExtensionContext) {
                         vscode.ViewColumn.One,
                         {}
                     );
+                    trackWebviewPanel(panel, "fileInfo", "contentIndexes.getFileInfo");
 
                     // Generate HTML content
                     panel.webview.html = `

--- a/src/bookNameSettings/bookNameSettings.ts
+++ b/src/bookNameSettings/bookNameSettings.ts
@@ -3,8 +3,15 @@ import * as vscode from "vscode";
 import * as xml2js from "xml2js";
 import { addMetadataEdit } from "@/utils/editMapUtils";
 import { getCorrespondingSourceUri } from "@/utils/codexNotebookUtils";
+import { trackWebviewPanel } from "../utils/webviewTracker";
+
+let currentPanel: vscode.WebviewPanel | undefined;
 
 export async function openBookNameEditor() {
+    if (currentPanel) {
+        currentPanel.reveal();
+        return;
+    }
     const panel = vscode.window.createWebviewPanel(
         "bookNameEditor",
         "Edit Book Names",
@@ -14,6 +21,11 @@ export async function openBookNameEditor() {
             retainContextWhenHidden: true,
         }
     );
+    trackWebviewPanel(panel, "bookNameEditor", "openBookNameEditor");
+    currentPanel = panel;
+    panel.onDidDispose(() => {
+        currentPanel = undefined;
+    });
 
     // Dynamic import for fs and path
     const fs = await import("fs");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ import { checkIfMetadataAndGitIsInitialized } from "./projectManager/utils/proje
 import { CommentsMigrator } from "./utils/commentsMigrationUtils";
 import { registerTestingCommands } from "./evaluation/testingCommands";
 import { initializeABTesting } from "./utils/abTestingSetup";
+import { dumpActiveWebviews } from "./utils/webviewTracker";
 import {
     migration_addValidationsForUserEdits,
     migration_moveTimestampsToMetadataData,
@@ -560,6 +561,12 @@ export async function activate(context: vscode.ExtensionContext) {
             initializeWebviews(context),
             (async () => registerTestingCommands(context))(),
         ]);
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand("codex-editor.debugWebviews", () => {
+                dumpActiveWebviews();
+            })
+        );
 
         // Initialize A/B testing registry (always-on)
         initializeABTesting();

--- a/src/licenseSettings/licenseSettings.ts
+++ b/src/licenseSettings/licenseSettings.ts
@@ -1,8 +1,15 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
+import { trackWebviewPanel } from "../utils/webviewTracker";
+
+let currentPanel: vscode.WebviewPanel | undefined;
 
 export async function openLicenseEditor() {
+    if (currentPanel) {
+        currentPanel.reveal();
+        return;
+    }
     const panel = vscode.window.createWebviewPanel(
         "licenseEditor",
         "Project License",
@@ -12,6 +19,11 @@ export async function openLicenseEditor() {
             retainContextWhenHidden: true,
         }
     );
+    trackWebviewPanel(panel, "licenseEditor", "openLicenseEditor");
+    currentPanel = panel;
+    panel.onDidDispose(() => {
+        currentPanel = undefined;
+    });
 
     // Get workspace folder
     const workspaceFolders = vscode.workspace.workspaceFolders;

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1,8 +1,15 @@
 import { CodexExportFormat } from "../exportHandler/exportHandler";
 import * as vscode from "vscode";
 import { safePostMessageToPanel } from "../utils/webviewUtils";
+import { trackWebviewPanel } from "../utils/webviewTracker";
+
+let currentPanel: vscode.WebviewPanel | undefined;
 
 export async function openProjectExportView(context: vscode.ExtensionContext) {
+    if (currentPanel) {
+        currentPanel.reveal();
+        return;
+    }
     const panel = vscode.window.createWebviewPanel(
         "projectExportView",
         "Export Project",
@@ -12,6 +19,11 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
             retainContextWhenHidden: true,
         }
     );
+    trackWebviewPanel(panel, "projectExportView", "openProjectExportView");
+    currentPanel = panel;
+    panel.onDidDispose(() => {
+        currentPanel = undefined;
+    });
 
     // Get project configuration
     const projectConfig = vscode.workspace.getConfiguration("codex-project-manager");

--- a/src/providers/EditAnalysisView/EditAnalysisViewProvider.ts
+++ b/src/providers/EditAnalysisView/EditAnalysisViewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { analyzeEditHistory } from "../../activationHelpers/contextAware/contentIndexes/indexes/editHistory";
 import { readLocalProjectSettings, writeLocalProjectSettings } from "../../utils/localProjectSettings";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 
 export class EditAnalysisProvider implements vscode.Disposable {
     public static readonly viewType = "codex-editor.editAnalysis";
@@ -28,6 +29,7 @@ export class EditAnalysisProvider implements vscode.Disposable {
                 retainContextWhenHidden: true,
             }
         );
+        trackWebviewPanel(this._panel, EditAnalysisProvider.viewType, "EditAnalysisProvider.show");
 
         this._panel.onDidDispose(() => {
             this._panel = undefined;

--- a/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
+++ b/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
@@ -26,6 +26,7 @@ import { getNotebookMetadataManager } from "../../utils/notebookMetadataManager"
 import { migrateLocalizedBooksToMetadata as migrateLocalizedBooks } from "./localizedBooksMigration/localizedBooksMigration";
 import { removeLocalizedBooksJsonIfPresent as removeLocalizedBooksJson } from "./localizedBooksMigration/removeLocalizedBooksJson";
 import { getAttachmentDocumentSegmentFromUri } from "../../utils/attachmentFolderUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 // import { parseRtfWithPandoc as parseRtfNode } from "../../../webviews/codex-webviews/src/NewSourceUploader/importers/rtf/pandocNodeBridge";
 
 const execAsync = promisify(exec);
@@ -102,6 +103,7 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         webviewPanel: vscode.WebviewPanel,
         token: vscode.CancellationToken
     ): Promise<void> {
+        trackWebviewPanel(webviewPanel, NewSourceUploaderProvider.viewType, "NewSourceUploaderProvider.resolveCustomTextEditor");
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         webviewPanel.webview.options = {
             enableScripts: true,

--- a/src/providers/SplashScreen/SplashScreenProvider.ts
+++ b/src/providers/SplashScreen/SplashScreenProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { ActivationTiming } from "../../extension";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 
 const DEBUG_SPLASH_SCREEN_PROVIDER = false;
 function debug(message: string, ...args: any[]): void {
@@ -61,6 +62,7 @@ export class SplashScreenProvider {
                 retainContextWhenHidden: true,
             }
         );
+        trackWebviewPanel(this._panel, SplashScreenProvider.viewType, "SplashScreenProvider.show");
         debug("[SplashScreen] Panel created successfully");
 
         // Set webview options

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -26,6 +26,7 @@ import JSZip from "jszip";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
 
 import { safePostMessageToPanel, safeIsVisible, safeSetHtml, safeSetOptions } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 import * as path from "path";
 import * as fs from "fs";
 import git from "isomorphic-git";
@@ -197,6 +198,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
         _token: vscode.CancellationToken
     ): void | Thenable<void> {
         this.webviewPanel = webviewPanel;
+        trackWebviewPanel(webviewPanel, StartupFlowProvider.viewType, "StartupFlowProvider.resolveCustomTextEditor");
         this.disposables.push(webviewPanel);
 
         // Set options before content

--- a/src/providers/VideoEditor/VideoEditorProvider.ts
+++ b/src/providers/VideoEditor/VideoEditorProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 
 export class VideoEditorProvider implements vscode.CustomTextEditorProvider {
     public static readonly viewType = "codex.videoEditor";
@@ -10,6 +11,7 @@ export class VideoEditorProvider implements vscode.CustomTextEditorProvider {
         webviewPanel: vscode.WebviewPanel,
         _token: vscode.CancellationToken
     ): Promise<void> {
+        trackWebviewPanel(webviewPanel, VideoEditorProvider.viewType, "VideoEditorProvider.resolveCustomTextEditor");
         // Set the HTML content for the webview
         webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
 

--- a/src/providers/VideoPlayer/VideoPlayerProvider.ts
+++ b/src/providers/VideoPlayer/VideoPlayerProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 export class VideoPlayerProvider
     implements vscode.TextDocumentContentProvider, vscode.CustomTextEditorProvider
 {
@@ -30,6 +31,7 @@ export class VideoPlayerProvider
         webviewPanel: vscode.WebviewPanel,
         _token: vscode.CancellationToken
     ): Promise<void> {
+        trackWebviewPanel(webviewPanel, VideoPlayerProvider.viewType, "VideoPlayerProvider.resolveCustomTextEditor");
         webviewPanel.webview.options = {
             enableScripts: true,
             localResourceRoots: [this.context.extensionUri],

--- a/src/providers/WelcomeView/welcomeViewProvider.ts
+++ b/src/providers/WelcomeView/welcomeViewProvider.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 import { getAuthApi } from "../../extension";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 import { StartupFlowGlobalState } from "../StartupFlow/StartupFlowProvider";
 
 const DEBUG_MODE = false;
@@ -278,6 +279,7 @@ export class WelcomeViewProvider {
                 retainContextWhenHidden: true,
             }
         );
+        trackWebviewPanel(this._panel, WelcomeViewProvider.viewType, "WelcomeViewProvider.show");
 
         // Set the webview's html content
         this._panel.webview.html = this._getHtmlForWebview();

--- a/src/providers/WordsView/WordsViewProvider.ts
+++ b/src/providers/WordsView/WordsViewProvider.ts
@@ -7,6 +7,7 @@ import {
 } from "../../activationHelpers/contextAware/contentIndexes/indexes/wordsIndex";
 import { readSourceAndTargetFiles } from "../../activationHelpers/contextAware/contentIndexes/indexes/fileReaders";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 
 export class WordsViewProvider implements vscode.Disposable {
     public static readonly viewType = "frontier.wordsView";
@@ -43,6 +44,7 @@ export class WordsViewProvider implements vscode.Disposable {
                 retainContextWhenHidden: true,
             }
         );
+        trackWebviewPanel(this._panel, WordsViewProvider.viewType, "WordsViewProvider.show");
 
         this._panel.onDidDispose(() => {
             this._panel = undefined;

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -28,6 +28,7 @@ import { SyncManager } from "../../projectManager/syncManager";
 import bibleData from "../../../webviews/codex-webviews/src/assets/bible-books-lookup.json";
 import { getNonce } from "../dictionaryTable/utilities/getNonce";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 import path from "path";
 import * as fs from "fs";
 import { getAuthApi } from "@/extension";
@@ -488,6 +489,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         _token: vscode.CancellationToken
     ): Promise<void> {
         debug("Resolving custom editor for:", document.uri.toString());
+        trackWebviewPanel(webviewPanel, CodexCellEditorProvider.viewType, "CodexCellEditorProvider.resolveCustomEditor");
 
         // Store the webview panel with its document URI as the key
         this.webviewPanels.set(document.uri.toString(), webviewPanel);

--- a/src/providers/dictionaryTable/DictionaryEditorProvider.ts
+++ b/src/providers/dictionaryTable/DictionaryEditorProvider.ts
@@ -18,6 +18,7 @@ import {
     deleteWord,
     updateWord,
 } from "../../sqldb";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 
 type FetchPageResult = {
     entries: DictionaryEntry[];
@@ -60,6 +61,7 @@ export class DictionaryEditorProvider implements vscode.CustomTextEditorProvider
         webviewPanel: vscode.WebviewPanel,
         _token: vscode.CancellationToken
     ): Promise<void> {
+        trackWebviewPanel(webviewPanel, DictionaryEditorProvider.viewType, "DictionaryEditorProvider.resolveCustomTextEditor");
         this.document = await this.handleFetchPage(this.page, this.pageSize, this.searchQuery);
         webviewPanel.webview.options = {
             enableScripts: true,

--- a/src/providers/publishProjectView/PublishProjectView.ts
+++ b/src/providers/publishProjectView/PublishProjectView.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
+import { trackWebviewPanel } from "../../utils/webviewTracker";
 import { GlobalProvider } from "../../globalProvider";
 import { getAuthApi } from "../../extension";
 import { updateProjectSettings, updateMetadataFile } from "../../projectManager/utils/projectUtils";
@@ -253,6 +254,7 @@ export class PublishProjectView {
                 ],
             }
         );
+        trackWebviewPanel(panel, "frontierPublishProject", "PublishProjectView.createOrShow");
 
         PublishProjectView.currentPanel = new PublishProjectView(
             panel,

--- a/src/test/suite/integration/cellLabelImporter.integration.test.ts
+++ b/src/test/suite/integration/cellLabelImporter.integration.test.ts
@@ -1,0 +1,87 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { matchCellLabels } from "../../../cellLabelImporter/matcher";
+import type { FileData } from "../../../cellLabelImporter/types";
+
+suite("Cell Label Importer Integration", () => {
+    test("matches using mapped start time column to metadata.data.startTime", async () => {
+        const sourceFiles: FileData[] = [
+            {
+                uri: vscode.Uri.file("/tmp/sample.codex"),
+                cells: [
+                    {
+                        value: "<span>Line 1</span>\n",
+                        metadata: {
+                            id: "uuid-1",
+                            data: { startTime: 10.5, endTime: 11.2 },
+                            cellLabel: "OLD",
+                        },
+                    },
+                ],
+            },
+        ];
+
+        const importedRows = [
+            {
+                LABEL: "NEW_LABEL",
+                BEGIN_TS: "00:00:10.500",
+            },
+        ];
+
+        const result = await matchCellLabels(
+            importedRows,
+            sourceFiles,
+            [],
+            "LABEL",
+            {
+                matchColumn: "BEGIN_TS",
+                matchFieldPath: "metadata.data.startTime",
+            }
+        );
+
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].matched, true);
+        assert.strictEqual(result[0].cellId, "uuid-1");
+        assert.strictEqual(result[0].newLabel, "NEW_LABEL");
+    });
+
+    test("matches using mapped column to metadata.id string", async () => {
+        const sourceFiles: FileData[] = [
+            {
+                uri: vscode.Uri.file("/tmp/sample-2.codex"),
+                cells: [
+                    {
+                        value: "<span>Line 2</span>\n",
+                        metadata: {
+                            id: "uuid-2",
+                            data: { startTime: 20.1, endTime: 21.2 },
+                        },
+                    },
+                ],
+            },
+        ];
+
+        const importedRows = [
+            {
+                LABEL: "NEW_LABEL_2",
+                CELL_ID: "uuid-2",
+            },
+        ];
+
+        const result = await matchCellLabels(
+            importedRows,
+            sourceFiles,
+            [],
+            "LABEL",
+            {
+                matchColumn: "CELL_ID",
+                matchFieldPath: "metadata.id",
+            }
+        );
+
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].matched, true);
+        assert.strictEqual(result[0].cellId, "uuid-2");
+        assert.strictEqual(result[0].newLabel, "NEW_LABEL_2");
+    });
+});

--- a/src/utils/webviewTracker.ts
+++ b/src/utils/webviewTracker.ts
@@ -1,0 +1,93 @@
+import * as vscode from "vscode";
+
+type WebviewKind = "panel" | "view";
+
+type WebviewEntry = {
+    id: string;
+    kind: WebviewKind;
+    viewType: string;
+    title?: string;
+    createdAt: number;
+    source?: string;
+};
+
+const entries = new Map<string, WebviewEntry>();
+let counter = 0;
+let outputChannel: vscode.OutputChannel | undefined;
+
+function getOutputChannel(): vscode.OutputChannel {
+    if (!outputChannel) {
+        outputChannel = vscode.window.createOutputChannel("Codex Webviews");
+    }
+    return outputChannel;
+}
+
+function log(line: string): void {
+    getOutputChannel().appendLine(line);
+}
+
+export function trackWebviewPanel(
+    panel: vscode.WebviewPanel,
+    viewType: string,
+    source?: string
+): string {
+    const id = `${viewType}:${++counter}`;
+    const entry: WebviewEntry = {
+        id,
+        kind: "panel",
+        viewType,
+        title: panel.title,
+        createdAt: Date.now(),
+        source,
+    };
+    entries.set(id, entry);
+    log(`[create][panel] ${entry.viewType} id=${id} title="${entry.title}" source=${source ?? "unknown"}`);
+    panel.onDidDispose(() => {
+        entries.delete(id);
+        log(`[dispose][panel] ${entry.viewType} id=${id}`);
+    });
+    return id;
+}
+
+export function trackWebviewView(
+    view: vscode.WebviewView,
+    viewType: string,
+    source?: string
+): string {
+    const id = `${viewType}:${++counter}`;
+    const entry: WebviewEntry = {
+        id,
+        kind: "view",
+        viewType,
+        createdAt: Date.now(),
+        source,
+    };
+    entries.set(id, entry);
+    log(`[create][view] ${entry.viewType} id=${id} source=${source ?? "unknown"}`);
+    view.onDidDispose(() => {
+        entries.delete(id);
+        log(`[dispose][view] ${entry.viewType} id=${id}`);
+    });
+    return id;
+}
+
+export function dumpActiveWebviews(): void {
+    const channel = getOutputChannel();
+    channel.appendLine("---- Active webviews ----");
+    if (entries.size === 0) {
+        channel.appendLine("(none)");
+        channel.show(true);
+        return;
+    }
+    const sorted = Array.from(entries.values()).sort((a, b) => a.createdAt - b.createdAt);
+    for (const entry of sorted) {
+        const ageMs = Date.now() - entry.createdAt;
+        const ageSec = Math.round(ageMs / 1000);
+        channel.appendLine(
+            `[active][${entry.kind}] ${entry.viewType} id=${entry.id} age=${ageSec}s` +
+            (entry.title ? ` title="${entry.title}"` : "") +
+            (entry.source ? ` source=${entry.source}` : "")
+        );
+    }
+    channel.show(true);
+}


### PR DESCRIPTION
- Introduced `trackWebviewPanel` and `trackWebviewView` functions in `webviewTracker.ts` to log the creation and disposal of webviews and webview views.
- Updated various providers and components to utilize the new tracking functions for better monitoring of webview usage.
- Added a debug command `codex-editor.debugWebviews` to dump active webview information to the output channel.
- Enhanced existing webview management by ensuring proper disposal of resources and tracking of active instances.