### PR TITLE
861 text only paste option

### DIFF
--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -555,6 +555,27 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         }
     },
 
+    getPasteAsPlainText: async ({ webviewPanel, provider }) => {
+        try {
+            const enabled = provider.getPasteAsPlainText();
+            provider.postMessageToWebview(webviewPanel, {
+                type: "pasteAsPlainTextPreference",
+                enabled,
+            });
+        } catch (error) {
+            console.error("Error getting paste-as-plain-text preference:", error);
+        }
+    },
+
+    setPasteAsPlainText: async ({ event, provider }) => {
+        const typedEvent = event as Extract<EditorPostMessages, { command: "setPasteAsPlainText"; }>;
+        try {
+            provider.updatePasteAsPlainText(typedEvent.content.enabled);
+        } catch (error) {
+            console.error("Error setting paste-as-plain-text preference:", error);
+        }
+    },
+
 
     getCommentsForCell: async ({ event, webviewPanel }) => {
         const typedEvent = event as Extract<EditorPostMessages, { command: "getCommentsForCell"; }>;

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -39,6 +39,8 @@ import {
     updateCachedSubsection as updateCachedSubsectionUtil,
     getPreferredEditorTab as getPreferredEditorTabUtil,
     updatePreferredEditorTab as updatePreferredEditorTabUtil,
+    getPasteAsPlainText as getPasteAsPlainTextUtil,
+    updatePasteAsPlainText as updatePasteAsPlainTextUtil,
 } from "./utils/workspaceStateUtils";
 import { processVideoUrl } from "./utils/videoUtils";
 import {
@@ -1499,6 +1501,14 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         tab: "source" | "backtranslation" | "footnotes" | "timestamps" | "audio"
     ) {
         await updatePreferredEditorTabUtil(this.context.workspaceState, tab);
+    }
+
+    public getPasteAsPlainText(): boolean {
+        return getPasteAsPlainTextUtil(this.context.workspaceState);
+    }
+
+    public async updatePasteAsPlainText(enabled: boolean) {
+        await updatePasteAsPlainTextUtil(this.context.workspaceState, enabled);
     }
 
     private getHtmlForWebview(

--- a/src/providers/codexCellEditorProvider/utils/workspaceStateUtils.ts
+++ b/src/providers/codexCellEditorProvider/utils/workspaceStateUtils.ts
@@ -79,3 +79,26 @@ export async function updatePreferredEditorTab(
     const key = `codex-editor-preferred-tab`;
     await workspaceState.update(key, tab);
 }
+
+/**
+ * Gets the paste-as-plain-text preference from workspace state
+ * @param workspaceState The workspace state memento
+ * @returns Whether paste-as-plain-text is enabled (defaults to false)
+ */
+export function getPasteAsPlainText(workspaceState: vscode.Memento): boolean {
+    const key = `codex-editor-paste-as-plain-text`;
+    return workspaceState.get(key, false);
+}
+
+/**
+ * Updates the paste-as-plain-text preference in workspace state
+ * @param workspaceState The workspace state memento
+ * @param enabled Whether to enable paste-as-plain-text
+ */
+export async function updatePasteAsPlainText(
+    workspaceState: vscode.Memento,
+    enabled: boolean
+): Promise<void> {
+    const key = `codex-editor-paste-as-plain-text`;
+    await workspaceState.update(key, enabled);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -375,6 +375,8 @@ export type EditorPostMessages =
             | "audio";
         };
     }
+    | { command: "getPasteAsPlainText"; }
+    | { command: "setPasteAsPlainText"; content: { enabled: boolean; }; }
     | { command: "setCurrentIdToGlobalState"; content: { currentLineId: string; }; }
     | { command: "webviewFocused"; content: { uri: string; }; }
     | { command: "updateCellLabel"; content: { cellId: string; cellLabel: string; }; }
@@ -1887,6 +1889,10 @@ type EditorReceiveMessages =
         | "footnotes"
         | "timestamps"
         | "audio";
+    }
+    | {
+        type: "pasteAsPlainTextPreference";
+        enabled: boolean;
     }
     | {
         type: "providerAutocompletionState";

--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -376,30 +376,48 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                 }, 50);
             };
 
