### PR TITLE
Added simple 3 way merge for unknown files instead of override.

### DIFF
--- a/docs/merge-strategy.md
+++ b/docs/merge-strategy.md
@@ -56,7 +56,7 @@ This document outlines the strategy for resolving merge conflicts in Codex proje
 
 ### 6. Codex Cell Files (`files/*.codex`)
 
-- **Strategy**: 
+- **Strategy**:
     1. Parse both versions as JSON
     2. Take the newest `metadata` object
     3. Merge cells array from both versions
@@ -66,6 +66,19 @@ This document outlines the strategy for resolving merge conflicts in Codex proje
         - Preserve cell IDs and metadata
     5. Complete the merge and sync the entire project.
     6. This approach will trigger the merge conflict view of the codex cell editor. The user will be forced to resolve the cell-level conflicts manually when they open the file.
+
+### 7. Unrecognized Files (Default: Simple 3-Way)
+
+- **Files**: Any file not matching the patterns above (e.g., `.yaml`, `.py`, `.txt`, etc.)
+- **Strategy**: `SIMPLE_3WAY` — 3-way base comparison
+    1. Compare `ours` (local) against `base` (common ancestor)
+    2. Compare `theirs` (remote) against `base`
+    3. Resolution:
+        - If only remote changed from base → accept remote version
+        - If only local changed from base → keep local version
+        - If both changed from base → keep local version (local wins)
+        - If neither changed → keep local version
+- **Rationale**: Prevents silent data loss when remote-only changes to unrecognized file types are discarded during diverged merges. Previously, the `OVERRIDE` strategy was used as the default, which unconditionally kept the local version regardless of whether it had actually changed.
 
 Note: we also need to just ignore some files, like `complete_drafts.txt`, as they are auto-generated and not meant to be merged.
 

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -124,7 +124,7 @@ function mergeValidatedByLists(
  * - Rule 1: Preserve local isOldProject in each entry (never overwrite from remote)
  * - Rule 2: Merge swapEntries by swapUUID (unique identifier for each swap)
  * - Rule 3: For matching entries, merge swappedUsers arrays
- * 
+ *
  * All swap info is now contained in each entry (swapUUID, isOldProject, oldProjectUrl, etc.)
  */
 function mergeProjectSwap(
@@ -237,10 +237,10 @@ function mergeProjectSwap(
  * Union by hash: combine all entries. For same hash, merge referencedBy and originalNames.
  */
 export function mergeOriginalFilesHashes(
-    base: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string> } | undefined,
-    ours: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string> } | undefined,
-    theirs: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string> } | undefined
-): { version: number; files: Record<string, any>; fileNameToHash: Record<string, string> } | undefined {
+    base: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string>; } | undefined,
+    ours: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string>; } | undefined,
+    theirs: { version?: number; files?: Record<string, any>; fileNameToHash?: Record<string, string>; } | undefined
+): { version: number; files: Record<string, any>; fileNameToHash: Record<string, string>; } | undefined {
     const ourFiles = ours?.files || {};
     const theirFiles = theirs?.files || {};
     const baseFiles = base?.files || {};
@@ -601,6 +601,32 @@ export async function resolveConflictFile(
                 debugLog("Resolving JSON 3-way merge for:", conflict.filepath);
                 resolvedContent = await resolveSettingsJsonConflict(conflict);
                 debugLog("Successfully merged settings.json with 3-way merge");
+                break;
+            }
+
+            // SIMPLE_3WAY = "simple-3way", // 3-way base comparison for unknown file types
+            case ConflictResolutionStrategy.SIMPLE_3WAY: {
+                debugLog("Resolving with simple 3-way merge for:", conflict.filepath);
+                const oursMatchesBase = conflict.ours === conflict.base;
+                const theirsMatchesBase = conflict.theirs === conflict.base;
+
+                if (oursMatchesBase && !theirsMatchesBase) {
+                    // Only remote changed from base — accept remote version
+                    debugLog("Only remote changed, taking theirs for:", conflict.filepath);
+                    resolvedContent = conflict.theirs;
+                } else if (!oursMatchesBase && theirsMatchesBase) {
+                    // Only local changed from base — keep our version
+                    debugLog("Only local changed, keeping ours for:", conflict.filepath);
+                    resolvedContent = conflict.ours;
+                } else if (oursMatchesBase && theirsMatchesBase) {
+                    // Neither changed from base (shouldn't be a conflict, but handle gracefully)
+                    debugLog("Neither side changed from base, keeping ours for:", conflict.filepath);
+                    resolvedContent = conflict.ours;
+                } else {
+                    // Both changed from base — local wins (safe default)
+                    debugLog("Both sides changed from base, keeping ours for:", conflict.filepath);
+                    resolvedContent = conflict.ours;
+                }
                 break;
             }
 
@@ -1434,7 +1460,7 @@ export async function resolveCommentThreadsConflict(
             );
         }
 
