### PR TITLE
848 project spanishreference  verses in genesis have disappeared missing

### DIFF
--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -14,6 +14,7 @@ import { getCorrespondingSourceUri, getCorrespondingCodexUri } from "../../utils
 import {
     parseVerseRef,
     getSortKeyFromParsedRef,
+    stripCellIdSuffix,
     type ParsedVerseRef,
 } from "../../utils/verseRefUtils";
 import bibleData from "../../../webviews/codex-webviews/src/assets/bible-books-lookup.json";
@@ -3011,6 +3012,7 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
         const contentWithoutRef: any[] = [];
         const paratextByParentId = new Map<string, any[]>();
         const styleOrOther: any[] = [];
+        let hadSuffixedRefs = false;
 
         for (let i = 0; i < cells.length; i++) {
             const cell = cells[i];
@@ -3044,6 +3046,15 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
                 continue;
             }
 
+            const rawRef = md.data?.globalReferences?.[0];
+            if (typeof rawRef === "string") {
+                const cleanedRef = stripCellIdSuffix(rawRef);
+                if (cleanedRef !== rawRef) {
+                    md.data.globalReferences = [cleanedRef];
+                    cell.metadata = md;
+                    hadSuffixedRefs = true;
+                }
+            }
             const ref = md.data?.globalReferences?.[0];
             const parsed = typeof ref === "string" ? parseVerseRef(ref) : null;
             if (parsed) {
@@ -3052,6 +3063,57 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
             } else {
                 contentWithoutRef.push(cell);
             }
+        }
+
+        let hasChanges = hadSuffixedRefs;
+
+        // Merge phase: recombine split verse-range cells (child has parentId -> parent)
+        const idToContentIndex = new Map<string, number>();
+        for (let i = 0; i < contentWithRef.length; i++) {
+            const id = contentWithRef[i].cell.metadata?.id;
+            if (id) idToContentIndex.set(id, i);
+        }
+        const mergedChildIndices = new Set<number>();
+        for (let i = 0; i < contentWithRef.length; i++) {
+            const childMd = contentWithRef[i].cell.metadata || {};
+            const parentId = childMd.parentId;
+            if (!parentId) continue;
+            const parentIdx = idToContentIndex.get(parentId);
+            if (parentIdx === undefined) continue;
+
+            const parent = contentWithRef[parentIdx];
+            const child = contentWithRef[i];
+            const pRef = parent.parsed;
+            const cRef = child.parsed;
+            const sameRange =
+                pRef.kind === cRef.kind &&
+                pRef.book === cRef.book &&
+                pRef.chapter === cRef.chapter &&
+                (pRef.kind === "range" && cRef.kind === "range"
+                    ? pRef.verseStart === cRef.verseStart && pRef.verseEnd === cRef.verseEnd
+                    : pRef.kind === "single" && cRef.kind === "single"
+                        ? pRef.verse === cRef.verse
+                        : false);
+            if (!sameRange) continue;
+
+            parent.cell.value = (parent.cell.value || "") + (child.cell.value || "");
+            const parentEdits: any[] = parent.cell.metadata?.edits || [];
+            parentEdits.push({
+                editMap: ["value"],
+                value: parent.cell.value,
+                timestamp: Date.now(),
+                type: EditType.MIGRATION,
+                author: "system",
+                validatedBy: [],
+            });
+            parent.cell.metadata.edits = parentEdits;
+            mergedChildIndices.add(i);
+            hasChanges = true;
+        }
+        if (mergedChildIndices.size > 0) {
+            const filtered = contentWithRef.filter((_, idx) => !mergedChildIndices.has(idx));
+            contentWithRef.length = 0;
+            contentWithRef.push(...filtered);
         }
 
         // Partition content-with-ref by (book, chapter), sort each by verse
@@ -3066,7 +3128,6 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
         }
 
         const newCells: any[] = [];
