### PR TITLE
Automate PR pre-releases via /build slash command

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,197 @@
+name: PR Build
+
+on:
+    issue_comment:
+        types: [created]
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: "PR number to build"
+                required: true
+                type: string
+            version:
+                description: "Version override (leave blank to auto-generate as x.y.z-prNNN-shorthash)"
+                required: false
+                type: string
+
+permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+
+jobs:
+    build:
+        if: >-
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.issue.pull_request != null &&
+             contains(github.event.comment.body, '/build') &&
+             (github.event.comment.author_association == 'OWNER' ||
+              github.event.comment.author_association == 'MEMBER' ||
+              github.event.comment.author_association == 'COLLABORATOR'))
+        runs-on: ubuntu-latest
+        concurrency:
+            group: pr-build-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.issue.number }}
+            cancel-in-progress: true
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        steps:
+            - name: React to comment (acknowledge)
+              if: github.event_name == 'issue_comment'
+              run: |
+                  set -euo pipefail
+                  gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+                    --method POST -f content='+1'
+
+            - name: Get PR info
+              id: pr
+              run: |
+                  set -euo pipefail
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    PR_NUMBER="${{ inputs.pr_number }}"
+                  else
+                    PR_NUMBER="${{ github.event.issue.number }}"
+                  fi
+                  PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+                  echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+                  echo "ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+                  echo "sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+                  echo "head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
+
+            - name: Checkout PR branch
+              run: |
+                  set -euo pipefail
+                  git init .
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "github-actions[bot]"
+                  HEAD_REPO="${{ steps.pr.outputs.head_repo }}"
+                  HEAD_REF="${{ steps.pr.outputs.ref }}"
+                  HEAD_SHA="${{ steps.pr.outputs.sha }}"
+                  FETCH_URL="https://x-access-token:${GH_TOKEN}@github.com/${HEAD_REPO}.git"
+                  git remote add origin "$FETCH_URL"
+                  git fetch --depth=1 origin "$HEAD_REF"
+                  git checkout "$HEAD_SHA"
+
+            - name: Setup Node 20
+              run: |
+                  set -euo pipefail
+                  export NVM_DIR="$HOME/.nvm"
+                  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+                    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+                  fi
+                  . "$NVM_DIR/nvm.sh"
+                  nvm install 20
+                  nvm use 20
+                  echo "$(dirname "$(which node)")" >> "$GITHUB_PATH"
+
+            - name: Setup pnpm
+              run: npm install -g pnpm
+
+            - name: Generate version
+              id: version
+              run: |
+                  set -euo pipefail
+                  VERSION="${{ inputs.version || '' }}"
+                  if [[ -z "$VERSION" ]]; then
+                    BASE_VERSION=$(jq -r .version package.json)
+                    SHORT_HASH=$(git rev-parse --short HEAD)
+                    VERSION="${BASE_VERSION}-pr${{ steps.pr.outputs.number }}-${SHORT_HASH}"
+                  fi
+                  NAME=$(jq -r .name package.json)
+                  REPO_URL=$(gh repo view --json url -q .url)
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "vsix=${NAME}-${VERSION}.vsix" >> "$GITHUB_OUTPUT"
+                  echo "release_url=${REPO_URL}/releases/tag/${VERSION}" >> "$GITHUB_OUTPUT"
+
+            - name: Check if release already exists
+              run: |
+                  set -euo pipefail
+                  VERSION="${{ steps.version.outputs.version }}"
+                  RELEASE_URL="${{ steps.version.outputs.release_url }}"
+                  RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  if gh release view "$VERSION" &>/dev/null; then
+                    echo "RELEASE_EXISTS=true" >> "$GITHUB_ENV"
+                    gh pr comment "${{ steps.pr.outputs.number }}" \
+                      --body "Release for the latest commit already exists: ${RELEASE_URL} (this run: ${RUN_URL})"
+                    exit 1
+                  fi
+
+            - name: Bump version in package.json
+              run: |
+                  set -euo pipefail
+                  jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' package.json > package.json.tmp
+                  mv package.json.tmp package.json
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build webviews (if applicable)
+              run: |
+                  set -euo pipefail
+                  if jq -e '.scripts["build:webviews"]' package.json &>/dev/null; then
+                    (cd webviews/codex-webviews && pnpm install)
+                    pnpm run build:webviews
+                  fi
+
+            - name: Production build
+              run: pnpm run package
+
+            - name: Package VSIX
+              run: xvfb-run -a pnpm dlx @vscode/vsce package --no-dependencies
+
+            - name: Restore package.json
+              if: always()
+              run: git checkout -- package.json
+
+            - name: Generate release notes
+              run: |
+                  set -euo pipefail
+                  PR_NUMBER="${{ steps.pr.outputs.number }}"
+                  VERSION="${{ steps.version.outputs.version }}"
+                  REPO="${{ github.repository }}"
+                  REPO_URL="https://github.com/${REPO}"
+
+                  GENERATED_NOTES=$(gh api "repos/${REPO}/releases/generate-notes" \
+                    --method POST \
+                    --field tag_name="${VERSION}" \
+                    --field target_commitish="$(git rev-parse HEAD)" \
+                    -q .body)
+
+                  PR_TITLE=$(gh pr view "${PR_NUMBER}" --json title -q .title)
+                  printf 'For PR #%s: [%s](%s)\n\n%s\n' \
+                    "${PR_NUMBER}" "${PR_TITLE}" "${REPO_URL}/pull/${PR_NUMBER}" \
+                    "${GENERATED_NOTES}" > /tmp/release-notes.md
+
+            - name: Create GitHub prerelease
+              run: |
+                  gh release create "${{ steps.version.outputs.version }}" \
+                    --target "$(git rev-parse HEAD)" \
+                    --prerelease \
+                    --title "${{ steps.version.outputs.version }}" \
+                    --notes-file /tmp/release-notes.md \
+                    "./${{ steps.version.outputs.vsix }}"
+
+            - name: Comment on PR
+              run: |
+                  gh pr comment "${{ steps.pr.outputs.number }}" \
+                    --body "Pre-release: ${{ steps.version.outputs.version }} ${{ steps.version.outputs.release_url }}"
+
+            - name: React with rocket on success
+              if: success() && github.event_name == 'issue_comment'
+              run: |
+                  gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+                    --method POST -f content='rocket'
+
+            - name: Handle failure
+              if: failure()
+              run: |
+                  set -euo pipefail
+                  RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  PR_NUMBER="${{ steps.pr.outputs.number }}"
+                  if [[ -n "$PR_NUMBER" ]] && [[ "${RELEASE_EXISTS:-}" != "true" ]]; then
+                    gh pr comment "${PR_NUMBER}" --body "Build failed: ${RUN_URL}"
+                  fi
+                  if [ "${{ github.event_name }}" = "issue_comment" ]; then
+                    gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+                      --method POST -f content='-1'
+                  fi

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -1,0 +1,157 @@
+name: Tag Build
+
+on:
+    create:
+
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Tag to build (e.g. 1.2.3)"
+                required: false
+                type: string
+
+    workflow_run:
+        workflows: ["Auto Tag on Version Change"]
+        types: [completed]
+
+permissions:
+    contents: write
+
+jobs:
+    build:
+        if: ${{ (github.event_name == 'create' && github.ref_type == 'tag' && github.actor != 'github-actions[bot]') || (github.event_name == 'workflow_dispatch') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+        runs-on: ubuntu-latest
+        concurrency:
+            group: tag-build-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref || 'manual' }}
+            cancel-in-progress: false
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        steps:
+            - name: Prepare repository
+              id: prep
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  REPO="${GITHUB_REPOSITORY}"
+                  mkdir -p repo
+                  cd repo
+                  git init -q
+                  git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+                  git fetch -q --tags --prune origin
+                  git fetch -q origin "${GITHUB_SHA}" || true
+                  git checkout -q "${GITHUB_SHA}" || true
+
+            - name: Determine version
+              id: version
+              shell: bash
+              working-directory: repo
+              env:
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+              run: |
+                  set -euo pipefail
+                  if [ -n "${{ github.event.inputs.tag || '' }}" ]; then
+                    VERSION="${{ github.event.inputs.tag }}"
+                  elif [ "${GITHUB_EVENT_NAME}" = "create" ]; then
+                    VERSION="${GITHUB_REF#refs/tags/}"
+                  elif [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ -n "${HEAD_SHA:-}" ]; then
+                    CANDIDATE_TAG=$(git tag --points-at "${HEAD_SHA}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+                    VERSION="${CANDIDATE_TAG:-}"
+                  fi
+
+                  if [ -z "${VERSION:-}" ] || ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Could not determine a numeric SemVer tag for this run; skipping." >&2
+                    echo "skip=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ -n "${HEAD_SHA:-}" ]; then
+                    CURR_COMMIT="$HEAD_SHA"
+                  elif git rev-parse "$VERSION" >/dev/null 2>&1; then
+                    CURR_COMMIT=$(git rev-list -n 1 "$VERSION")
+                  else
+                    CURR_COMMIT="$GITHUB_SHA"
+                  fi
+
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "current_commit=$CURR_COMMIT" >> "$GITHUB_OUTPUT"
+
+            - name: Stop if non-numeric tag
+              if: steps.version.outputs.skip == 'true'
+              run: echo "Non-numeric tag detected; workflow skipped."
+
+            - name: Setup Node 20
+              if: steps.version.outputs.skip != 'true'
+              shell: bash
+              working-directory: repo
+              run: |
+                  set -euo pipefail
+                  export NVM_DIR="$HOME/.nvm"
+                  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+                    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+                  fi
+                  . "$NVM_DIR/nvm.sh"
+                  nvm install 20
+                  nvm use 20
+                  echo "$(dirname "$(which node)")" >> "$GITHUB_PATH"
+
+            - name: Setup pnpm
+              if: steps.version.outputs.skip != 'true'
+              run: npm install -g pnpm
+
+            - name: Set package.json version
+              if: steps.version.outputs.skip != 'true'
+              shell: bash
+              working-directory: repo
+              run: |
+                  set -euo pipefail
+                  jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' package.json > package.json.tmp
+                  mv package.json.tmp package.json
+
+            - name: Install dependencies
+              if: steps.version.outputs.skip != 'true'
+              working-directory: repo
+              run: pnpm install
+
+            - name: Build webviews (if applicable)
+              if: steps.version.outputs.skip != 'true'
+              shell: bash
+              working-directory: repo
+              run: |
+                  set -euo pipefail
+                  if jq -e '.scripts["build:webviews"]' package.json &>/dev/null; then
+                    (cd webviews/codex-webviews && pnpm install)
+                    pnpm run build:webviews
+                  fi
+
+            - name: Production build
+              if: steps.version.outputs.skip != 'true'
+              working-directory: repo
+              run: pnpm run package
+
+            - name: Package VSIX
+              if: steps.version.outputs.skip != 'true'
+              working-directory: repo
+              run: xvfb-run -a pnpm dlx @vscode/vsce package --no-dependencies
+
+            - name: Restore package.json
+              if: always()
+              shell: bash
+              working-directory: repo
+              run: git checkout -- package.json || true
+
+            - name: Create GitHub prerelease
+              if: steps.version.outputs.skip != 'true'
+              shell: bash
+              working-directory: repo
+              run: |
+                  set -euo pipefail
+                  VERSION="${{ steps.version.outputs.version }}"
+                  CURR_COMMIT="${{ steps.version.outputs.current_commit }}"
+                  NAME=$(jq -r .name package.json)
+                  gh release create "$VERSION" \
+                    --target "$CURR_COMMIT" \
+                    --prerelease \
+                    --title "$VERSION" \
+                    --generate-notes \
+                    "./${NAME}-${VERSION}.vsix"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,8 +22,6 @@ out/**/*.map
 # vscode.css was removed in favor of Tailwind CSS
 !src/assets/bible_data_with_vref_keys.json.gz
 !**/*.svg
-!node_modules/@vscode/codicons/dist/**
-!node_modules/vscode-uri
 !node_modules/dugite/build/**
 !node_modules/dugite/package.json
 

--- a/src/cellLabelImporter/cellLabelImporter.ts
+++ b/src/cellLabelImporter/cellLabelImporter.ts
@@ -105,6 +105,7 @@ async function getHtmlForCellLabelImporterView(
     const codiconsUri = webview.asWebviewUri(
         vscode.Uri.joinPath(
             context.extensionUri,
+            "out",
             "node_modules",
             "@vscode/codicons",
             "dist",

--- a/src/codexMigrationTool/codexMigrationTool.ts
+++ b/src/codexMigrationTool/codexMigrationTool.ts
@@ -33,6 +33,7 @@ async function getHtmlForCodexMigrationToolView(
     const codiconsUri = webview.asWebviewUri(
         vscode.Uri.joinPath(
             context.extensionUri,
+            "out",
             "node_modules",
             "@vscode/codicons",
             "dist",

--- a/src/copilotSettings/copilotSettings.ts
+++ b/src/copilotSettings/copilotSettings.ts
@@ -53,7 +53,7 @@ export async function openSystemMessageEditor() {
     const codiconsUri = panel.webview.asWebviewUri(
         vscode.Uri.joinPath(
             vscode.extensions.getExtension('project-accelerate.codex-editor-extension')!.extensionUri,
-            'node_modules', '@vscode', 'codicons', 'dist', 'codicon.css'
+            'out', 'node_modules', '@vscode', 'codicons', 'dist', 'codicon.css'
         )
     );
 

--- a/src/globalProvider.ts
+++ b/src/globalProvider.ts
@@ -102,6 +102,7 @@ export abstract class BaseWebviewProvider implements vscode.WebviewViewProvider 
         const codiconsUri = webviewView.webview.asWebviewUri(
             vscode.Uri.joinPath(
                 this._context.extensionUri,
+                "out",
                 "node_modules",
                 "@vscode/codicons",
                 "dist",

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -106,6 +106,7 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
     const codiconsUri = panel.webview.asWebviewUri(
         vscode.Uri.joinPath(
             context.extensionUri,
+            "out",
             "node_modules",
             "@vscode/codicons",
             "dist",

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -231,7 +231,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                 vscode.Uri.joinPath(this.context.extensionUri, "src", "assets"),
                 vscode.Uri.joinPath(this.context.extensionUri, "media"),
                 vscode.Uri.joinPath(this.context.extensionUri, "webviews", "codex-webviews", "dist"),
-                vscode.Uri.file(path.join(this.context.extensionUri.fsPath, 'node_modules', '@vscode/codicons', 'dist')),
+                vscode.Uri.joinPath(this.context.extensionUri, 'out', 'node_modules', '@vscode', 'codicons', 'dist'),
             ],
         });
 

--- a/src/providers/WelcomeView/welcomeViewProvider.ts
+++ b/src/providers/WelcomeView/welcomeViewProvider.ts
@@ -351,6 +351,7 @@ export class WelcomeViewProvider {
         const codiconsUri = webview.asWebviewUri(
             vscode.Uri.joinPath(
                 this._extensionUri,
+                "out",
                 "node_modules",
                 "@vscode/codicons",
                 "dist",

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -561,7 +561,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
             enableScripts: true,
             localResourceRoots: [
                 vscode.Uri.joinPath(this.context.extensionUri, "src", "assets"),
-                vscode.Uri.joinPath(this.context.extensionUri, "node_modules", "@vscode", "codicons", "dist"),
+                vscode.Uri.joinPath(this.context.extensionUri, "out", "node_modules", "@vscode", "codicons", "dist"),
                 vscode.Uri.joinPath(this.context.extensionUri, "webviews", "codex-webviews", "dist")
             ]
         };
@@ -1526,6 +1526,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         const codiconsUri = webview.asWebviewUri(
             vscode.Uri.joinPath(
                 this.context.extensionUri,
+                "out",
                 "node_modules",
                 "@vscode/codicons",
                 "dist",

--- a/src/utils/webviewTemplate.ts
+++ b/src/utils/webviewTemplate.ts
@@ -20,7 +20,7 @@ export function getWebviewHtml(
     );
     // Note: vscode.css was removed in favor of Tailwind CSS in individual webviews
     const codiconsUri = webview.asWebviewUri(
-        vscode.Uri.joinPath(context.extensionUri, "node_modules", "@vscode/codicons", "dist", "codicon.css")
+        vscode.Uri.joinPath(context.extensionUri, "out", "node_modules", "@vscode/codicons", "dist", "codicon.css")
     );
     const scriptUri = webview.asWebviewUri(
         vscode.Uri.joinPath(context.extensionUri, "webviews", "codex-webviews", "dist", ...options.scriptPath)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,6 +117,14 @@ const extensionConfig = {
                     from: "node_modules/fts5-sql-bundle/package.json",
                     to: "node_modules/fts5-sql-bundle/package.json",
                 },
+                {
+                    from: "node_modules/@vscode/codicons/dist/codicon.css",
+                    to: "node_modules/@vscode/codicons/dist/codicon.css",
+                },
+                {
+                    from: "node_modules/@vscode/codicons/dist/codicon.ttf",
+                    to: "node_modules/@vscode/codicons/dist/codicon.ttf",
+                },
             ],
         }),
     ],


### PR DESCRIPTION
Adds two GitHub Actions to automate VSIX builds, and fixes a packaging bug that caused icons to be missing in builds using `--no-dependencies`.

## Changes

**`.github/workflows/pr-build.yml`** — Slash-command build for PR previews
- Triggers when an org member (`OWNER`, `MEMBER`, `COLLABORATOR`) comments `/build` on a PR
- Reacts 👍 immediately; 🚀 on success, 👎 on failure
- Posts a PR comment with the prerelease URL on success, or a link to the failed run on failure
- Detects if a release for the current commit already exists and posts a specific message instead of failing generically
- Correctly checks out PRs opened from forks (fetches from fork's remote by SHA)
- Concurrency group per PR cancels any in-progress build when `/build` is fired again
- `workflow_dispatch` accepts `pr_number` (required) and optional `version` override for manual runs

**`.github/workflows/tag-build.yml`** — Automatic release build on version tag
- Fires alongside `release-notes.yml` when `auto-tag.yml` creates a version tag (via `workflow_run`); also handles manually pushed tags and `workflow_dispatch`
- Skips non-numeric tags (same guard as `release-notes.yml`)
- Builds VSIX and creates a GitHub prerelease with it attached
- Runs in parallel with `release-notes.yml` — no conflict (VSIX release vs. Discord notification)

**Codicons packaging fix** (affects both workflows and `create-pr-release`)
- `vsce package --no-dependencies` skips root `node_modules` entirely, so `@vscode/codicons` CSS and font files were missing from VSIX builds, causing icons to not appear
- Adds CopyWebpackPlugin entries to copy `codicon.css` and `codicon.ttf` into `out/node_modules/@vscode/codicons/dist/` at build time (same pattern already used for `fts5-sql-bundle`)
- Updates all 9 source files that reference the codicons path to point to `out/node_modules/` instead of root `node_modules/`
- Removes dead `node_modules/` allowlist entries from `.vscodeignore` (irrelevant when using `--no-dependencies`)

## Testing

- Manually triggered a failed build and a successful build via `/build` comment
- Resulting VSIX installs and runs correctly as a pinned ext in Codex Beta