### PR TITLE
721 main we should be saving the users current codex binary version in the metadata

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -582,6 +582,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 } catch (error) {
                     console.warn("[Extension] Error ensuring extension version requirements:", error);
                 }
+
+                try {
+                    await MetadataManager.ensureCurrentUserVersionRecorded(workspaceFolders[0].uri);
+                } catch (error) {
+                    console.warn("[Extension] Error recording user codex version:", error);
+                }
             }
 
             trackTiming("Initializing Workspace", workspaceStart);

--- a/src/projectManager/syncManager.ts
+++ b/src/projectManager/syncManager.ts
@@ -977,6 +977,16 @@ export class SyncManager {
                 // Don't fail sync if webview refresh fails
             }
 
+            // Record current user's Codex version after a successful sync
+            if (workspaceFolders && workspaceFolders.length > 0) {
+                try {
+                    const { MetadataManager } = await import("../utils/metadataManager");
+                    await MetadataManager.ensureCurrentUserVersionRecorded(workspaceFolders[0].uri);
+                } catch (error) {
+                    console.warn("[SyncManager] Error recording user codex version after sync:", error);
+                }
+            }
+
         } catch (error) {
             console.error("Error during background sync operation:", error);
             const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -13,7 +13,7 @@ import { NotebookCommentThread, NotebookComment, CustomNotebookCellData, CustomN
 import { CommentsMigrator } from "../../../utils/commentsMigrationUtils";
 import { CodexCell } from "@/utils/codexNotebookUtils";
 import { CodexCellTypes, EditType } from "../../../../types/enums";
-import { EditHistory, ValidationEntry, FileEditHistory, ProjectEditHistory } from "../../../../types/index.d";
+import { EditHistory, ValidationEntry, FileEditHistory, ProjectEditHistory, ProjectUserVersionEntry } from "../../../../types/index.d";
 import { EditMapUtils, deduplicateFileMetadataEdits } from "../../../utils/editMapUtils";
 import { normalizeAttachmentUrl } from "@/utils/pathUtils";
 import { formatJsonForNotebookFile } from "../../../utils/notebookFileFormattingUtils";
@@ -280,6 +280,28 @@ export function mergeOriginalFilesHashes(
         files: mergedFiles,
         fileNameToHash: mergedFileNameToHash,
     };
+}
+
+/**
+ * Merges user-version entries from two sides by userName.
+ * When the same userName appears on both sides, the entry with the higher updatedAt wins.
+ */
+export function mergeUserVersionEntries(
+    oursUsers: ProjectUserVersionEntry[] | undefined,
+    theirsUsers: ProjectUserVersionEntry[] | undefined
+): ProjectUserVersionEntry[] | undefined {
+    if (!oursUsers?.length && !theirsUsers?.length) {
+        return undefined;
+    }
+    const map = new Map<string, ProjectUserVersionEntry>();
+    for (const entry of [...(oursUsers ?? []), ...(theirsUsers ?? [])]) {
+        if (!entry?.userName) continue;
+        const existing = map.get(entry.userName);
+        if (!existing || (entry.updatedAt ?? 0) > (existing.updatedAt ?? 0)) {
+            map.set(entry.userName, entry);
+        }
+    }
+    return Array.from(map.values());
 }
 
 /**
@@ -2235,8 +2257,13 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
         // Merge other fields (excluding edits and initiateRemoteUpdatingFor which are already handled)
         const otherFieldsMerged = mergeObjects(base, ours, theirs);
 
+        const mergedUsers = mergeUserVersionEntries(
+            ours.users as ProjectUserVersionEntry[] | undefined,
+            theirs.users as ProjectUserVersionEntry[] | undefined
+        );
+
         // Combine: use edit history result as base, then overlay other merged fields
-        // But preserve edits, initiateRemoteUpdatingFor, projectSwap, and originalFilesHashes from our specialized merges
+        // But preserve edits, initiateRemoteUpdatingFor, projectSwap, users, and originalFilesHashes from our specialized merges
         const otherMeta = (otherFieldsMerged as Record<string, unknown>).meta as Record<string, unknown> | undefined;
         const finalResult: Record<string, unknown> = {
             ...otherFieldsMerged,
@@ -2247,6 +2274,9 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
                 projectSwap: mergedProjectSwap, // From specialized merge
             }
         };
+        if (mergedUsers) {
+            finalResult.users = mergedUsers;
+        }
         if (mergedOriginalFilesHashes) {
             finalResult.originalFilesHashes = mergedOriginalFilesHashes;
         }

--- a/src/test/suite/metadataManager.test.ts
+++ b/src/test/suite/metadataManager.test.ts
@@ -293,6 +293,115 @@ suite('MetadataManager Tests', () => {
         });
     });
 
+    suite('User version tracking (users array)', () => {
+        test('should insert a new user entry into an empty users array', async () => {
+            const initialMetadata = {
+                format: 'codex',
+                meta: { version: '0.0.1', category: 'source', generator: { softwareName: 'codex-editor', softwareVersion: '0.22.0', userName: 'test' }, defaultLocale: 'en', dateCreated: '2025-01-01', normalization: 'NFC' },
+            };
+            await vscode.workspace.fs.writeFile(metadataPath,
+                new TextEncoder().encode(JSON.stringify(initialMetadata, null, 4)));
+
+            await MetadataManager.safeUpdateMetadata(testWorkspaceUri, (metadata: any) => {
+                const users = metadata.users ?? [];
+                users.push({ userName: 'alice', codexVersion: '0.22.0', updatedAt: 1000 });
+                metadata.users = users;
+                return metadata;
+            });
+
+            const content = await vscode.workspace.fs.readFile(metadataPath);
+            const result = JSON.parse(new TextDecoder().decode(content));
+            assert.ok(Array.isArray(result.users));
+            assert.strictEqual(result.users.length, 1);
+            assert.strictEqual(result.users[0].userName, 'alice');
+            assert.strictEqual(result.users[0].codexVersion, '0.22.0');
+        });
+
+        test('should update an existing user entry when version changes', async () => {
+            const initialMetadata = {
+                format: 'codex',
+                users: [{ userName: 'alice', codexVersion: '0.21.0', updatedAt: 500 }],
+                meta: { version: '0.0.1', category: 'source', generator: { softwareName: 'codex-editor', softwareVersion: '0.22.0', userName: 'test' }, defaultLocale: 'en', dateCreated: '2025-01-01', normalization: 'NFC' },
+            };
+            await vscode.workspace.fs.writeFile(metadataPath,
+                new TextEncoder().encode(JSON.stringify(initialMetadata, null, 4)));
+
+            await MetadataManager.safeUpdateMetadata(testWorkspaceUri, (metadata: any) => {
+                const users = metadata.users ?? [];
+                const existing = users.find((u: any) => u.userName === 'alice');
+                if (existing) {
+                    existing.codexVersion = '0.22.0';
+                    existing.updatedAt = 1000;
+                }
+                metadata.users = users;
+                return metadata;
+            });
+
+            const content = await vscode.workspace.fs.readFile(metadataPath);
+            const result = JSON.parse(new TextDecoder().decode(content));
+            assert.strictEqual(result.users.length, 1);
+            assert.strictEqual(result.users[0].codexVersion, '0.22.0');
+            assert.strictEqual(result.users[0].updatedAt, 1000);
+        });
+
+        test('should not add duplicate users when upserting by userName', async () => {
+            const initialMetadata = {
+                format: 'codex',
+                users: [
+                    { userName: 'alice', codexVersion: '0.22.0', updatedAt: 500 },
+                    { userName: 'bob', codexVersion: '0.21.0', updatedAt: 400 },
+                ],
+                meta: { version: '0.0.1', category: 'source', generator: { softwareName: 'codex-editor', softwareVersion: '0.22.0', userName: 'test' }, defaultLocale: 'en', dateCreated: '2025-01-01', normalization: 'NFC' },
+            };
+            await vscode.workspace.fs.writeFile(metadataPath,
+                new TextEncoder().encode(JSON.stringify(initialMetadata, null, 4)));
+
+            // Upsert alice with a new version
+            await MetadataManager.safeUpdateMetadata(testWorkspaceUri, (metadata: any) => {
+                const users = metadata.users ?? [];
+                const existing = users.find((u: any) => u.userName === 'alice');
+                if (existing) {
+                    existing.codexVersion = '0.23.0';
+                    existing.updatedAt = 2000;
+                } else {
+                    users.push({ userName: 'alice', codexVersion: '0.23.0', updatedAt: 2000 });
+                }
+                metadata.users = users;
+                return metadata;
+            });
+
+            const content = await vscode.workspace.fs.readFile(metadataPath);
+            const result = JSON.parse(new TextDecoder().decode(content));
+            assert.strictEqual(result.users.length, 2);
+            const alice = result.users.find((u: any) => u.userName === 'alice');
+            assert.strictEqual(alice.codexVersion, '0.23.0');
+        });
+
+        test('should preserve other metadata fields when updating users', async () => {
+            const initialMetadata = {
+                format: 'codex',
+                projectName: 'My Project',
+                users: [{ userName: 'alice', codexVersion: '0.22.0', updatedAt: 500 }],
+                meta: { version: '0.0.1', category: 'source', generator: { softwareName: 'codex-editor', softwareVersion: '0.22.0', userName: 'test' }, defaultLocale: 'en', dateCreated: '2025-01-01', normalization: 'NFC' },
+            };
+            await vscode.workspace.fs.writeFile(metadataPath,
+                new TextEncoder().encode(JSON.stringify(initialMetadata, null, 4)));
+
+            await MetadataManager.safeUpdateMetadata(testWorkspaceUri, (metadata: any) => {
+                const users = metadata.users ?? [];
+                users.push({ userName: 'bob', codexVersion: '0.23.0', updatedAt: 1000 });
+                metadata.users = users;
+                return metadata;
+            });
+
+            const content = await vscode.workspace.fs.readFile(metadataPath);
+            const result = JSON.parse(new TextDecoder().decode(content));
+            assert.strictEqual(result.projectName, 'My Project');
+            assert.strictEqual(result.format, 'codex');
+            assert.strictEqual(result.users.length, 2);
+        });
+    });
+
     suite('Performance', () => {
         test('should complete updates within reasonable time', async () => {
             const startTime = Date.now();

--- a/src/test/suite/resolvers/mergeUserVersionEntries.test.ts
+++ b/src/test/suite/resolvers/mergeUserVersionEntries.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "assert";
+import { mergeUserVersionEntries } from "../../../projectManager/utils/merge/resolvers";
+import type { ProjectUserVersionEntry } from "../../../../types/index.d";
+
+const makeEntry = (
+    userName: string,
+    codexVersion: string,
+    updatedAt: number
+): ProjectUserVersionEntry => ({ userName, codexVersion, updatedAt });
+
+suite("Resolver unit: mergeUserVersionEntries", () => {
+    test("returns undefined when both inputs are undefined", () => {
+        const result = mergeUserVersionEntries(undefined, undefined);
+        assert.strictEqual(result, undefined);
+    });
+
+    test("returns undefined when both inputs are empty arrays", () => {
+        const result = mergeUserVersionEntries([], []);
+        assert.strictEqual(result, undefined);
+    });
+
+    test("returns ours entries when theirs is undefined", () => {
+        const ours = [makeEntry("alice", "0.22.0", 1000)];
+        const result = mergeUserVersionEntries(ours, undefined);
+        assert.ok(result);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].userName, "alice");
+    });
+
+    test("returns theirs entries when ours is undefined", () => {
+        const theirs = [makeEntry("bob", "0.23.0", 2000)];
+        const result = mergeUserVersionEntries(undefined, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].userName, "bob");
+    });
+
+    test("unions entries with different userNames", () => {
+        const ours = [makeEntry("alice", "0.22.0", 1000)];
+        const theirs = [makeEntry("bob", "0.23.0", 2000)];
+        const result = mergeUserVersionEntries(ours, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 2);
+        const names = result.map((e) => e.userName).sort();
+        assert.deepStrictEqual(names, ["alice", "bob"]);
+    });
+
+    test("keeps the entry with higher updatedAt when same userName appears on both sides", () => {
+        const ours = [makeEntry("alice", "0.22.0", 1000)];
+        const theirs = [makeEntry("alice", "0.23.0", 2000)];
+        const result = mergeUserVersionEntries(ours, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].codexVersion, "0.23.0");
+        assert.strictEqual(result[0].updatedAt, 2000);
+    });
+
+    test("keeps ours when updatedAt is equal (ours is seen first, theirs cannot beat it)", () => {
+        const ours = [makeEntry("alice", "0.22.0", 1000)];
+        const theirs = [makeEntry("alice", "0.23.0", 1000)];
+        const result = mergeUserVersionEntries(ours, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 1);
+        // With equal timestamps, theirs overwrites ours because iteration order
+        // is [...ours, ...theirs] and the `>` comparison means theirs does NOT replace ours
+        assert.strictEqual(result[0].codexVersion, "0.22.0");
+    });
+
+    test("skips entries with missing userName", () => {
+        const ours = [{ userName: "", codexVersion: "0.22.0", updatedAt: 1000 } as ProjectUserVersionEntry];
+        const theirs = [makeEntry("bob", "0.23.0", 2000)];
+        const result = mergeUserVersionEntries(ours, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].userName, "bob");
+    });
+
+    test("complex scenario: multiple users, some shared, some exclusive", () => {
+        const ours = [
+            makeEntry("alice", "0.22.0", 1000),
+            makeEntry("carol", "0.21.0", 500),
+        ];
+        const theirs = [
+            makeEntry("alice", "0.23.0", 2000),
+            makeEntry("bob", "0.22.5", 1500),
+        ];
+        const result = mergeUserVersionEntries(ours, theirs);
+        assert.ok(result);
+        assert.strictEqual(result.length, 3);
+
+        const byName = new Map(result.map((e) => [e.userName, e]));
+        assert.strictEqual(byName.get("alice")?.codexVersion, "0.23.0");
+        assert.strictEqual(byName.get("bob")?.codexVersion, "0.22.5");
+        assert.strictEqual(byName.get("carol")?.codexVersion, "0.21.0");
+    });
+});

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { ProjectUserVersionEntry } from "@types";
 import { addProjectMetadataEdit } from "./editMapUtils";
 
 /**
@@ -21,6 +22,7 @@ interface ProjectMetadata {
         [key: string]: unknown;
     };
     edits?: any[];
+    users?: ProjectUserVersionEntry[];
     chatSystemMessage?: string;
     [key: string]: unknown;
 }
@@ -444,6 +446,59 @@ export class MetadataManager {
         } catch (error) {
             console.warn("[MetadataManager] Failed to ensure extension versions:", error);
             // Non-fatal - don't block project opening
+        }
+    }
+
+    /**
+     * Record the current user's Codex editor version in the metadata `users` array.
+     * Called on project open and after sync so deploy-compatibility checks can see
+     * which binary each collaborator is running.
+     */
+    static async ensureCurrentUserVersionRecorded(workspaceUri: vscode.Uri): Promise<void> {
+        try {
+            const codexVersion = vscode.version;
+            if (!codexVersion) {
+                return;
+            }
+
+            let userName: string | undefined;
+            try {
+                const { getAuthApi } = await import("../extension");
+                const authApi = getAuthApi();
+                const userInfo = await authApi?.getUserInfo();
+                userName = userInfo?.username;
+            } catch {
+                // Auth not available — fall through to config
+            }
+            if (!userName) {
+                userName =
+                    vscode.workspace
+                        .getConfiguration("codex-project-manager")
+                        .get<string>("userName") || undefined;
+            }
+            if (!userName) {
+                return;
+            }
+
+            await this.safeUpdateMetadata<ProjectMetadata>(workspaceUri, (metadata) => {
+                const users: ProjectUserVersionEntry[] = metadata.users ?? [];
+                const existing = users.find((u) => u.userName === userName);
+
+                if (existing) {
+                    if (existing.codexVersion === codexVersion) {
+                        return metadata; // nothing changed — skip write
+                    }
+                    existing.codexVersion = codexVersion;
+                    existing.updatedAt = Date.now();
+                } else {
+                    users.push({ userName, codexVersion, updatedAt: Date.now() });
+                }
+
+                metadata.users = users;
+                return metadata;
+            });
+        } catch (error) {
+            console.warn("[MetadataManager] Failed to record user version:", error);
         }
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1194,6 +1194,15 @@ interface ProjectOverview extends Project {
     spellcheckIsEnabled: boolean;
 }
 
+/** A snapshot of a single user's Codex app (host IDE) version, recorded on project open and after sync */
+type ProjectUserVersionEntry = {
+    userName: string;
+    /** Host IDE / app binary version (vscode.version), e.g. "1.108.11148" */
+    codexVersion: string;
+    /** Epoch milliseconds when this entry was last written */
+    updatedAt: number;
+};
+
 /* This is the project metadata that is saved in the metadata.json file */
 type ProjectMetadata = {
     projectName?: string;
@@ -1206,6 +1215,8 @@ type ProjectMetadata = {
         fileNameToHash: { [fileName: string]: string; };
     };
     edits?: ProjectEditHistory[];
+    /** Per-user Codex editor version tracking for deploy compatibility checks */
+    users?: ProjectUserVersionEntry[];
     meta: {
         version: string;
         category: string;


### PR DESCRIPTION
Closes #721 

### Summary
- Create a users array with ProjectUserVersionEntry which contains the codexVersion.
- Write tests for changes

### To Test
- [x] Check if the user array populates correctly on reload and sync
- [x] Check user array with another person to check merging strategy when syncing