-        let hasChanges = false;
 
         const emitContentCell = (item: (typeof contentWithRef)[0]) => {
             const { cell, parsed } = item;

--- a/src/test/suite/verseRefUtils.test.ts
+++ b/src/test/suite/verseRefUtils.test.ts
@@ -5,6 +5,7 @@ import {
     verseRefRegex,
     parseVerseRef,
     getSortKeyFromParsedRef,
+    stripCellIdSuffix,
 } from "../../utils/verseRefUtils";
 
 suite("verseRefUtils Test Suite", () => {
@@ -185,9 +186,75 @@ suite("verseRefUtils Test Suite", () => {
             assert.strictEqual(r.cellLabel, "7-8");
         });
 
+        test("parses verse range with legacy cell-ID suffix", () => {
+            const r = parseVerseRef("GEN 1:11-12:1764564500321-k9yvyjy9o");
+            assert.ok(r && r.kind === "range");
+            assert.strictEqual(r.book, "GEN");
+            assert.strictEqual(r.chapter, 1);
+            assert.strictEqual(r.verseStart, 11);
+            assert.strictEqual(r.verseEnd, 12);
+            assert.strictEqual(r.cellLabel, "11-12");
+        });
+
+        test("parses single verse with legacy cell-ID suffix", () => {
+            const r = parseVerseRef("GEN 5:3:1764697827224-vcolbmsb4");
+            assert.ok(r && r.kind === "single");
+            assert.strictEqual(r.book, "GEN");
+            assert.strictEqual(r.chapter, 5);
+            assert.strictEqual(r.verse, 3);
+        });
+
         test("returns null for invalid or empty", () => {
             assert.strictEqual(parseVerseRef(""), null);
             assert.strictEqual(parseVerseRef("not a ref"), null);
+        });
+    });
+
+    suite("stripCellIdSuffix", () => {
+        test("strips timestamp-random suffix from verse range ref", () => {
+            assert.strictEqual(
+                stripCellIdSuffix("GEN 1:11-12:1764564500321-k9yvyjy9o"),
+                "GEN 1:11-12"
+            );
+        });
+
+        test("strips timestamp-random suffix from single verse ref", () => {
+            assert.strictEqual(
+                stripCellIdSuffix("GEN 5:3:1764697827224-vcolbmsb4"),
+                "GEN 5:3"
+            );
+        });
+
+        test("returns clean refs unchanged", () => {
+            assert.strictEqual(stripCellIdSuffix("GEN 1:11-12"), "GEN 1:11-12");
+            assert.strictEqual(stripCellIdSuffix("MAT 1:1"), "MAT 1:1");
+        });
+
+        test("returns non-ref strings unchanged", () => {
+            assert.strictEqual(stripCellIdSuffix("not-a-ref"), "not-a-ref");
+            assert.strictEqual(stripCellIdSuffix(""), "");
+        });
+    });
+
+    suite("getVerseRefFromCellMetadata with legacy suffix", () => {
+        test("strips suffix from globalReferences and returns clean ref", () => {
+            assert.strictEqual(
+                getVerseRefFromCellMetadata({
+                    id: "369007f2-5c08-69ff-c037-dea3e5b5729f",
+                    data: { globalReferences: ["GEN 1:11-12:1764564500321-k9yvyjy9o"] },
+                }),
+                "GEN 1:11-12"
+            );
+        });
+
+        test("strips suffix from single verse globalReferences", () => {
+            assert.strictEqual(
+                getVerseRefFromCellMetadata({
+                    id: "some-uuid",
+                    data: { globalReferences: ["GEN 5:3:1764697827224-vcolbmsb4"] },
+                }),
+                "GEN 5:3"
+            );
         });
     });
 

--- a/src/utils/verseRefUtils/index.ts
+++ b/src/utils/verseRefUtils/index.ts
@@ -107,12 +107,27 @@ const verseRangeRefRegex = /^\s*([^\s]+)\s+(\d+):(\d+)-(\d+)\s*$/;
 const singleVerseRefRegex = /^\s*([^\s]+)\s+(\d+):(\d+)\s*$/;
 
 /**
+ * Strip a legacy cell-ID suffix from a verse ref string.
+ * Legacy globalReferences may look like "GEN 1:11-12:1764564500321-k9yvyjy9o"
+ * where the ":TIMESTAMP-RANDOM" suffix is a leftover from the old cell ID format
+ * (before the UUID migration). The parent-child relationship is now stored in
+ * metadata.parentId, so this suffix is redundant and breaks ref parsing.
+ */
+const cellIdSuffixRegex = /^(\S+\s+\d+:\d+(?:-\d+)?):\d+-\w+$/;
+export function stripCellIdSuffix(ref: string): string {
+    const match = ref.match(cellIdSuffixRegex);
+    return match ? match[1]! : ref;
+}
+
+/**
  * Parse a ref string into a single-verse or verse-range result.
  * Examples: "JHN 4:4" -> single; "JHN 4:1-3" -> range with cellLabel "1-3".
+ * Also handles legacy suffixed refs like "GEN 1:11-12:1764564500321-k9yvyjy9o".
  */
 export function parseVerseRef(ref: string): ParsedVerseRef | null {
     if (typeof ref !== "string" || !ref.trim()) return null;
-    const rangeMatch = ref.match(verseRangeRefRegex);
+    const cleaned = stripCellIdSuffix(ref);
+    const rangeMatch = cleaned.match(verseRangeRefRegex);
     if (rangeMatch) {
         const [, book, chapter, verseStart, verseEnd] = rangeMatch;
         return {
@@ -124,7 +139,7 @@ export function parseVerseRef(ref: string): ParsedVerseRef | null {
             cellLabel: `${verseStart}-${verseEnd}`,
         };
     }
-    const singleMatch = ref.match(singleVerseRefRegex);
+    const singleMatch = cleaned.match(singleVerseRefRegex);
     if (singleMatch) {
         const [, book, chapter, verse] = singleMatch;
         return {
@@ -169,7 +184,10 @@ export function getVerseRefFromCellMetadata(metadata: {
     const id = metadata.id;
     if (typeof id === "string" && verseRefOrRangeAtEndRegex.test(id)) return id;
     const ref = metadata.data?.globalReferences?.[0];
-    if (typeof ref === "string" && verseRefOrRangeAtEndRegex.test(ref)) return ref;
+    if (typeof ref === "string") {
+        const cleaned = stripCellIdSuffix(ref);
+        if (verseRefOrRangeAtEndRegex.test(cleaned)) return cleaned;
+    }
     const { bookCode, chapter, verse } = metadata;
     if (bookCode != null && chapter != null && verse != null)
         return `${String(bookCode).trim()} ${chapter}:${verse}`;


### PR DESCRIPTION
Closes #848
Closes #850 

PROJECT TEST FOR CODEX BETA: 848-project-spanishreference---verses-in-genesis-have-disappeared-missing

## Summary

The root cause: some `.codex` / source notebooks contain `globalReferences` with a legacy cell-ID suffix carried over from the old cell ID format (before the UUID migration). For example:

```
GEN 1:11-12:1764564500321-k9yvyjy9o
```

The trailing `:TIMESTAMP-RANDOM` part used to encode the parent/child cell relationship. That relationship is now stored in `metadata.parentId`, so the suffix is redundant — but it also broke `parseVerseRef` / `getVerseRefFromCellMetadata`, which caused verse-range cells to be dropped during reordering/labelling and to appear "missing" in the editor.

### Changes

1. `src/utils/verseRefUtils/index.ts`
   - New `stripCellIdSuffix(ref)` helper that strips the legacy `:TIMESTAMP-RANDOM` suffix from a ref string.
   - `parseVerseRef` now normalizes via `stripCellIdSuffix` before matching, so suffixed refs parse correctly as single verses or ranges.
   - `getVerseRefFromCellMetadata` strips the suffix when reading `globalReferences`, so callers always see a clean ref (e.g. `GEN 1:11-12`).

2. `src/projectManager/utils/migrationUtils.ts` — `migrateVerseRangeLabelsAndPositionsForFile`
   - Rewrites any suffixed `globalReferences` on disk to their clean form (persists the normalization).
   - Adds a merge phase that recombines split verse-range cells back into their parent when a child cell has a matching `parentId` and the same parsed verse range. The child's value is concatenated into the parent and a `MIGRATION` edit is recorded; the child is dropped.
   - `hasChanges` now also fires when suffixes are stripped or split cells are merged, so the notebook is written back.

3. `src/test/suite/verseRefUtils.test.ts`
   - Unit tests for `stripCellIdSuffix`, `parseVerseRef` with suffixed refs, and `getVerseRefFromCellMetadata` normalization (including verse ranges and single verses).

### Risk / scope

- Pure normalization — clean refs are unchanged (`"GEN 1:11-12"` and `"MAT 1:1"` pass through untouched), and non-ref strings are returned as-is.
- The merge phase is gated on a matching `parentId` **and** identical parsed ref (`book`, `chapter`, `verseStart/End` or `verse`), so it should only combine cells that were split copies of the same verse/range.

## Testing Method

Manual: affected project (Spanish reference / Genesis)

- [ ] Open the project that originally reported missing Genesis verses from issue #848 (or a copy of its `.codex` file). Make note of the missing Genesis verses and the extra verses at the end of Genesis 50. 
- [ ] Run the "Codex Maintenance: Codex: Fix Verse Range Labels and Positions" command (use Shift+CMD+P and copy the command name and then select it
- [ ] Confirm all previously missing verses in Genesis are now visible in the editor.
- [ ] Confirm that split verse-range cells (e.g. `GEN 1:11-12` with a child carrying `parentId` pointing at the parent) are merged into a single cell after the migration runs, with the child's content appended to the parent.
- [ ] Inspect the parent cell's `metadata.edits` and confirm a new entry of type `MIGRATION` was appended with the concatenated value.
- [ ] Check that `metadata.data.globalReferences[0]` on affected cells no longer contains the `:TIMESTAMP-RANDOM` suffix (e.g. `"GEN 1:11-12"` instead of `"GEN 1:11-12:1764564500321-k9yvyjy9o"`).

Manual: regression checks

- [ ] Open a project whose notebooks already have clean refs and verify the migration is a no-op (file timestamps / git diff unchanged; no spurious edits added).
- [ ] Verify ordering: after migration, verse-range cells still appear under the correct chapter milestone and in verse order.
- [ ] Verify paratext, style, and other non-content cells are not moved or merged.
- [ ] Re-run the migration on the same project and confirm it reports no further changes (idempotent).

Editor behavior

- [x] In the CodexCellEditor, `cellLabel` for verse-range cells displays as `"11-12"` (not the raw suffixed ref).
- [ ] Exporting the notebook (VTT/subtitle or plain-text export) still shows the correct values for the cells.