### PR TITLE
Add updatedAt-based conflict resolution for pinnedExtensions

### DIFF
--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -2205,6 +2205,20 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
                 const oVal = ourObj?.[key];
                 const tVal = theirObj?.[key];
 
+                // Pin conflict resolution: when both sides changed the same pin,
+                // the entry with the latest updatedAt wins (including stable entries).
+                if (path.length === 2 && path[0] === 'meta' && path[1] === 'pinnedExtensions') {
+                    const bStr = JSON.stringify(bVal);
+                    const oStr = JSON.stringify(oVal);
+                    const tStr = JSON.stringify(tVal);
+                    if (oStr !== bStr && tStr !== bStr) {
+                        const oTime = oVal?.updatedAt ?? 0;
+                        const tTime = tVal?.updatedAt ?? 0;
+                        result[key] = tTime > oTime ? tVal : oVal;
+                        continue;
+                    }
+                }
+
                 // Recurse for objects
                 const isObj = (v: any) => typeof v === 'object' && v !== null && !Array.isArray(v);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1225,10 +1225,11 @@ type ProjectMetadata = {
             codexEditor?: string;
             frontierAuthentication?: string;
         };
-        /** Pin specific extension versions for this project */
+        /** Pin specific extension versions for this project. Version "stable" means unpinned. */
         pinnedExtensions?: Record<string, {
             version: string;
             url: string;
+            updatedAt: number;
         }>;
         /** List of users that should be forced to restore/update their project when opening */
         initiateRemoteUpdatingFor?: RemoteUpdatingEntry[];


### PR DESCRIPTION
When both local and remote modify the same pin entry during a merge, use the `updatedAt` timestamp to determine the winner — the most recent change takes precedence. Stable (unpin) entries default to `updatedAt: 0` so any active pin always wins over an unpin unless the unpin is newer.

Part of the extension pinning project. See the [architecture doc](https://github.com/genesis-ai-dev/codex-arch/blob/main/2026-03-project-extension-pinning.md).

## Changes
- Add `updatedAt` field to the `PinnedExtension` type in `types/index.d.ts`
- Add pin-specific conflict resolution in `resolvers.ts` that compares `updatedAt` timestamps when both sides modified the same pin entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge behavior for `metadata.json` extension pin entries, which could affect how sync conflicts are resolved and potentially override a user's intended pin/unpin if timestamps are wrong or missing.
> 
> **Overview**
> Adds pin-specific conflict resolution for `meta.pinnedExtensions` during `metadata.json` 3-way merges: when both ours and theirs changed the same pin entry, the version with the highest `updatedAt` now wins.
> 
> Extends the project metadata type so each `pinnedExtensions` record includes `updatedAt` (and documents that version `"stable"` represents an unpinned state).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f71e434fcd9590c6e53328f5ccb171e136f1645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->