-            // Capture-phase listener intercepts paste before Quill's clipboard
-            // module so we can strip formatting without Quill also inserting
-            // the rich content (which would double the text).
+            // Pending toolbar formats (e.g. bold + italic) that should be
+            // applied to pasted content. Captured in the capture phase before
+            // Quill's clipboard module runs, then consumed in the bubble phase.
+            let prePasteFormats: ReturnType<Quill["getFormat"]> | null = null;
+            let prePasteLength: number | null = null;
+
+            // Capture-phase listener fires before Quill's clipboard module.
+            // When plain-text mode is active it intercepts the event entirely;
+            // otherwise it just snapshots the active formats for the bubble handler.
             quill.root.addEventListener("paste", (event: ClipboardEvent) => {
+                if (!quillRef.current) return;
+
+                const formats = quillRef.current.getFormat();
+                const hasActiveFormats = Object.keys(formats).length > 0;
+
+                if (hasActiveFormats) {
+                    prePasteFormats = formats;
+                    prePasteLength = quillRef.current.getLength();
+                }
+
                 if (!pasteAsPlainTextRef.current) return;
 
                 event.preventDefault();
                 event.stopPropagation();
 
                 const text = event.clipboardData?.getData("text/plain") ?? "";
-                if (!text || !quillRef.current) return;
+                if (!text) return;
 
                 const sel = quillRef.current.getSelection(true);
                 if (sel) {
                     if (sel.length > 0) {
                         quillRef.current.deleteText(sel.index, sel.length, "user");
                     }
-                    quillRef.current.insertText(sel.index, text, "user");
+                    quillRef.current.insertText(sel.index, text, formats, "user");
                     quillRef.current.setSelection(sel.index + text.length, 0, "silent");
                 } else {
                     const end = quillRef.current.getLength() - 1;
-                    quillRef.current.insertText(end, text, "user");
+                    quillRef.current.insertText(end, text, formats, "user");
                 }
 
+                prePasteFormats = null;
+                prePasteLength = null;
                 triggerPostPasteProcessing();
             }, { capture: true });
 
@@ -407,6 +425,29 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
             // When plain-text mode is active the event never reaches here
             // because the capture-phase handler stops propagation.
             quill.root.addEventListener("paste", () => {
+                if (prePasteFormats && prePasteLength !== null && quillRef.current) {
+                    const formats = prePasteFormats;
+                    const prevLen = prePasteLength;
+                    prePasteFormats = null;
+                    prePasteLength = null;
+
+                    // Quill processes clipboard content asynchronously, so
+                    // wait for it to finish before applying the formats.
+                    setTimeout(() => {
+                        if (!quillRef.current) return;
+                        const newLen = quillRef.current.getLength();
+                        const insertedCount = newLen - prevLen;
+                        if (insertedCount <= 0) return;
+
+                        const sel = quillRef.current.getSelection();
+                        const insertStart = (sel?.index ?? newLen - 1) - insertedCount;
+                        if (insertStart < 0) return;
+
+                        for (const [name, value] of Object.entries(formats)) {
+                            quillRef.current.formatText(insertStart, insertedCount, name, value, "silent");
+                        }
+                    }, 0);
+                }
                 triggerPostPasteProcessing();
             });
 

--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -43,6 +43,8 @@ export interface EditorProps {
     setIsEditingFootnoteInline: (isEditing: boolean) => void;
     isEditingFootnoteInline: boolean;
     footnoteOffset?: number;
+    pasteAsPlainText?: boolean;
+    onCharacterCountChange?: (count: number) => void;
 }
 
 // Fix the imports with correct typing
@@ -254,6 +256,7 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
     const { setUnsavedChanges } = useContext(UnsavedChangesContext);
     const quillRef = useRef<Quill | null>(null);
     const editorRef = useRef<HTMLDivElement>(null);
+    const pasteAsPlainTextRef = useRef(props.pasteAsPlainText ?? false);
 
     const [currentAuthor, setCurrentAuthor] = useState<string>(
         (window as any).initialData?.userInfo?.username || "anonymous"
@@ -265,6 +268,10 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
 
     const [footnoteCount, setFootnoteCount] = useState(1);
     const [characterCount, setCharacterCount] = useState(0);
+
+    useEffect(() => {
+        props.onCharacterCountChange?.(characterCount);
+    }, [characterCount, props.onCharacterCountChange]);
 
     // Track the baseline content for dirty checking (updated when LLM content is set)
     const quillInitialContentRef = useRef<string>("");
@@ -302,6 +309,10 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
         };
     }, [isEditingFootnoteInline]);
 