-        // Convert to relative paths  
+        // Convert to relative paths
         migratedTheirThread = convertThreadToRelativePaths(migratedTheirThread);
 
         if (!existingThread) {
@@ -1618,7 +1644,7 @@ export async function resolveCommentThreadsConflict(
 /**
  * Merges audio attachments from two cell versions, preserving all recordings
  * @param ourAttachments Our version of attachments
- * @param theirAttachments Their version of attachments  
+ * @param theirAttachments Their version of attachments
  * @returns Merged attachments object
  */
 export function mergeAttachments(

--- a/src/projectManager/utils/merge/strategies.ts
+++ b/src/projectManager/utils/merge/strategies.ts
@@ -37,6 +37,10 @@ export const filePatternsToResolve: Record<ConflictResolutionStrategy, string[]>
 
     // JSON settings files - 3-way merge with intelligent conflict resolution
     [ConflictResolutionStrategy.JSON_MERGE_3WAY]: [".vscode/settings.json"],
+
+    // Simple 3-way merge for unrecognized files (used as the default fallback)
+    // If only one side changed from base, take that side; if both changed, local wins
+    [ConflictResolutionStrategy.SIMPLE_3WAY]: [],
 };
 
 export function determineStrategy(filePath: string): ConflictResolutionStrategy {
@@ -75,7 +79,7 @@ export function determineStrategy(filePath: string): ConflictResolutionStrategy 
     console.warn(
         "No merge strategy found for file:",
         filePath,
-        "defaulting to OVERRIDE (take the newest version)"
+        "defaulting to SIMPLE_3WAY (3-way base comparison)"
     );
-    return ConflictResolutionStrategy.OVERRIDE;
+    return ConflictResolutionStrategy.SIMPLE_3WAY;
 }

--- a/src/projectManager/utils/merge/types.ts
+++ b/src/projectManager/utils/merge/types.ts
@@ -9,6 +9,7 @@ export enum ConflictResolutionStrategy {
     CODEX_CUSTOM_MERGE = "codex", // Special merge process for cell arrays
     JSONL = "jsonl", // Combine and deduplicate JSONL files
     JSON_MERGE_3WAY = "json-merge-3way", // 3-way merge for JSON settings with chatSystemMessage tie-breaker
+    SIMPLE_3WAY = "simple-3way", // 3-way base comparison: accept remote-only changes, keep local-only changes, local wins on true conflicts
 }
 
 export interface SmartEdit {

--- a/src/test/suite/mergeStrategies.test.ts
+++ b/src/test/suite/mergeStrategies.test.ts
@@ -49,10 +49,10 @@ suite("Merge Strategies Test Suite", () => {
         assert.strictEqual(strategy5, ConflictResolutionStrategy.IGNORE);
     });
 
-    test("should default to OVERRIDE for unknown file types", () => {
+    test("should default to SIMPLE_3WAY for unknown file types", () => {
         const unknownFile = "unknown_file.txt";
         const strategy = determineStrategy(unknownFile);
-        assert.strictEqual(strategy, ConflictResolutionStrategy.OVERRIDE);
+        assert.strictEqual(strategy, ConflictResolutionStrategy.SIMPLE_3WAY);
     });
 
     test("should handle path separators correctly", () => {


### PR DESCRIPTION
## Fix: Remote-only changes to unrecognized file types silently discarded during sync

### The Problem

When syncing, if the local user has **any** modified file (e.g., `metadata.json`), the branches diverge and Frontier reports all differing files as conflicts — including files that only changed on the remote side. The `OVERRIDE` strategy, which was the default for all unrecognized file types (`.yaml`, `.py`, `.txt`, etc.), unconditionally kept the local version, silently discarding the remote changes.

**The behavior was inconsistent and confusing:**
- ✅ Remote changes to unrecognized files were accepted when there were **no local changes** (clean fast-forward)
- ❌ Remote changes to the **exact same files** were silently **thrown away** when any unrelated local file had been modified

Whether remote changes survived depended entirely on whether you happened to have an unsaved edit somewhere — a race condition that's hard to debug.

### The Fix

Introduces a new `SIMPLE_3WAY` merge strategy that becomes the default fallback for unrecognized file types. It compares both sides against the common ancestor (base) to determine which side actually changed:

| Scenario | Before (`OVERRIDE`) | After (`SIMPLE_3WAY`) |
|---|---|---|
| Only remote changed the file | ❌ Discarded remote, kept stale local | ✅ Accepts remote version |
| Only local changed the file | ✅ Kept local | ✅ Kept local |
| Both sides changed the file | ✅ Kept local | ✅ Kept local (local wins) |
| Neither side changed | ✅ Kept local | ✅ Kept local |

### Why This Is Safe

1. **No change to existing explicit strategies** — Files mapped to `OVERRIDE` (`chat-threads.json`, `dictionary.sqlite`, etc.), `CODEX_CUSTOM_MERGE`, `SPECIAL`, `ARRAY`, `JSONL`, `JSON_MERGE_3WAY`, and `IGNORE` are completely unaffected.

2. **Makes behavior consistent, not new** — Remote changes to unrecognized files were *already being accepted* when no local changes existed (fast-forward path). This PR simply makes the diverged-merge path behave the same way. If accepting remote changes was safe in the fast-forward case, it's equally safe in the diverged case when the local copy hasn't changed.

3. **Local always wins on true conflicts** — When both sides modify the same file, local still wins. The only change is that we stop overwriting remote changes when the local file is identical to the base.

### Files Changed

- `src/projectManager/utils/merge/types.ts` — Added `SIMPLE_3WAY` enum value
- `src/projectManager/utils/merge/strategies.ts` — Added pattern list, changed default fallback
- `src/projectManager/utils/merge/resolvers.ts` — Added `SIMPLE_3WAY` case handler
- `src/test/suite/mergeStrategies.test.ts` — Updated test expectation
- `docs/merge-strategy.md` — Documented the new strategy

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default conflict resolution for previously unrecognized file types, which can alter which side’s content is kept during sync/merge and could surface new merge outcomes for users’ projects.
> 
> **Overview**
> Updates merge conflict handling so **previously unrecognized file types** default to a new `SIMPLE_3WAY` strategy rather than `OVERRIDE`, preventing remote-only changes from being silently discarded during diverged merges.
> 
> Implements `SIMPLE_3WAY` in `resolvers.ts` (base/ours/theirs comparison with *local wins on true conflicts*), wires it into `types.ts` and `strategies.ts` as the fallback strategy, updates the merge-strategy docs, and adjusts the `mergeStrategies` test to expect the new default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0b74f9383a11468d7d2a2441f6ffd1d9d728c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->