### PR TITLE
Gate startup to ensure appropriate extension pin

### DIFF
--- a/create-pr-release
+++ b/create-pr-release
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+
+# Ensure we're in a directory with a package.json
+if [[ ! -f package.json ]]; then
+  echo "Error: no package.json in current directory" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  printf '\033[33mWarning: git working tree is dirty.\033[0m\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve VERSION
+# ---------------------------------------------------------------------------
+if [[ -z "$VERSION" ]]; then
+  # No version argument — check for an open PR and suggest one
+  if ! command -v gh &>/dev/null; then
+    echo "Error: 'gh' CLI is required when no version argument is provided." >&2
+    exit 1
+  fi
+
+  PR_NUMBER="$(gh pr view --json number -q .number 2>/dev/null || true)"
+
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "Usage: ext-release-create <version>" >&2
+    echo "  version: x.y.z | x.y.z-prNNN | x.y.z-prNNN-shorthash" >&2
+    echo "" >&2
+    echo "No open PR detected for the current branch, so cannot auto-suggest a version." >&2
+    exit 1
+  fi
+
+  BASE_VERSION="$(jq -r .version package.json)"
+  SHORT_HASH="$(git rev-parse --short HEAD)"
+  VERSION="${BASE_VERSION}-pr${PR_NUMBER}-${SHORT_HASH}"
+
+  echo "Open PR #${PR_NUMBER} detected."
+  echo "Generated version: $VERSION"
+  echo "Releasing in 5s, ctrl-c to cancel..."
+  sleep 5
+fi
+
+# ---------------------------------------------------------------------------
+# Validate VERSION — allowed forms:
+#   x.y.z
+#   x.y.z-pr123
+#   x.y.z-pr123-shorthash
+# Explicitly forbid x.y.z.prNNN (dot before pr)
+# ---------------------------------------------------------------------------
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-zA-Z][-0-9a-zA-Z]*)*$ ]]; then
+  echo "Error: version must match x.y.z, x.y.z-prNNN, or x.y.z-prNNN-shorthash" >&2
+  echo "  (dot-separated pre-release like x.y.z.prNNN is NOT allowed)" >&2
+  exit 1
+fi
+
+# Resolve PR_NUMBER if not already set (i.e. version was supplied directly)
+if [[ -z "${PR_NUMBER:-}" ]]; then
+  PR_NUMBER="$(gh pr view --json number -q .number 2>/dev/null || true)"
+fi
+
+NAME="$(jq -r .name package.json)"
+ORIGINAL_VERSION="$(jq -r .version package.json)"
+VSIX_FILE="${NAME}-${VERSION}.vsix"
+PACKAGE_JSON_BACKUP="$(mktemp "${TMPDIR:-/tmp}/package.json.backup.XXXXXX")"
+cp -p package.json "$PACKAGE_JSON_BACKUP"
+
+cleanup() {
+  if [[ -f "$PACKAGE_JSON_BACKUP" ]]; then
+    echo "Restoring package.json from backup"
+    cp -p "$PACKAGE_JSON_BACKUP" package.json
+  fi
+  rm -f "$PACKAGE_JSON_BACKUP"
+}
+trap cleanup EXIT
+
+echo "==> Bumping version: $ORIGINAL_VERSION -> $VERSION"
+jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+
+echo "==> Installing dependencies"
+pnpm install
+
+# Conditionally build webviews if the script exists
+if jq -e '.scripts["build:webviews"]' package.json &>/dev/null; then
+  echo "==> Installing webview dependencies"
+  (cd webviews/codex-webviews && pnpm install)
+  echo "==> Building webviews"
+  pnpm run build:webviews
+fi
+
+echo "==> Building extension (production)"
+pnpm run package
+
+echo "==> Packaging VSIX"
+# No dependencies results in errors like can't find codicon.css. We should probably bundle depens explicitly.
+pnpm dlx @vscode/vsce package --no-dependencies
+#pnpm dlx @vscode/vsce package
+
+echo "==> Restoring version before release"
+cleanup
+trap - EXIT
+
+# We need to ensure head is on remote so it's there to attach the release to.
+# Skip verify as we just built and tested successfully.
+git push --no-verify
+
+echo "==> Creating GitHub prerelease: $VERSION"
+gh release create "$VERSION" \
+  --target "$(git rev-parse HEAD)" \
+  --prerelease \
+  --title "$VERSION" \
+  --generate-notes \
+  "./$VSIX_FILE"
+
+REPO_URL="$(gh repo view --json url -q .url)"
+RELEASE_URL="${REPO_URL}/releases/tag/${VERSION}"
+echo "Done! Prerelease $VERSION created with $VSIX_FILE"
+
+if [[ -n "${PR_NUMBER:-}" ]]; then
+  PR_URL="${REPO_URL}/pull/${PR_NUMBER}"
+  gh pr comment "$PR_NUMBER" --body "Pre-release: ${VERSION} ${RELEASE_URL}"
+  echo "Commented PR #${PR_NUMBER} ${PR_URL}"
+fi
+
+open "$REPO_URL/releases"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,43 @@ function finishRealtimeStep(): number {
     return globalThis.performance.now();
 }
 