+    useEffect(() => {
+        pasteAsPlainTextRef.current = props.pasteAsPlainText ?? false;
+    }, [props.pasteAsPlainText]);
+
     // Initialize Quill editor
     useEffect(() => {
         if (editorRef.current && !quillRef.current) {
@@ -337,9 +348,7 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                 toolbar.setAttribute("style", "transition: all 0.2s ease; overflow: hidden;");
             }
 
-            // Add paste event listener to handle paste operations
-            quill.root.addEventListener("paste", () => {
-                // Set unsaved changes immediately when paste is detected
+            const triggerPostPasteProcessing = () => {
                 setUnsavedChanges(true);
 
                 // Use setTimeout to ensure the paste operation completes, then process content
@@ -364,7 +373,41 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                             html: finalContent,
                         });
                     }
-                }, 50); // Slightly longer timeout to ensure paste is complete
+                }, 50);
+            };
+
+            // Capture-phase listener intercepts paste before Quill's clipboard
+            // module so we can strip formatting without Quill also inserting
+            // the rich content (which would double the text).
+            quill.root.addEventListener("paste", (event: ClipboardEvent) => {
+                if (!pasteAsPlainTextRef.current) return;
+
+                event.preventDefault();
+                event.stopPropagation();
+
+                const text = event.clipboardData?.getData("text/plain") ?? "";
+                if (!text || !quillRef.current) return;
+
+                const sel = quillRef.current.getSelection(true);
+                if (sel) {
+                    if (sel.length > 0) {
+                        quillRef.current.deleteText(sel.index, sel.length, "user");
+                    }
+                    quillRef.current.insertText(sel.index, text, "user");
+                    quillRef.current.setSelection(sel.index + text.length, 0, "silent");
+                } else {
+                    const end = quillRef.current.getLength() - 1;
+                    quillRef.current.insertText(end, text, "user");
+                }
+
+                triggerPostPasteProcessing();
+            }, { capture: true });
+
+            // Bubble-phase listener handles the normal (rich) paste path.
+            // When plain-text mode is active the event never reaches here
+            // because the capture-phase handler stops propagation.
+            quill.root.addEventListener("paste", () => {
+                triggerPostPasteProcessing();
             });
 
             // Add Microsoft Word-style footnote deletion behavior
@@ -1347,20 +1390,6 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                             : {}
                     }
                 ></div>
