### PR TITLE
Preventative measures for cell deletion when syncing.

### DIFF
--- a/src/projectManager/utils/merge/index.ts
+++ b/src/projectManager/utils/merge/index.ts
@@ -29,6 +29,43 @@ function debug(...args: any[]): void {
     }
 }
 
+/**
+ * Scans all .codex files in the workspace after saveAll(). If any file now
+ * has 0 cells but the last committed (HEAD) version has cells, the file is
+ * restored from HEAD to prevent data loss before the commit is created.
+ */
+async function auditCodexFilesBeforeSync(workspaceFolder: string): Promise<void> {
+    const codexFiles = await vscode.workspace.findFiles("**/*.codex");
+    for (const fileUri of codexFiles) {
+        try {
+            const rawContent = await vscode.workspace.fs.readFile(fileUri);
+            const parsed = JSON.parse(new TextDecoder().decode(rawContent));
+            if (!Array.isArray(parsed.cells) || parsed.cells.length > 0) {
+                continue;
+            }
+
+            const relativePath = vscode.workspace.asRelativePath(fileUri, false);
+            const headOid = await git.resolveRef({ fs, dir: workspaceFolder, ref: "HEAD" });
+            const { blob } = await git.readBlob({
+                fs,
+                dir: workspaceFolder,
+                oid: headOid,
+                filepath: relativePath,
+            });
+            const gitParsed = JSON.parse(new TextDecoder().decode(blob));
+            if (Array.isArray(gitParsed.cells) && gitParsed.cells.length > 0) {
+                console.warn(
+                    `[SYNC AUDIT] Restoring ${relativePath}: ` +
+                    `file on disk has 0 cells but HEAD has ${gitParsed.cells.length} cells`
+                );
+                await vscode.workspace.fs.writeFile(fileUri, blob);
+            }
+        } catch {
+            // Skip files that can't be read, parsed, or have no git history
+        }
+    }
+}
+
 export interface SyncResult {
     success: boolean;
     changedFiles: string[];
@@ -60,6 +97,11 @@ export async function stageAndCommitAllAndSync(
 
     // Save all files before syncing
     await vscode.workspace.saveAll();
+
+    // Guard 4: Audit .codex files for accidental wipes before committing.
+    // If saveAll() wrote a 0-cell file over a non-empty one, restore from HEAD.
+    await auditCodexFilesBeforeSync(workspaceFolder);
+
     // Enforce Frontier version requirement for sync operations (Git LFS safety gate)
     // Note: Check before constructing syncResult to avoid using before declaration
     const versionStatus = await getFrontierVersionStatus();

--- a/src/providers/codexCellEditorProvider/codexDocument.ts
+++ b/src/providers/codexCellEditorProvider/codexDocument.ts
@@ -62,6 +62,13 @@ export class CodexCellDocument implements vscode.CustomDocument {
     // Track when we last saved to prevent file watcher from reverting our own saves
     private _lastSaveTimestamp: number = 0;
 
+    // Tracks whether the initial JSON parse failed, producing a fallback empty document.
+    // When true, save() must not overwrite a non-empty file on disk.
+    private _loadFailed = false;
+    public get loadFailed(): boolean {
+        return this._loadFailed;
+    }
+
     // Cache for immediate indexing optimization
     private _cachedFileId: number | null = null;
     private _indexManager = getSQLiteIndexManager();
@@ -111,6 +118,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
             }
         } catch (error) {
             console.error("Error parsing document content:", error);
+            this._loadFailed = true;
             this._documentData = {
                 cells: [],
                 metadata: {
@@ -675,7 +683,29 @@ export class CodexCellDocument implements vscode.CustomDocument {
     }
 
     public async save(cancellation: vscode.CancellationToken): Promise<void> {
-        const ourContent = formatJsonForNotebookFile(this.getDocumentDataForSerialization());
+        const ourData = this.getDocumentDataForSerialization();
+
+        // Guard 2: Refuse to overwrite a non-empty file when in-memory has 0 cells.
+        // This prevents the exact data-loss scenario where a stale/failed-load document
+        // wipes a good file on disk during saveAll().
+        if (ourData.cells.length === 0) {
+            const diskCheck = await readExistingFileOrThrow(this.uri);
+            if (diskCheck.kind === "readable") {
+                try {
+                    const diskData = JSON.parse(diskCheck.content);
+                    if (Array.isArray(diskData.cells) && diskData.cells.length > 0) {
+                        console.warn(
+                            `[SAVE GUARD] Refusing to save ${this.uri.fsPath}: ` +
+                            `in-memory has 0 cells but disk has ${diskData.cells.length} cells. ` +
+                            `Load failed: ${this._loadFailed}`
+                        );
+                        return;
+                    }
+                } catch { /* disk content unparseable, allow save to proceed */ }
+            }
+        }
+
+        const ourContent = formatJsonForNotebookFile(ourData);
 
         // If a file exists but can't be read, we must not overwrite (this can permanently nuke data).
         const existing = await readExistingFileOrThrow(this.uri);
@@ -705,6 +735,24 @@ export class CodexCellDocument implements vscode.CustomDocument {
             } catch {
                 candidate = normalizeNotebookFileText(ourContent);
             }
+
+            // Guard 3: Post-merge cell-count validation.
+            // If the merge produced 0 cells but disk has cells, fall back to disk content
+            // to avoid data loss from a broken merge.
+            try {
+                const candidateParsed = JSON.parse(candidate);
+                const diskParsed = JSON.parse(existing.content);
+                if (
+                    Array.isArray(diskParsed.cells) && diskParsed.cells.length > 0 &&
+                    (!Array.isArray(candidateParsed.cells) || candidateParsed.cells.length === 0)
+                ) {
+                    console.warn(
+                        `[SAVE GUARD] Merge produced 0 cells but disk has ${diskParsed.cells.length}. ` +
+                        `Falling back to disk content for ${this.uri.fsPath}`
+                    );
+                    candidate = normalizeNotebookFileText(existing.content);
+                }
+            } catch { /* parse error in validation, proceed with candidate */ }
 
             await atomicWriteUriText(this.uri, candidate);
         }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -34,42 +34,19 @@ export class CodexContentSerializer implements vscode.NotebookSerializer {
         token: vscode.CancellationToken
     ): Promise<CodexNotebookAsJSONData> {
         debug("Deserializing notebook data");
-        const contents = new TextDecoder().decode(data); // convert to String
+        const contents = new TextDecoder().decode(data);
         debug("Contents:", contents);
-        // Read file contents
+
         let raw: RawNotebookData;
         try {
             raw = <RawNotebookData>JSON.parse(contents);
-            debug("Successfully parsed notebook contents", { cellCount: raw.cells.length });
-            return raw as CodexNotebookAsJSONData;
-        } catch {
-            debug("Failed to parse notebook contents, creating empty notebook");
-            raw = { cells: [], metadata: {} };
-        }
-        // Create array of Notebook cells for the VS Code API from file contents
-        const cells = raw.cells.map((item) => {
-            debug("Processing cell", { id: item.metadata?.id, kind: item.kind });
-            const cell = new vscode.NotebookCellData(
-                item.kind,
-                item.value,
-                item.languageId || "html"
-            );
-            cell.metadata = item.metadata || {}; // Ensure metadata is included if available
-            if (item.metadata && item.metadata.id) {
-                cell.metadata.id = item.metadata.id;
-            }
-            return cell;
-        });
-        const notebookData = new vscode.NotebookData(cells);
-        notebookData.metadata = raw.metadata || {};
-
-        // Ensure metadata.edits array exists for backward compatibility
-        if (!notebookData.metadata.edits) {
-            notebookData.metadata.edits = [];
+        } catch (error) {
+            console.error("Failed to parse codex notebook contents:", error);
+            throw new Error(`Failed to deserialize codex notebook: ${error}`);
         }
 
-        debug("Notebook deserialization complete", { cellCount: cells.length });
-        return notebookData as CodexNotebookAsJSONData;
+        debug("Successfully parsed notebook contents", { cellCount: raw.cells.length });
+        return raw as CodexNotebookAsJSONData;
     }
 
     async serializeNotebook(


### PR DESCRIPTION
Closes #766 

Guard 1 -- codexDocument.ts: Added _loadFailed boolean flag with a public getter. Set to true in the constructor's catch block when JSON parsing fails and the fallback empty document is created.

Guard 2 -- codexDocument.ts save(): Added an early-exit check at the top of save(). If the in-memory document has 0 cells, it reads the disk file. If disk has cells, the save is aborted with a [SAVE GUARD] warning log, preserving the on-disk data.

Guard 3 -- codexDocument.ts save(): After the merge produces a candidate string but before atomicWriteUriText, the candidate is parsed and compared against the disk version. If the merge produced 0 cells but disk has cells, it falls back to the disk content.

Guard 4 -- merge/index.ts: Added auditCodexFilesBeforeSync() which scans all .codex files after saveAll() completes but before syncChanges() commits. For any file that now has 0 cells, it checks the HEAD commit -- if HEAD has cells, it restores the file from git.

Guard 5 -- serializer.ts: Changed deserializeNotebook to throw on JSON parse failure instead of silently returning an empty notebook. Removed the now-unreachable dead code that constructed NotebookCellData from the empty fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 01b881ff7ec9970b42e28a83e14693336937cd77. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->