### PR TITLE
fix(docx): simplify isArray callback for fast-xml-parser v5 compatibility

### DIFF
--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.ts
@@ -32,7 +32,7 @@ const XML_PARSER_OPTIONS = {
     processEntities: true,
     ignoreDeclaration: false,
     ignorePiTags: false,
-    isArray: (name: string, _jpath: unknown, _isLeafNode: boolean, _isAttribute: boolean) => {
+    isArray: (name: string) => {
         // Treat these elements as arrays even if there's only one
         return ['w:p', 'w:r', 'w:t', 'w:tab', 'w:br', 'w:drawing'].includes(name);
     },


### PR DESCRIPTION
The `isArray` callback in `XML_PARSER_OPTIONS` declared `jpath: string`, which conflicts with the `JPathOrMatcher` type introduced in newer fast-xml-parser v5 releases (observed at v5.5.12 with specifier `^5.2.3`).

I [previously fixed this](https://github.com/genesis-ai-dev/codex-editor/commit/dee0bbaa781de2a1330cb683b397b762b6b534e8) by adding the full new signature. However, this will only work for those who run `pnpm install`.

If we want things to continue to work for those who haven't run `pnpm install` yet, this is a better fix: remove the unused params altogether.

This would need to be done on `dev` as well, which as the same file but without the `experiment` directory.