-                <div
-                    style={{
-                        display: "flex",
-                        justifyContent: "flex-end",
-                        alignItems: "center",
-                        marginTop: "4px",
-                        padding: "2px 4px",
-                        fontSize: "0.8em",
-                        color: "var(--vscode-descriptionForeground)",
-                        backgroundColor: "transparent",
-                    }}
-                >
-                    <span>{characterCount} characters</span>
-                </div>
             </div>
             {showHistoryModal && (
                 <div

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -43,6 +43,7 @@ import {
     DialogTitle,
 } from "../components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover";
+import { Checkbox } from "../components/ui/checkbox";
 import "./TextCellEditor-overrides.css";
 import { Slider } from "../components/ui/slider";
 
@@ -310,6 +311,14 @@ const CellEditor: React.FC<CellEditorProps> = ({
     // Load preferred tab from provider on mount
     useEffect(() => {
         window.vscodeApi.postMessage({ command: "getPreferredEditorTab" });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const [pasteAsPlainText, setPasteAsPlainText] = useState(false);
+    const [characterCount, setCharacterCount] = useState(0);
+
+    useEffect(() => {
+        window.vscodeApi.postMessage({ command: "getPasteAsPlainText" });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -1087,6 +1096,16 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }
         },
         [cellMarkers, centerEditor]
+    );
+
+    useMessageHandler(
+        "textCellEditor-pasteAsPlainText",
+        (event: MessageEvent) => {
+            if (event.data?.type === "pasteAsPlainTextPreference") {
+                setPasteAsPlainText(event.data.enabled);
+            }
+        },
+        []
     );
 
     // Listen for storeFootnote messages
@@ -2196,8 +2215,32 @@ const CellEditor: React.FC<CellEditorProps> = ({
                             setIsEditingFootnoteInline={setIsEditingFootnoteInline}
                             isEditingFootnoteInline={isEditingFootnoteInline}
                             footnoteOffset={footnoteOffset}
+                            pasteAsPlainText={pasteAsPlainText}
+                            onCharacterCountChange={setCharacterCount}
                         />
                     </div>
+                </div>
+
+                <div className="flex items-center justify-between px-1 py-1">
+                    <label className="flex items-center gap-1.5 cursor-pointer select-none">
+                        <Checkbox
+                            checked={pasteAsPlainText}
+                            onCheckedChange={(checked: boolean | "indeterminate") => {
+                                const next = checked === true;
+                                setPasteAsPlainText(next);
+                                window.vscodeApi.postMessage({
+                                    command: "setPasteAsPlainText",
+                                    content: { enabled: next },
+                                });
+                            }}
+                        />
+                        <span className="text-xs text-muted-foreground">
+                            Paste as plain text
+                        </span>
+                    </label>
+                    <span className="text-xs text-muted-foreground">
+                        {characterCount} characters
+                    </span>
                 </div>
 
                 <Tabs

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/Editor.pasteAsPlainText.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/Editor.pasteAsPlainText.test.tsx
@@ -67,7 +67,7 @@ vi.mock("quill", () => {
             insertText: vi.fn(),
             deleteText: vi.fn(),
             format: vi.fn(),
-            getFormat: vi.fn(),
+            getFormat: vi.fn().mockReturnValue({}),
             removeFormat: vi.fn(),
             setSelection: vi.fn(),
             getSelection: vi
@@ -238,6 +238,7 @@ describe("Editor paste-as-plain-text", () => {
         expect(quillInstance.insertText).toHaveBeenCalledWith(
             0,
             "pasted plain",
+            {},
             "user"
         );
     });
@@ -273,6 +274,7 @@ describe("Editor paste-as-plain-text", () => {
         expect(quillInstance.insertText).toHaveBeenCalledWith(
             6,
             "universe",
+            {},
             "user"
         );
         expect(quillInstance.setSelection).toHaveBeenCalledWith(

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/Editor.pasteAsPlainText.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/Editor.pasteAsPlainText.test.tsx
@@ -1,0 +1,376 @@
+import React from "react";
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import Editor from "../Editor";
+
+const mockVscode = {
+    postMessage: vi.fn(),
+    getState: vi.fn(),
+    setState: vi.fn(),
+};
+
+Object.defineProperty(window, "vscodeApi", {
+    value: mockVscode,
+    writable: true,
+});
+
+global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
+
+type EventListenerEntry = {
+    type: string;
+    handler: EventListener;
+    options?: boolean | AddEventListenerOptions;
+};
+
+let capturedListeners: EventListenerEntry[] = [];
+
+vi.mock("quill", () => {
+    class MockBlot {
+        static blotName = "mock";
+        static tagName = "span";
+    }
+
+    class MockInline extends MockBlot {
+        static blotName = "inline";
+        static tagName = "span";
+    }
+
+    const MockQuill = vi.fn().mockImplementation(() => {
+        capturedListeners = [];
+
+        const quillInstance = {
+            root: {
+                innerHTML: "<p>existing content</p>",
+                focus: vi.fn(),
+                blur: vi.fn(),
+                click: vi.fn(),
+                addEventListener: vi.fn(
+                    (
+                        type: string,
+                        handler: EventListener,
+                        options?: boolean | AddEventListenerOptions
+                    ) => {
+                        capturedListeners.push({ type, handler, options });
+                    }
+                ),
+                removeEventListener: vi.fn(),
+                querySelectorAll: vi.fn().mockReturnValue([]),
+                querySelector: vi.fn().mockReturnValue(null),
+            },
+            getText: vi.fn().mockReturnValue("existing content"),
+            getLength: vi.fn().mockReturnValue(17),
+            getContents: vi
+                .fn()
+                .mockReturnValue({ ops: [{ insert: "existing content" }] }),
+            setContents: vi.fn(),
+            updateContents: vi.fn(),
+            insertText: vi.fn(),
+            deleteText: vi.fn(),
+            format: vi.fn(),
+            getFormat: vi.fn(),
+            removeFormat: vi.fn(),
+            setSelection: vi.fn(),
+            getSelection: vi
+                .fn()
+                .mockReturnValue({ index: 0, length: 0 }),
+            getLeaf: vi
+                .fn()
+                .mockReturnValue([
+                    { domNode: document.createElement("span") },
+                ]),
+            getIndex: vi.fn().mockReturnValue(0),
+            getSemanticHTML: vi.fn().mockReturnValue(""),
+            getModule: vi
+                .fn()
+                .mockReturnValue({ destroy: vi.fn(), dispose: vi.fn() }),
+            focus: vi.fn(),
+            on: vi.fn(),
+            off: vi.fn(),
+            update: vi.fn(),
+            clipboard: { dangerouslyPasteHTML: vi.fn() },
+            history: { clear: vi.fn() },
+            emitter: { emit: vi.fn() },
+        };
+
+        return quillInstance;
+    });
+
+    (MockQuill as any).import = vi.fn().mockImplementation((path: string) => {
+        if (path === "ui/icons") return {};
+        return MockInline;
+    });
+    (MockQuill as any).register = vi.fn();
+
+    return { default: MockQuill };
+});
+
+vi.mock("../contextProviders/UnsavedChangesContext", () => ({
+    default: React.createContext({
+        setUnsavedChanges: vi.fn(),
+        showFlashingBorder: false,
+        unsavedChanges: false,
+    }),
+}));
+
+vi.mock("@sharedUtils", () => ({
+    getVSCodeAPI: () => mockVscode,
+}));
+
+beforeAll(() => {
+    URL.createObjectURL = URL.createObjectURL || vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = URL.revokeObjectURL || vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+const getPasteListeners = () =>
+    capturedListeners.filter((l) => l.type === "paste");
+
+const isCapture = (entry: EventListenerEntry) => {
+    if (typeof entry.options === "boolean") return entry.options;
+    if (typeof entry.options === "object") return !!entry.options?.capture;
+    return false;
+};
+
+const makePasteEvent = (plainText: string, htmlText?: string) => {
+    const prevented = { value: false };
+    const stopped = { value: false };
+    return {
+        preventDefault: vi.fn(() => {
+            prevented.value = true;
+        }),
+        stopPropagation: vi.fn(() => {
+            stopped.value = true;
+        }),
+        clipboardData: {
+            getData: vi.fn((type: string) => {
+                if (type === "text/plain") return plainText;
+                if (type === "text/html")
+                    return htmlText ?? `<b>${plainText}</b>`;
+                return "";
+            }),
+        },
+        _prevented: prevented,
+        _stopped: stopped,
+    } as unknown as ClipboardEvent & {
+        _prevented: { value: boolean };
+        _stopped: { value: boolean };
+    };
+};
+
+describe("Editor paste-as-plain-text", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        capturedListeners = [];
+        cleanup();
+    });
+
+    it("registers a capture-phase paste listener and a bubble-phase paste listener", () => {
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={false}
+            />
+        );
+
+        const pasteListeners = getPasteListeners();
+        expect(pasteListeners.length).toBe(2);
+
+        const captureListeners = pasteListeners.filter(isCapture);
+        const bubbleListeners = pasteListeners.filter((l) => !isCapture(l));
+        expect(captureListeners.length).toBe(1);
+        expect(bubbleListeners.length).toBe(1);
+    });
+
+    it("does NOT preventDefault when pasteAsPlainText is false", () => {
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={false}
+            />
+        );
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event = makePasteEvent("plain text");
+
+        captureListener.handler(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
+
+    it("calls preventDefault + stopPropagation and inserts plain text when pasteAsPlainText is true", async () => {
+        const onChange = vi.fn();
+
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                onChange={onChange}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={true}
+            />
+        );
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event = makePasteEvent("pasted plain");
+
+        captureListener.handler(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+
+        const Quill = (await import("quill")).default;
+        const quillInstance = (Quill as any).mock.results[0].value;
+
+        expect(quillInstance.insertText).toHaveBeenCalledWith(
+            0,
+            "pasted plain",
+            "user"
+        );
+    });
+
+    it("replaces selected text when there is a selection during plain-text paste", async () => {
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello world</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={true}
+            />
+        );
+
+        const Quill = (await import("quill")).default;
+        const quillInstance = (Quill as any).mock.results[0].value;
+
+        quillInstance.getSelection.mockReturnValue({ index: 6, length: 5 });
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event = makePasteEvent("universe");
+
+        captureListener.handler(event);
+
+        expect(quillInstance.deleteText).toHaveBeenCalledWith(
+            6,
+            5,
+            "user"
+        );
+        expect(quillInstance.insertText).toHaveBeenCalledWith(
+            6,
+            "universe",
+            "user"
+        );
+        expect(quillInstance.setSelection).toHaveBeenCalledWith(
+            14,
+            0,
+            "silent"
+        );
+    });
+
+    it("does not insert text when clipboard is empty", async () => {
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={true}
+            />
+        );
+
+        const Quill = (await import("quill")).default;
+        const quillInstance = (Quill as any).mock.results[0].value;
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event = makePasteEvent("");
+
+        captureListener.handler(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(quillInstance.insertText).not.toHaveBeenCalled();
+    });
+
+    it("responds to pasteAsPlainText prop changing from false to true", async () => {
+        const { rerender } = render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={false}
+            />
+        );
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event1 = makePasteEvent("should pass through");
+        captureListener.handler(event1);
+        expect(event1.preventDefault).not.toHaveBeenCalled();
+
+        rerender(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={true}
+            />
+        );
+
+        await waitFor(() => {
+            const event2 = makePasteEvent("should be plain");
+            captureListener.handler(event2);
+            expect(event2.preventDefault).toHaveBeenCalled();
+            expect(event2.stopPropagation).toHaveBeenCalled();
+        });
+    });
+
+    it("triggers onChange after plain-text paste", async () => {
+        vi.useFakeTimers();
+        const onChange = vi.fn();
+
+        render(
+            <Editor
+                currentLineId="cell-1"
+                initialValue="<p>hello</p>"
+                editHistory={[]}
+                onChange={onChange}
+                textDirection="ltr"
+                setIsEditingFootnoteInline={vi.fn()}
+                isEditingFootnoteInline={false}
+                pasteAsPlainText={true}
+            />
+        );
+
+        const captureListener = getPasteListeners().find(isCapture)!;
+        const event = makePasteEvent("new text");
+
+        captureListener.handler(event);
+
+        vi.advanceTimersByTime(100);
+
+        expect(onChange).toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+});


### PR DESCRIPTION
### Summary
- Adds a Paste as plain text option for the Quill-based cell editor so pastes use clipboard plain text only (no rich HTML / styling). The choice is persisted per workspace (same pattern as the preferred editor tab), so it survives reopening the editor.

### What changed
- Webview ↔ extension: New messages getPasteAsPlainText, setPasteAsPlainText, and pasteAsPlainTextPreference (see types/index.d.ts).
- Persistence: Workspace state key codex-editor-paste-as-plain-text via workspaceStateUtils.ts, wired through codexCellEditorProvider.ts and codexCellEditorMessagehandling.ts.
- Editor: Capture-phase paste handler runs before Quill’s handler when plain-text mode is on (preventDefault + stopPropagation), then insertText with text/plain. A ref keeps the handler in sync when the toggle changes without remounting Quill.
- TextCellEditor: Checkbox + character count on one row (justify-between); character count is lifted from Editor via optional onCharacterCountChange.
- Tests: webviews/codex-webviews/src/CodexCellEditor/__tests___/Editor.pasteAsPlainText.test.tsx (Vitest).

### Testing
- [x] Open a .codex cell in TextCellEditor.
- [x] Character count: Confirm the row under the editor shows “N characters” on the right and updates as you type.
- [x] Rich paste (toggle off): Uncheck Paste as plain text.
- [x] Copy formatted text from a browser or Word (bold, links, etc.).
- [x] Paste into the cell and confirm formatting still appears (Quill default).
- [x] Plain paste (toggle on): Check Paste as plain text.
- [x] Paste the same rich source; content should match plain text only (no doubling, no extra markup).
- [x] Confirm the checkbox is still on and pastes remain plain after enabling the checkbox, close the cell editor / reload the webview or reopen the notebook, reopen a cell.
- [x] Selection replace: With plain mode on, select part of a verse, paste; only the selection should be replaced by plain text (no duplicate full line).