### PR TITLE
[Ext Pinning] Feat: perfer remote pin over local

### DIFF
--- a/create-pr-release
+++ b/create-pr-release
@@ -9,6 +9,10 @@ if [[ ! -f package.json ]]; then
   exit 1
 fi
 
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  printf '\033[33mWarning: git working tree is dirty.\033[0m\n' >&2
+fi
+
 # ---------------------------------------------------------------------------
 # Resolve VERSION
 # ---------------------------------------------------------------------------
@@ -55,12 +59,17 @@ fi
 NAME="$(jq -r .name package.json)"
 ORIGINAL_VERSION="$(jq -r .version package.json)"
 VSIX_FILE="${NAME}-${VERSION}.vsix"
+PACKAGE_JSON_BACKUP="$(mktemp "${TMPDIR:-/tmp}/package.json.backup.XXXXXX")"
+cp -p package.json "$PACKAGE_JSON_BACKUP"
 
-restore_version() {
-  echo "Restoring package.json version to $ORIGINAL_VERSION"
-  jq --arg v "$ORIGINAL_VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+cleanup() {
+  if [[ -f "$PACKAGE_JSON_BACKUP" ]]; then
+    echo "Restoring package.json from backup"
+    cp -p "$PACKAGE_JSON_BACKUP" package.json
+  fi
+  rm -f "$PACKAGE_JSON_BACKUP"
 }
-trap restore_version EXIT
+trap cleanup EXIT
 
 echo "==> Bumping version: $ORIGINAL_VERSION -> $VERSION"
 jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
@@ -85,7 +94,7 @@ pnpm dlx @vscode/vsce package --no-dependencies
 #pnpm dlx @vscode/vsce package
 
 echo "==> Restoring version before release"
-restore_version
+cleanup
 trap - EXIT
 
 # We need to ensure head is on remote so it's there to attach the release to.

