### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Codex Translation Editor Extension is a powerful Visual Studio Code extensio
 
 > Note: this extension is in active development and may have bugs or incomplete features. Please report any issues or suggestions on the [GitHub repository](https://github.com/genesis-ai-dev/codex-editor).
 
-Read more about Codex Translation Editor Extension in the [documentation](https://codex-editor.gitbook.io/).
+Read more about Codex Translation Editor Extension in the [documentation](https://docs.codexeditor.app/docs).
 
 ## Features
 


### PR DESCRIPTION
Updated documentation link to point to the new site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (a URL update) with no impact on runtime behavior or shipped code.
> 
> **Overview**
> Updates the README’s documentation hyperlink to point from the old GitBook site to the new `https://docs.codexeditor.app/docs` domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b318c46488acc63b6a5541dde1ac679997db8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->