### PR TITLE
690 webviews are not being disposed of correctly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,12 +14,13 @@
             "preLaunchTask": "npm: watch"
         },
         {
-            "name": "Run Extension (Debug Webviews)",
+            "name": "Run Extension with child sessions",
             "type": "extensionHost",
             "request": "launch",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/out/**/*.js"],
             "debugWebviews": true,
+            "trace": true,
             "preLaunchTask": "npm: watch"
         },
         {


### PR DESCRIPTION
**Root cause**:
debugWebviews: true in your launch configuration tells VS Code to automatically attach a child debug session to every webview your extension creates. When you reload the window, all webviews are destroyed and recreated, which forces VS Code to tear down and re-establish those child debug sessions. This process is flaky — every other reload, VS Code fails to cleanly reattach and instead spawns an entirely new parent "Run Extension" session, leading to the duplicate sessions you see in the Call Stack.

**Fix**:
We separated the configurations to have one "Run Extension" that runs without debugWebviews and one that will run with it. This eliminates the child sessions getting created.