+/**
+ * Pin-match gate: returns true when the running version of codex-editor does
+ * not match the project's pinned version, meaning activation must halt at the
+ * gate while the Conductor switches profiles.
+ *
+ * Reads pins via the Conductor's effective pin resolution (admin intent →
+ * remote → local). The Conductor command is always available because
+ * workbench contributions activate before extensions.
+ */
+async function failsPinMatchGate(activationStart: number): Promise<boolean> {
+    const EXTENSION_ID = "project-accelerate.codex-editor-extension";
+
+    let effectivePins: Record<string, { version: string; url: string; }> | undefined;
+    try {
+        effectivePins = await vscode.commands.executeCommand(
+            "codex.conductor.getEffectivePinnedExtensions"
+        );
+    } catch {
+        // Conductor command not available in older Codex builds
+        return false;
+    }
+    if (!effectivePins) return false;
+
+    const myPin = effectivePins[EXTENSION_ID];
+    if (!myPin) return false;
+
+    const myVersion = MetadataManager.getCurrentExtensionVersion(EXTENSION_ID);
+    if (!myVersion) return false; // unknown — can't decide
+    if (myVersion === myPin.version) {
+        return false;
+    }
+
+    console.log(`[Extension] Pin mismatch: ${myVersion} != ${myPin.version}. Halting at pin-match gate.`);
+    trackTiming("Starting Project Synchronization (Version Pin Enforcement)", activationStart);
+    return true;
+}
+
 declare global {
     // eslint-disable-next-line
     var db: Database | undefined;
@@ -340,6 +377,26 @@ export async function activate(context: vscode.ExtensionContext) {
         // Continue with activation even if splash screen fails
     }
 
+    // Check for metadata.json early — this determines if we're in a Codex project
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    let metadataExists = false;
+    if (workspaceFolders && workspaceFolders.length > 0) {
+        const metadataUri = vscode.Uri.joinPath(workspaceFolders[0].uri, "metadata.json");
+        try {
+            await vscode.workspace.fs.stat(metadataUri);
+            metadataExists = true;
+        } catch {
+            metadataExists = false;
+        }
+    }
+
+    // Pin-match gate: before heavy initialization, halt if our running version
+    // doesn't match the project's pin so the Conductor can switch profiles.
+    if (metadataExists && await failsPinMatchGate(activationStart)) {
+        updateSplashScreenSync(0, "Applying extension version pins...");
+        return;
+    }
+
     let stepStart = activationStart;
 
     try {
@@ -360,19 +417,6 @@ export async function activate(context: vscode.ExtensionContext) {
         notebookMetadataManager = NotebookMetadataManager.getInstance(context);
         await notebookMetadataManager.initialize();
         stepStart = trackTiming("Loading Project Metadata", metadataStart);
-
-        // Check for metadata.json early — this determines if we're in a Codex project
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        let metadataExists = false;
-        if (workspaceFolders && workspaceFolders.length > 0) {
-            const metadataUri = vscode.Uri.joinPath(workspaceFolders[0].uri, "metadata.json");
-            try {
-                await vscode.workspace.fs.stat(metadataUri);
-                metadataExists = true;
-            } catch {
-                metadataExists = false;
-            }
-        }
 
         // Comments migration is now manual via command palette: "Codex: Migrate Legacy Comments"
         // Repair still runs at startup to fix any corrupted data

--- a/src/projectManager/utils/versionChecks.ts
+++ b/src/projectManager/utils/versionChecks.ts
@@ -21,7 +21,10 @@ export async function getFrontierVersionStatus(): Promise<{ ok: boolean; install
     const frontierExt = vscode.extensions.getExtension("frontier-rnd.frontier-authentication");
     const installedVersion: string | undefined = (frontierExt as any)?.packageJSON?.version;
 
-    if (!installedVersion || !semver.gte(installedVersion, REQUIRED_FRONTIER_VERSION)) {
+    // Strip prerelease suffix (e.g. "0.24.0-pr829-5489534a" → "0.24.0") so PR
+    // builds aren't rejected by the minimum-version gate.
+    const baseVersion = installedVersion ? semver.coerce(installedVersion)?.version : undefined;
+    if (!baseVersion || !semver.gte(baseVersion, REQUIRED_FRONTIER_VERSION)) {
         return { ok: false, installedVersion, requiredVersion: REQUIRED_FRONTIER_VERSION };
     }
 

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -328,7 +328,7 @@ export class MetadataManager {
                 }
 
                 const pinnedExtensions: Record<string, { version: string; url: string }> =
-                    (metadata.meta as any).pinnedExtensions ?? {};
+                    metadata.meta.pinnedExtensions ?? {};
 
                 // Only update codexEditor if new version is greater or missing,
                 // AND no codex-editor pin is active (the Conductor owns the floor while active).

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/experiment/docxParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/experiment/docxParser.ts
@@ -32,7 +32,7 @@ const XML_PARSER_OPTIONS = {
     processEntities: true,
     ignoreDeclaration: false,
     ignorePiTags: false,
-    isArray: (name: string, jpath: string) => {
+    isArray: (name: string, _jpath: unknown, _isLeafNode: boolean, _isAttribute: boolean) => {
         // Treat these elements as arrays even if there's only one
         return ['w:p', 'w:r', 'w:t', 'w:tab', 'w:br', 'w:drawing'].includes(name);
     },


### PR DESCRIPTION
Gate codex-editor startup to ensure the appropriate pinned extension is running.

### Key Features
- **Initialization Gate**: `extension.ts` now queries the `codex.conductor` early in the activation phase. If a version mismatch is detected, the extension returns early and displays an "Applying extension version pins..." message, allowing the Conductor to perform an authoritative reload into the target profile.
- **PR Build Compatibility**: Enhanced `versionChecks.ts` to use `semver.coerce` on the installed version string. This allows PR-specific builds (e.g., `0.24.0-pr829`) to be used as defaults (rare case, mostly for Codex beta testing).
- **Pinning Infrastructure**: Added a `create-pr-release` script to automate the generation of VSIXs with `-prNNN` versioning and the creation of GitHub prereleases.

### Maintenance & Refactors
- **DOCX Parser Fix**: Aligned the `isArray` signature in `docxParser.ts` with the `fast-xml-parser` v4+ API to resolve type-safety issues caught during production builds.
- **Metadata Refactor**: Removed unnecessary type casting when accessing `pinnedExtensions` in `MetadataManager`.

### Documentation
- [Extension Version Pinning for Codex Projects](https://github.com/genesis-ai-dev/codex-arch/blob/main/2026-03-project-extension-pinning.md)
- [Pin Enforcement Scenarios](https://github.com/genesis-ai-dev/codex-arch/blob/main/2026-03-pin-enforcement-scenarios.md)