--- a/create-pr-release
+++ b/create-pr-release
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+
+# Ensure we're in a directory with a package.json
+if [[ ! -f package.json ]]; then
+  echo "Error: no package.json in current directory" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve VERSION
+# ---------------------------------------------------------------------------
+if [[ -z "$VERSION" ]]; then
+  # No version argument — check for an open PR and suggest one
+  if ! command -v gh &>/dev/null; then
+    echo "Error: 'gh' CLI is required when no version argument is provided." >&2
+    exit 1
+  fi
+
+  PR_NUMBER="$(gh pr view --json number -q .number 2>/dev/null || true)"
+
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "Usage: ext-release-create <version>" >&2
+    echo "  version: x.y.z | x.y.z-prNNN | x.y.z-prNNN-shorthash" >&2
+    echo "" >&2
+    echo "No open PR detected for the current branch, so cannot auto-suggest a version." >&2
+    exit 1
+  fi
+
+  BASE_VERSION="$(jq -r .version package.json)"
+  SHORT_HASH="$(git rev-parse --short HEAD)"
+  VERSION="${BASE_VERSION}-pr${PR_NUMBER}-${SHORT_HASH}"
+
+  echo "Open PR #${PR_NUMBER} detected."
+  echo "Generated version: $VERSION"
+  echo "Releasing in 5s, ctrl-c to cancel..."
+  sleep 5
+fi
+
+# ---------------------------------------------------------------------------
+# Validate VERSION — allowed forms:
+#   x.y.z
+#   x.y.z-pr123
+#   x.y.z-pr123-shorthash
+# Explicitly forbid x.y.z.prNNN (dot before pr)
+# ---------------------------------------------------------------------------
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-zA-Z][-0-9a-zA-Z]*)*$ ]]; then
+  echo "Error: version must match x.y.z, x.y.z-prNNN, or x.y.z-prNNN-shorthash" >&2
+  echo "  (dot-separated pre-release like x.y.z.prNNN is NOT allowed)" >&2
+  exit 1
+fi
+
+NAME="$(jq -r .name package.json)"
+ORIGINAL_VERSION="$(jq -r .version package.json)"
+VSIX_FILE="${NAME}-${VERSION}.vsix"
+
+restore_version() {
+  echo "Restoring package.json version to $ORIGINAL_VERSION"
+  jq --arg v "$ORIGINAL_VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+}
+trap restore_version EXIT
+
+echo "==> Bumping version: $ORIGINAL_VERSION -> $VERSION"
+jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+
+echo "==> Installing dependencies"
+pnpm install
+
+# Conditionally build webviews if the script exists
+if jq -e '.scripts["build:webviews"]' package.json &>/dev/null; then
+  echo "==> Installing webview dependencies"
+  (cd webviews/codex-webviews && pnpm install)
+  echo "==> Building webviews"
+  pnpm run build:webviews
+fi
+
+echo "==> Building extension (production)"
+pnpm run package
+
+echo "==> Packaging VSIX"
+# No dependencies results in errors like can't find codicon.css. We should probably bundle depens explicitly.
+pnpm dlx @vscode/vsce package --no-dependencies
+#pnpm dlx @vscode/vsce package
+
+echo "==> Restoring version before release"
+restore_version
+trap - EXIT
+
+# We need to ensure head is on remote so it's there to attach the release to.
+# Skip verify as we just built and tested successfully.
+git push --no-verify
+
+echo "==> Creating GitHub prerelease: $VERSION"
+gh release create "$VERSION" \
+  --target "$(git rev-parse HEAD)" \
+  --prerelease \
+  --title "$VERSION" \
+  --generate-notes \
+  "./$VSIX_FILE"
+
+REPO_URL="$(gh repo view --json url -q .url)"
+echo "Done! Prerelease $VERSION created with $VSIX_FILE"
+open "$REPO_URL/releases"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -346,7 +346,36 @@ export async function activate(context: vscode.ExtensionContext) {
         try {
             const projectUri = workspaceFolders[0].uri;
 
-            // Priority 1: Check for Remote Pins (authoritative for users)
+            // 1. Check for Admin Intent (highest precedence)
+            // This allows an admin to bypass the splash-screen halt when they just applied a pin change locally.
+            let adminIntent: Record<string, { version: string; url: string }> | undefined;
+            try {
+                // adminPinnedExtensions is stored in workspaceState, which we query via Frontier's command
+                const remoteState: any = await vscode.commands.executeCommand(
+                    "frontier.getRemotePinnedExtensionsState"
+                );
+                adminIntent = remoteState?.adminPinnedExtensions;
+            } catch (e) { /* ignore */ }
+
+            if (adminIntent) {
+                const myPin = adminIntent["project-accelerate.codex-editor-extension"];
+                if (myPin) {
+                    const myVersion = MetadataManager.getCurrentExtensionVersion(
+                        "project-accelerate.codex-editor-extension"
+                    );
+                    if (myVersion && myVersion === myPin.version) {
+                        console.log(
+                            `[Extension] Admin intent matched (${myVersion}). Proceeding to activation.`
+                        );
+                        // Matched intent — bypass further checks
+                        return;
+                    }
+                    // If intent exists but doesn't match, we fall through to remote/local checks
+                    // (the admin might not have reloaded yet).
+                }
+            }
+
+            // 2. Check for Remote Pins (authoritative for users)
             let remotePins: Record<string, { version: string; url: string }> | undefined;
             try {
                 remotePins = await vscode.commands.executeCommand(
@@ -377,29 +406,30 @@ export async function activate(context: vscode.ExtensionContext) {
                         console.log(
                             `[Extension] Remote version matched (${myVersion}). Proceeding to activation.`
                         );
+                        return;
                     }
                 }
-            } else {
-                // Priority 2: Fall back to local metadata.json
-                const result = await MetadataManager.safeReadMetadata(projectUri);
-                if (result.success && result.metadata?.meta?.pinnedExtensions) {
-                    const pins = result.metadata.meta.pinnedExtensions;
-                    const myPin = pins["project-accelerate.codex-editor-extension"];
-                    if (myPin) {
-                        const myVersion = MetadataManager.getCurrentExtensionVersion(
-                            "project-accelerate.codex-editor-extension"
+            }
+
+            // 3. Fall back to local metadata.json
+            const result = await MetadataManager.safeReadMetadata(projectUri);
+            if (result.success && result.metadata?.meta?.pinnedExtensions) {
+                const pins = result.metadata.meta.pinnedExtensions;
+                const myPin = pins["project-accelerate.codex-editor-extension"];
+                if (myPin) {
+                    const myVersion = MetadataManager.getCurrentExtensionVersion(
+                        "project-accelerate.codex-editor-extension"
+                    );
+                    if (myVersion && myVersion !== myPin.version) {
+                        console.log(
+                            `[Extension] Local version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
                         );
-                        if (myVersion && myVersion !== myPin.version) {
-                            console.log(
-                                `[Extension] Local version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
-                            );
-                            trackTiming(
-                                "Starting Project Synchronization (Version Pin Enforcement)",
-                                activationStart
-                            );
-                            updateSplashScreenSync(0, "Applying extension version pins...");
-                            return;
-                        }
+                        trackTiming(
+                            "Starting Project Synchronization (Version Pin Enforcement)",
+                            activationStart
+                        );
+                        updateSplashScreenSync(0, "Applying extension version pins...");
+                        return;
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,77 @@ function finishRealtimeStep(): number {
     return globalThis.performance.now();
 }
 
+/**
+ * Checks version pins (admin intent → remote → local) and returns true if the
+ * extension should yield to the Conductor for a profile switch (version mismatch).
+ * Returns false when pins match or no pins exist — caller should continue activation.
+ */
+async function checkVersionPinsAndYield(
+    projectUri: vscode.Uri,
+    activationStart: number
+): Promise<boolean> {
+    const EXTENSION_ID = "project-accelerate.codex-editor-extension";
+
+    // 1. Admin Intent (highest precedence) — allows admin to bypass the
+    // splash-screen halt when they just applied a pin change locally.
+    try {
+        const remoteState: any = await vscode.commands.executeCommand(
+            "frontier.getRemotePinnedExtensionsState"
+        );
+        const adminIntent = remoteState?.adminPinnedExtensions;
+        if (adminIntent) {
+            const myPin = adminIntent[EXTENSION_ID];
+            if (myPin) {
+                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
+                if (myVersion && myVersion === myPin.version) {
+                    console.log(`[Extension] Admin intent matched (${myVersion}). Proceeding.`);
+                    return false;
+                }
+                // Intent exists but doesn't match — fall through to remote/local checks
+            }
+        }
+    } catch { /* Frontier may not be active */ }
+
+    // 2. Remote Pins (authoritative for users)
+    try {
+        const remotePins: Record<string, { version: string; url: string }> | undefined =
+            await vscode.commands.executeCommand("frontier.getRemotePinnedExtensions");
+        if (remotePins) {
+            const myPin = remotePins[EXTENSION_ID];
+            if (myPin) {
+                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
+                if (myVersion && myVersion !== myPin.version) {
+                    console.log(`[Extension] Remote mismatch: ${myVersion} != ${myPin.version}. Yielding.`);
+                    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+                    updateSplashScreenSync(0, "Applying extension version pins...");
+                    return true;
+                }
+                console.log(`[Extension] Remote version matched (${myVersion}). Proceeding.`);
+                return false;
+            }
+        }
+    } catch { /* Frontier may not be active */ }
+
+    // 3. Local metadata.json (fallback)
+    try {
+        const result = await MetadataManager.safeReadMetadata(projectUri);
+        if (result.success && result.metadata?.meta?.pinnedExtensions) {
+            const myPin = result.metadata.meta.pinnedExtensions[EXTENSION_ID];
+            if (myPin) {
+                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
+                if (myVersion && myVersion !== myPin.version) {
+                    console.log(`[Extension] Local mismatch: ${myVersion} != ${myPin.version}. Yielding.`);
+                    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+                    updateSplashScreenSync(0, "Applying extension version pins...");
+                    return true;
+                }
+            }
+        }
+    } catch { /* ignore */ }
+
+    return false;
+}
+
 declare global {
     // eslint-disable-next-line
     var db: Database | undefined;
@@ -340,101 +411,13 @@ export async function activate(context: vscode.ExtensionContext) {
         // Continue with activation even if splash screen fails
     }
 
-    // Check for version pins before heavy initialization
+    // Check for version pins before heavy initialization.
+    // If there's a mismatch, yield to the Conductor for profile switch.
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders && workspaceFolders.length > 0) {
-        try {
-            const projectUri = workspaceFolders[0].uri;
-
-            // 1. Check for Admin Intent (highest precedence)
-            // This allows an admin to bypass the splash-screen halt when they just applied a pin change locally.
-            let adminIntent: Record<string, { version: string; url: string }> | undefined;
-            try {
-                // adminPinnedExtensions is stored in workspaceState, which we query via Frontier's command
-                const remoteState: any = await vscode.commands.executeCommand(
-                    "frontier.getRemotePinnedExtensionsState"
-                );
-                adminIntent = remoteState?.adminPinnedExtensions;
-            } catch (e) { /* ignore */ }
-
-            if (adminIntent) {
-                const myPin = adminIntent["project-accelerate.codex-editor-extension"];
-                if (myPin) {
-                    const myVersion = MetadataManager.getCurrentExtensionVersion(
-                        "project-accelerate.codex-editor-extension"
-                    );
-                    if (myVersion && myVersion === myPin.version) {
-                        console.log(
-                            `[Extension] Admin intent matched (${myVersion}). Proceeding to activation.`
-                        );
-                        // Matched intent — bypass further checks
-                        return;
-                    }
-                    // If intent exists but doesn't match, we fall through to remote/local checks
-                    // (the admin might not have reloaded yet).
-                }
-            }
-
-            // 2. Check for Remote Pins (authoritative for users)
-            let remotePins: Record<string, { version: string; url: string }> | undefined;
-            try {
-                remotePins = await vscode.commands.executeCommand(
-                    "frontier.getRemotePinnedExtensions"
-                );
-            } catch (e) {
-                // Command might not exist if Frontier isn't active/installed
-            }
-
-            if (remotePins) {
-                const myPin = remotePins["project-accelerate.codex-editor-extension"];
-                if (myPin) {
-                    const myVersion = MetadataManager.getCurrentExtensionVersion(
-                        "project-accelerate.codex-editor-extension"
-                    );
-                    if (myVersion && myVersion !== myPin.version) {
-                        console.log(
-                            `[Extension] Remote version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
-                        );
-                        trackTiming(
-                            "Starting Project Synchronization (Version Pin Enforcement)",
-                            activationStart
-                        );
-                        updateSplashScreenSync(0, "Applying extension version pins...");
-                        return;
-                    } else {
-                        // We match the remote authority — proceed even if metadata.json is different (to allow merge)
-                        console.log(
-                            `[Extension] Remote version matched (${myVersion}). Proceeding to activation.`
-                        );
-                        return;
-                    }
-                }
-            }
-
-            // 3. Fall back to local metadata.json
-            const result = await MetadataManager.safeReadMetadata(projectUri);
-            if (result.success && result.metadata?.meta?.pinnedExtensions) {
-                const pins = result.metadata.meta.pinnedExtensions;
-                const myPin = pins["project-accelerate.codex-editor-extension"];
-                if (myPin) {
-                    const myVersion = MetadataManager.getCurrentExtensionVersion(
-                        "project-accelerate.codex-editor-extension"
-                    );
-                    if (myVersion && myVersion !== myPin.version) {
-                        console.log(
-                            `[Extension] Local version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
-                        );
-                        trackTiming(
-                            "Starting Project Synchronization (Version Pin Enforcement)",
-                            activationStart
-                        );
-                        updateSplashScreenSync(0, "Applying extension version pins...");
-                        return;
-                    }
-                }
-            }
-        } catch (err) {
-            console.error("[Extension] Error checking for version pins:", err);
+        const shouldYield = await checkVersionPinsAndYield(workspaceFolders[0].uri, activationStart);
+        if (shouldYield) {
+            return;
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,10 +168,33 @@ function finishRealtimeStep(): number {
     return globalThis.performance.now();
 }
 
+/** Compare running version against a pinned version; yield if mismatched. */
+function checkPinAndYield(
+    source: string,
+    pinnedVersion: string,
+    activationStart: number
+): boolean | undefined {
+    const EXTENSION_ID = "project-accelerate.codex-editor-extension";
+    const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
+    if (!myVersion) { return undefined; } // unknown — can't decide
+    if (myVersion === pinnedVersion) {
+        console.log(`[Extension] ${source} pin matched (${myVersion}). Proceeding.`);
+        return false;
+    }
+    console.log(`[Extension] ${source} pin mismatch: ${myVersion} != ${pinnedVersion}. Yielding.`);
+    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+    updateSplashScreenSync(0, "Applying extension version pins...");
+    return true;
+}
+
 /**
- * Checks version pins (admin intent → remote → local) and returns true if the
- * extension should yield to the Conductor for a profile switch (version mismatch).
+ * Checks version pins and returns true if the extension should yield to the
+ * Conductor for a profile switch (version mismatch).
  * Returns false when pins match or no pins exist — caller should continue activation.
+ *
+ * Uses the Conductor's consolidated pin resolution (admin intent → remote → local)
+ * via a workbench command that reads directly from IStorageService — no dependency
+ * on frontier being activated yet.
  */
 async function checkVersionPinsAndYield(
     projectUri: vscode.Uri,
@@ -179,60 +202,47 @@ async function checkVersionPinsAndYield(
 ): Promise<boolean> {
     const EXTENSION_ID = "project-accelerate.codex-editor-extension";
 
-    // 1. Admin Intent (highest precedence) — allows admin to bypass the
-    // splash-screen halt when they just applied a pin change locally.
+    // Primary: use Conductor's effective pin resolution (always available —
+    // workbench contributions activate before extensions, so this avoids the
+    // activation race where frontier hasn't registered commands yet)
+    try {
+        const effectivePins: Record<string, { version: string; url: string }> | undefined =
+            await vscode.commands.executeCommand("codex.conductor.getEffectivePinnedExtensions");
+        if (effectivePins) {
+            const myPin = effectivePins[EXTENSION_ID];
+            if (!myPin) { return false; } // no pin for our extension — no constraint
+            return checkPinAndYield("Conductor", myPin.version, activationStart) ?? false;
+        }
+    } catch { /* Conductor command not available in older Codex builds */ }
+
+    // Fallback for older Codex builds without the conductor command:
+    // query frontier commands, then metadata.json
     try {
         const remoteState: any = await vscode.commands.executeCommand(
             "frontier.getRemotePinnedExtensionsState"
         );
-        const adminIntent = remoteState?.adminPinnedExtensions;
-        if (adminIntent) {
-            const myPin = adminIntent[EXTENSION_ID];
-            if (myPin) {
-                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
-                if (myVersion && myVersion === myPin.version) {
-                    console.log(`[Extension] Admin intent matched (${myVersion}). Proceeding.`);
-                    return false;
-                }
-                // Intent exists but doesn't match — fall through to remote/local checks
-            }
+        const adminPin = remoteState?.adminPinnedExtensions?.[EXTENSION_ID];
+        if (adminPin) {
+            const result = checkPinAndYield("Admin intent", adminPin.version, activationStart);
+            if (result === false) { return false; } // matched — proceed
+            // doesn't match — fall through to remote/local checks
         }
     } catch { /* Frontier may not be active */ }
 
-    // 2. Remote Pins (authoritative for users)
     try {
         const remotePins: Record<string, { version: string; url: string }> | undefined =
             await vscode.commands.executeCommand("frontier.getRemotePinnedExtensions");
-        if (remotePins) {
-            const myPin = remotePins[EXTENSION_ID];
-            if (myPin) {
-                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
-                if (myVersion && myVersion !== myPin.version) {
-                    console.log(`[Extension] Remote mismatch: ${myVersion} != ${myPin.version}. Yielding.`);
-                    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
-                    updateSplashScreenSync(0, "Applying extension version pins...");
-                    return true;
-                }
-                console.log(`[Extension] Remote version matched (${myVersion}). Proceeding.`);
-                return false;
-            }
+        const remotePin = remotePins?.[EXTENSION_ID];
+        if (remotePin) {
+            return checkPinAndYield("Remote", remotePin.version, activationStart) ?? false;
         }
     } catch { /* Frontier may not be active */ }
 
-    // 3. Local metadata.json (fallback)
     try {
         const result = await MetadataManager.safeReadMetadata(projectUri);
-        if (result.success && result.metadata?.meta?.pinnedExtensions) {
-            const myPin = result.metadata.meta.pinnedExtensions[EXTENSION_ID];
-            if (myPin) {
-                const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
-                if (myVersion && myVersion !== myPin.version) {
-                    console.log(`[Extension] Local mismatch: ${myVersion} != ${myPin.version}. Yielding.`);
-                    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
-                    updateSplashScreenSync(0, "Applying extension version pins...");
-                    return true;
-                }
-            }
+        const localPin = result.success ? result.metadata?.meta?.pinnedExtensions?.[EXTENSION_ID] : undefined;
+        if (localPin) {
+            return checkPinAndYield("Local", localPin.version, activationStart) ?? false;
         }
     } catch { /* ignore */ }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,23 +345,61 @@ export async function activate(context: vscode.ExtensionContext) {
     if (workspaceFolders && workspaceFolders.length > 0) {
         try {
             const projectUri = workspaceFolders[0].uri;
-            const result = await MetadataManager.safeReadMetadata(projectUri);
-            if (result.success && result.metadata?.meta?.pinnedExtensions) {
-                const pins = result.metadata.meta.pinnedExtensions;
-                const myPin = pins["project-accelerate.codex-editor-extension"];
+
+            // Priority 1: Check for Remote Pins (authoritative for users)
+            let remotePins: Record<string, { version: string; url: string }> | undefined;
+            try {
+                remotePins = await vscode.commands.executeCommand(
+                    "frontier.getRemotePinnedExtensions"
+                );
+            } catch (e) {
+                // Command might not exist if Frontier isn't active/installed
+            }
+
+            if (remotePins) {
+                const myPin = remotePins["project-accelerate.codex-editor-extension"];
                 if (myPin) {
                     const myVersion = MetadataManager.getCurrentExtensionVersion(
                         "project-accelerate.codex-editor-extension"
                     );
                     if (myVersion && myVersion !== myPin.version) {
                         console.log(
-                            `[Extension] Version mismatch detected: ${myVersion} != ${myPin.version}. Suspending initialization for Conductor.`
+                            `[Extension] Remote version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
                         );
-                        // Trigger the "sync" style UI in the splash screen
-                        trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+                        trackTiming(
+                            "Starting Project Synchronization (Version Pin Enforcement)",
+                            activationStart
+                        );
                         updateSplashScreenSync(0, "Applying extension version pins...");
-                        // Halt activation - the window will be reloaded by CodexConductor
                         return;
+                    } else {
+                        // We match the remote authority — proceed even if metadata.json is different (to allow merge)
+                        console.log(
+                            `[Extension] Remote version matched (${myVersion}). Proceeding to activation.`
+                        );
+                    }
+                }
+            } else {
+                // Priority 2: Fall back to local metadata.json
+                const result = await MetadataManager.safeReadMetadata(projectUri);
+                if (result.success && result.metadata?.meta?.pinnedExtensions) {
+                    const pins = result.metadata.meta.pinnedExtensions;
+                    const myPin = pins["project-accelerate.codex-editor-extension"];
+                    if (myPin) {
+                        const myVersion = MetadataManager.getCurrentExtensionVersion(
+                            "project-accelerate.codex-editor-extension"
+                        );
+                        if (myVersion && myVersion !== myPin.version) {
+                            console.log(
+                                `[Extension] Local version mismatch: ${myVersion} != ${myPin.version}. Suspending for Conductor.`
+                            );
+                            trackTiming(
+                                "Starting Project Synchronization (Version Pin Enforcement)",
+                                activationStart
+                            );
+                            updateSplashScreenSync(0, "Applying extension version pins...");
+                            return;
+                        }
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -340,6 +340,36 @@ export async function activate(context: vscode.ExtensionContext) {
         // Continue with activation even if splash screen fails
     }
 
+    // Check for version pins before heavy initialization
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders && workspaceFolders.length > 0) {
+        try {
+            const projectUri = workspaceFolders[0].uri;
+            const result = await MetadataManager.safeReadMetadata(projectUri);
+            if (result.success && result.metadata?.meta?.pinnedExtensions) {
+                const pins = result.metadata.meta.pinnedExtensions;
+                const myPin = pins["project-accelerate.codex-editor-extension"];
+                if (myPin) {
+                    const myVersion = MetadataManager.getCurrentExtensionVersion(
+                        "project-accelerate.codex-editor-extension"
+                    );
+                    if (myVersion && myVersion !== myPin.version) {
+                        console.log(
+                            `[Extension] Version mismatch detected: ${myVersion} != ${myPin.version}. Suspending initialization for Conductor.`
+                        );
+                        // Trigger the "sync" style UI in the splash screen
+                        trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+                        updateSplashScreenSync(0, "Applying extension version pins...");
+                        // Halt activation - the window will be reloaded by CodexConductor
+                        return;
+                    }
+                }
+            }
+        } catch (err) {
+            console.error("[Extension] Error checking for version pins:", err);
+        }
+    }
+
     let stepStart = activationStart;
 
     try {
@@ -362,7 +392,6 @@ export async function activate(context: vscode.ExtensionContext) {
         stepStart = trackTiming("Loading Project Metadata", metadataStart);
 
         // Check for metadata.json early — this determines if we're in a Codex project
-        const workspaceFolders = vscode.workspace.workspaceFolders;
         let metadataExists = false;
         if (workspaceFolders && workspaceFolders.length > 0) {
             const metadataUri = vscode.Uri.joinPath(workspaceFolders[0].uri, "metadata.json");

--- a/src/projectManager/utils/versionChecks.ts
+++ b/src/projectManager/utils/versionChecks.ts
@@ -21,7 +21,10 @@ export async function getFrontierVersionStatus(): Promise<{ ok: boolean; install
     const frontierExt = vscode.extensions.getExtension("frontier-rnd.frontier-authentication");
     const installedVersion: string | undefined = (frontierExt as any)?.packageJSON?.version;
 
-    if (!installedVersion || !semver.gte(installedVersion, REQUIRED_FRONTIER_VERSION)) {
+    // Strip prerelease suffix (e.g. "0.24.0-pr829-5489534a" → "0.24.0") so PR
+    // builds aren't rejected by the minimum-version gate.
+    const baseVersion = installedVersion ? semver.coerce(installedVersion)?.version : undefined;
+    if (!baseVersion || !semver.gte(baseVersion, REQUIRED_FRONTIER_VERSION)) {
         return { ok: false, installedVersion, requiredVersion: REQUIRED_FRONTIER_VERSION };
     }
 

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -328,7 +328,7 @@ export class MetadataManager {
                 }
 
                 const pinnedExtensions: Record<string, { version: string; url: string }> =
-                    (metadata.meta as any).pinnedExtensions ?? {};
+                    metadata.meta.pinnedExtensions ?? {};
 
                 // Only update codexEditor if new version is greater or missing,
                 // AND no codex-editor pin is active (the Conductor owns the floor while active).

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/experiment/docxParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/experiment/docxParser.ts
@@ -32,7 +32,7 @@ const XML_PARSER_OPTIONS = {
     processEntities: true,
     ignoreDeclaration: false,
     ignorePiTags: false,
-    isArray: (name: string, jpath: string) => {
+    isArray: (name: string, _jpath: unknown, _isLeafNode: boolean, _isAttribute: boolean) => {
         // Treat these elements as arrays even if there's only one
         return ['w:p', 'w:r', 'w:t', 'w:tab', 'w:br', 'w:drawing'].includes(name);
     },


### PR DESCRIPTION
Fixes a bug where codex-editor wouldn't load due to pin mistmatch when we are trying to use a new pin coming from a remote project sync.
