### PR TITLE
Binaries in versioned folders and fixing download options, retries and more

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,9 +64,8 @@ import { initializeAudioMerger } from "./utils/audioMerger";
 import { initializeAudioExtractor } from "./utils/audioExtractor";
 import { initializeAudioExporter } from "./exportHandler/audioExporter";
 import { checkTools, getUnavailableTools } from "./utils/toolsManager";
-import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode } from "./utils/toolPreferences";
+import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode, getAudioToolMode } from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
-import { resetRetryCount } from "./utils/binaryIntegrityUtils";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
 import { cleanupOrphanedProjectFiles } from "./utils/fileUtils";
 // markUserAsUpdatedInRemoteList is now called in performProjectUpdate before window reload
@@ -584,14 +583,32 @@ export async function activate(context: vscode.ExtensionContext) {
             unavailableTools = getUnavailableTools(toolCheckResult);
         } catch (error) {
             console.error("[Extension] checkTools() threw unexpectedly:", error);
-            toolCheckResult = { git: false, nativeGitAvailable: false, sqlite: false, nativeSqliteAvailable: false, ffmpeg: false };
+            toolCheckResult = {
+                git: false,
+                nativeGitAvailable: false,
+                sqlite: false,
+                nativeSqliteAvailable: false,
+                ffmpeg: false,
+                platformUnsupported: { git: false, sqlite: false, ffmpeg: false },
+            };
             unavailableTools = getUnavailableTools(toolCheckResult);
         }
         stepStart = trackTiming("Checking tool availability", toolCheckStart);
 
-        const ok = (v: boolean) => v ? "ok" : "MISSING";
+        const toolState = (nativeAvailable: boolean, mode: string): string => {
+            const forced = mode === "force-builtin";
+            const builtin = mode === "builtin";
+            if (nativeAvailable && !builtin && !forced) return "native";
+            if (nativeAvailable && forced)             return "available but forced to fallback";
+            if (nativeAvailable && builtin)            return "available but using fallback";
+            if (!nativeAvailable && forced)            return "missing and forced to fallback";
+            /* !nativeAvailable && (auto | builtin) */ return "missing and using fallback";
+        };
         console.info(
-            `[Extension] Tools status — git: ${ok(toolCheckResult.git)}, sqlite: ${ok(toolCheckResult.sqlite)}, ffmpeg: ${ok(toolCheckResult.ffmpeg)}`
+            `[Extension] Tools status — ` +
+            `git: ${toolState(toolCheckResult.nativeGitAvailable, getGitToolMode())}, ` +
+            `sqlite: ${toolState(toolCheckResult.nativeSqliteAvailable, getSqliteToolMode())}, ` +
+            `ffmpeg: ${toolState(toolCheckResult.ffmpeg, getAudioToolMode())}`
         );
 
         // We used to display a blocking "Missing Tools" webview at this point

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -594,89 +594,36 @@ export async function activate(context: vscode.ExtensionContext) {
             `[Extension] Tools status — git: ${ok(toolCheckResult.git)}, sqlite: ${ok(toolCheckResult.sqlite)}, ffmpeg: ${ok(toolCheckResult.ffmpeg)}`
         );
 
-        // When offline, non-critical tools (git, audio) being unavailable is
-        // expected and not actionable -- skip the blocking warning panel.
-        const hasCriticalMissing = !toolCheckResult.sqlite;
-        const showWarningPanel =
-            unavailableTools.length > 0 && (networkAvailable || hasCriticalMissing);
-
-        if (unavailableTools.length > 0 && !showWarningPanel) {
-            console.log(
-                "[Extension] Offline -- non-critical tools unavailable (%s), continuing without warning panel",
+        // We used to display a blocking "Missing Tools" webview at this point
+        // whenever any tool failed to download. That startup interruption is
+        // now suppressed for all tools: the extension continues with its
+        // fallback implementations (isomorphic-git for sync, fts5 WASM for
+        // sqlite, wavUtils for audio) and the user can inspect or retry via
+        // the "Tools Status" command in the command palette at any time.
+        if (unavailableTools.length > 0) {
+            console.warn(
+                "[Extension] Unavailable tools after download attempts (continuing with fallbacks):",
                 unavailableTools.join(", ")
             );
         }
 
-        if (showWarningPanel) {
-            console.warn(
-                "[Extension] Unavailable tools after download attempts:",
-                unavailableTools.join(", ")
+        // Critical guard: if sqlite is genuinely broken (neither the native
+        // binary nor the fts5 WASM fallback is ready), the extension cannot
+        // function. Surface a lightweight notification and abort activation
+        // rather than silently producing a broken editor.
+        if (!toolCheckResult.sqlite) {
+            console.error(
+                "[Extension] SQLite is unavailable (both native and fts5 fallback failed) — aborting activation"
             );
-
-            const warningProvider = new MissingToolsWarningProvider(context);
-            context.subscriptions.push(warningProvider);
-
-            // Start showing the warning panel (creates the tab synchronously),
-            // then close the splash. This ensures a visible tab exists at all
-            // times, preventing the WelcomeView from flashing during the gap.
-            const userActionPromise = warningProvider.show(
-                toolCheckResult,
-                async () => {
-                    const retryOnline = await isOnline();
-                    if (!retryOnline) {
-                        console.warn("[Extension] Offline — cannot retry tool downloads");
-                        return checkTools(context, authApi).catch(() => toolCheckResult);
-                    }
-
-                    const current = await checkTools(context, authApi).catch(() => toolCheckResult);
-
-                    if (!current.git) {
-                        try {
-                            await resetRetryCount(context, "git");
-                            await authApi?.retryGitBinaryDownload?.();
-                        } catch (e) {
-                            console.error("[Extension] Git binary retry failed:", e);
-                        }
-                    }
-                    if (!current.sqlite) {
-                        try {
-                            await resetRetryCount(context, "sqlite");
-                            const binaryPath = await ensureSqliteNativeBinary(context);
-                            if (binaryPath) {
-                                initNativeSqlite(binaryPath);
-                            } else {
-                                await initFts5Sqlite(context);
-                            }
-                        } catch {
-                            try {
-                                await initFts5Sqlite(context);
-                            } catch (e) {
-                                console.error("[Extension] SQLite retry failed (both native and fts5):", e);
-                            }
-                        }
-                    }
-                    if (!current.ffmpeg) {
-                        try {
-                            await resetRetryCount(context, "ffmpeg");
-                            await downloadFFmpeg(context);
-                        } catch (e) {
-                            console.error("[Extension] FFmpeg retry failed:", e);
-                        }
-                    }
-                    return checkTools(context, authApi).catch(() => current);
+            vscode.window.showErrorMessage(
+                "Codex could not initialize its search backend. Open the Command Palette and run \"Status\" to view tool status and retry the download.",
+                "View Tools Status"
+            ).then((choice) => {
+                if (choice === "View Tools Status") {
+                    vscode.commands.executeCommand("codex-editor.openToolsStatus");
                 }
-            );
-
-            // Now that the warning tab exists, close the splash screen.
-            closeSplashScreen();
-
-            const userAction = await userActionPromise;
-
-            if (userAction === "blocked" && !toolCheckResult.sqlite) {
-                // SQLite is missing and the user closed the panel without
-                // continuing. The extension cannot function without SQLite.
-                return;
-            }
+            });
+            return;
         }
 
         // Check for pending update (swap) downloads (after workspace is ready)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ import { initializeAudioExporter } from "./exportHandler/audioExporter";
 import { checkTools, getUnavailableTools } from "./utils/toolsManager";
 import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode } from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
+import { resetRetryCount } from "./utils/binaryIntegrityUtils";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
 import { cleanupOrphanedProjectFiles } from "./utils/fileUtils";
 // markUserAsUpdatedInRemoteList is now called in performProjectUpdate before window reload
@@ -588,6 +589,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
                     if (!current.git) {
                         try {
+                            await resetRetryCount(context, "git");
                             await authApi?.retryGitBinaryDownload?.();
                         } catch (e) {
                             console.error("[Extension] Git binary retry failed:", e);
@@ -595,6 +597,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     }
                     if (!current.sqlite) {
                         try {
+                            await resetRetryCount(context, "sqlite");
                             const binaryPath = await ensureSqliteNativeBinary(context);
                             if (binaryPath) {
                                 initNativeSqlite(binaryPath);
@@ -610,7 +613,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         }
                     }
                     if (!current.ffmpeg) {
-                        try { await downloadFFmpeg(context); } catch (e) {
+                        try {
+                            await resetRetryCount(context, "ffmpeg");
+                            await downloadFFmpeg(context);
+                        } catch (e) {
                             console.error("[Extension] FFmpeg retry failed:", e);
                         }
                     }

--- a/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
+++ b/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
@@ -380,6 +380,7 @@ export class MissingToolsWarningProvider {
         try {
             switch (tool) {
                 case "sqlite": {
+                    await resetRetryCount(this._context, "sqlite");
                     const { ensureSqliteNativeBinary } = await import("../../utils/sqliteNativeBinaryManager");
                     const { initNativeSqlite } = await import("../../utils/nativeSqlite");
                     const binaryPath = await ensureSqliteNativeBinary(this._context);
@@ -399,6 +400,7 @@ export class MissingToolsWarningProvider {
                     break;
                 }
                 case "git": {
+                    await resetRetryCount(this._context, "git");
                     const { getAuthApi } = await import("../../extension");
                     const { resetGitBinaryPath } = await import("../../utils/dugiteGit");
                     const { setNativeGitAvailable } = await import("../../utils/toolPreferences");
@@ -413,6 +415,7 @@ export class MissingToolsWarningProvider {
                     break;
                 }
                 case "ffmpeg": {
+                    await resetRetryCount(this._context, "ffmpeg");
                     const { downloadFFmpeg } = await import("../../utils/ffmpegManager");
                     const result = await downloadFFmpeg(this._context);
                     success = result !== null;

--- a/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
+++ b/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
@@ -5,7 +5,6 @@ import { getWebviewHtml } from "../../utils/webviewTemplate";
 import { safePostMessageToPanel } from "../../utils/webviewUtils";
 import type { ToolCheckResult } from "../../utils/toolsManager";
 import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "../../utils/toolPreferences";
-import { resetRetryCount } from "../../utils/binaryIntegrityUtils";
 import type {
     MessagesToMissingToolsWarning,
     MessagesFromMissingToolsWarning,
@@ -380,7 +379,6 @@ export class MissingToolsWarningProvider {
         try {
             switch (tool) {
                 case "sqlite": {
-                    await resetRetryCount(this._context, "sqlite");
                     const { ensureSqliteNativeBinary } = await import("../../utils/sqliteNativeBinaryManager");
                     const { initNativeSqlite } = await import("../../utils/nativeSqlite");
                     const { isUsingNativeBackend } = await import("../../utils/sqliteDatabaseFactory");
@@ -446,7 +444,6 @@ export class MissingToolsWarningProvider {
                     break;
                 }
                 case "git": {
-                    await resetRetryCount(this._context, "git");
                     const { getAuthApi } = await import("../../extension");
                     const { resetGitBinaryPath } = await import("../../utils/dugiteGit");
                     const { setNativeGitAvailable } = await import("../../utils/toolPreferences");
@@ -468,7 +465,6 @@ export class MissingToolsWarningProvider {
                     break;
                 }
                 case "ffmpeg": {
-                    await resetRetryCount(this._context, "ffmpeg");
                     const { downloadFFmpeg } = await import("../../utils/ffmpegManager");
                     // Show the standalone progress notification so the user
                     // gets consistent feedback across all three tools.
@@ -507,6 +503,7 @@ export class MissingToolsWarningProvider {
             audioToolMode: getAudioToolMode(),
             gitToolMode: getGitToolMode(),
             sqliteToolMode: getSqliteToolMode(),
+            platformUnsupported: updated.platformUnsupported,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
     }
@@ -522,7 +519,6 @@ export class MissingToolsWarningProvider {
                     await fs.promises.rm(dir, { recursive: true, force: true });
                     const { resetSqliteBinaryCache } = await import("../../utils/sqliteNativeBinaryManager");
                     resetSqliteBinaryCache();
-                    await resetRetryCount(this._context, "sqlite");
                     break;
                 }
                 case "ffmpeg": {
@@ -530,7 +526,6 @@ export class MissingToolsWarningProvider {
                     await fs.promises.rm(dir, { recursive: true, force: true });
                     const { resetBinaryCache } = await import("../../utils/ffmpegManager");
                     resetBinaryCache();
-                    await resetRetryCount(this._context, "ffmpeg");
                     break;
                 }
                 case "git": {
@@ -542,7 +537,6 @@ export class MissingToolsWarningProvider {
                         const gitDir = path.join(storageBase, "..", "frontier-rnd.frontier-authentication", "git");
                         await fs.promises.rm(gitDir, { recursive: true, force: true });
                     }
-                    await resetRetryCount(this._context, "git");
                     break;
                 }
             }
@@ -656,6 +650,7 @@ export class MissingToolsWarningProvider {
             sqlite: result.sqlite,
             nativeSqliteAvailable: result.nativeSqliteAvailable,
             ffmpeg: result.ffmpeg,
+            platformUnsupported: result.platformUnsupported,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
     }
@@ -672,6 +667,7 @@ export class MissingToolsWarningProvider {
             audioToolMode: getAudioToolMode(),
             gitToolMode: getGitToolMode(),
             sqliteToolMode: getSqliteToolMode(),
+            platformUnsupported: result.platformUnsupported,
             ...flags,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
@@ -696,6 +692,7 @@ export class MissingToolsWarningProvider {
             sqlite: result.sqlite,
             nativeSqliteAvailable: result.nativeSqliteAvailable,
             ffmpeg: result.ffmpeg,
+            platformUnsupported: result.platformUnsupported,
             mode,
         };
 

--- a/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
+++ b/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
@@ -75,7 +75,7 @@ export class MissingToolsWarningProvider {
             return;
         }
 
-        await this._createPanel("Codex — Status", result, "status");
+        await this._createPanel("Codex — Tools Status", result, "status");
         this._setupStatusMessageHandler();
         this._subscribeSyncStatus();
     }
@@ -383,16 +383,62 @@ export class MissingToolsWarningProvider {
                     await resetRetryCount(this._context, "sqlite");
                     const { ensureSqliteNativeBinary } = await import("../../utils/sqliteNativeBinaryManager");
                     const { initNativeSqlite } = await import("../../utils/nativeSqlite");
+                    const { isUsingNativeBackend } = await import("../../utils/sqliteDatabaseFactory");
+
+                    // Snapshot which backend is active BEFORE any state
+                    // changes so we can tell whether a real switch happens.
+                    // Without this, a user who is already on native and
+                    // clicks "Download and Install" again would pay the cost
+                    // of a full database close/reopen for no benefit.
+                    const wasUsingNative = isUsingNativeBackend();
+
+                    // Let `ensureSqliteNativeBinary` show its own progress
+                    // notification ("Downloading AI Learning and Search
+                    // Tools…"). The card button also animates a spinner — the
+                    // two give the user consistent feedback matching how git
+                    // and ffmpeg behave.
                     const binaryPath = await ensureSqliteNativeBinary(this._context);
                     if (binaryPath) {
+                        // Idempotent — becomes a no-op if the binding was
+                        // already loaded in this process.
                         initNativeSqlite(binaryPath);
 
-                        const { getSQLiteIndexManager } = await import(
-                            "../../activationHelpers/contextAware/contentIndexes/indexes/sqliteIndexManager"
-                        );
-                        const manager = getSQLiteIndexManager();
-                        if (manager && !manager.isClosed) {
-                            await manager.reopenWithCurrentBackend();
+                        // If the user had opted into the fallback ("builtin"),
+                        // flip back to "auto" so the newly-installed native
+                        // backend is actually used. Force-builtin (admin lock)
+                        // is preserved.
+                        if (getSqliteToolMode() === "builtin") {
+                            const { setSqliteToolMode } = await import("../../utils/toolPreferences");
+                            await setSqliteToolMode("auto");
+                        }
+
+                        // Compute the target backend after all mutations. If
+                        // it matches the previous active backend, there is
+                        // literally nothing to switch — skip the reopen AND
+                        // the progress notification.
+                        const willUseNative = isUsingNativeBackend();
+
+                        if (wasUsingNative !== willUseNative) {
+                            await vscode.window.withProgress(
+                                {
+                                    location: vscode.ProgressLocation.Notification,
+                                    title: "Switching to Native AI Learning and Search Tools\u2026",
+                                    cancellable: false,
+                                },
+                                async () => {
+                                    const { getSQLiteIndexManager } = await import(
+                                        "../../activationHelpers/contextAware/contentIndexes/indexes/sqliteIndexManager"
+                                    );
+                                    const manager = getSQLiteIndexManager();
+                                    if (manager && !manager.isClosed) {
+                                        await manager.reopenWithCurrentBackend();
+                                    }
+                                },
+                            );
+                        } else {
+                            console.log(
+                                "[MissingToolsWarning] Native SQLite binary ready but active backend is unchanged — skipping reopen",
+                            );
                         }
 
                         success = true;
@@ -410,6 +456,13 @@ export class MissingToolsWarningProvider {
                         success = await frontierApi.retryGitBinaryDownload();
                         if (success) {
                             setNativeGitAvailable(true);
+                            // Flip "builtin" preference back to "auto" so the
+                            // native git binary is actually used. Force-builtin
+                            // (admin lock) is preserved.
+                            if (getGitToolMode() === "builtin") {
+                                const { setGitToolMode } = await import("../../utils/toolPreferences");
+                                await setGitToolMode("auto");
+                            }
                         }
                     }
                     break;
@@ -417,8 +470,17 @@ export class MissingToolsWarningProvider {
                 case "ffmpeg": {
                     await resetRetryCount(this._context, "ffmpeg");
                     const { downloadFFmpeg } = await import("../../utils/ffmpegManager");
-                    const result = await downloadFFmpeg(this._context);
+                    // Show the standalone progress notification so the user
+                    // gets consistent feedback across all three tools.
+                    const result = await downloadFFmpeg(this._context, { showProgress: true });
                     success = result !== null;
+                    if (success && getAudioToolMode() === "builtin") {
+                        // Flip "builtin" preference back to "auto" so the
+                        // newly-installed ffmpeg binary is actually used.
+                        // Force-builtin (admin lock) is preserved.
+                        const { setAudioToolMode } = await import("../../utils/toolPreferences");
+                        await setAudioToolMode("auto");
+                    }
                     break;
                 }
             }
@@ -649,7 +711,7 @@ export class MissingToolsWarningProvider {
             webview,
             { extensionUri: this._extensionUri } as vscode.ExtensionContext,
             {
-                title: mode === "status" ? "Codex — Status" : "Codex — Missing Tools",
+                title: mode === "status" ? "Codex — Tools Status" : "Codex — Missing Tools",
                 scriptPath: ["MissingToolsWarning", "index.js"],
                 initialData,
                 inlineStyles: `

--- a/src/test/suite/nativeSqliteDatabase.test.ts
+++ b/src/test/suite/nativeSqliteDatabase.test.ts
@@ -77,19 +77,47 @@ function findNativeBinary(): string | null {
 
     for (const base of bases) {
         for (const variant of variants) {
-            const candidate = realPath.join(
+            const sqliteParent = realPath.join(
                 base,
                 variant,
                 "User",
                 "globalStorage",
                 EXTENSION_ID,
-                "sqlite3-native",
-                BINARY_NAME
+                "sqlite3-native"
             );
+
+            // Current layout: version-subfolder per release (e.g. sqlite3-native/5.1.7/node_sqlite3.node).
+            // Walk every version subdirectory and look for the binary inside.
             try {
-                if (realFs.existsSync(candidate) && realFs.statSync(candidate).size > 500_000) {
-                    console.log(`[NativeSQLite Test] Found binary: ${candidate}`);
-                    return candidate;
+                if (realFs.existsSync(sqliteParent)) {
+                    for (const entry of realFs.readdirSync(sqliteParent, { withFileTypes: true })) {
+                        if (!entry.isDirectory()) {
+                            continue;
+                        }
+                        const candidate = realPath.join(sqliteParent, entry.name, BINARY_NAME);
+                        try {
+                            if (realFs.existsSync(candidate) && realFs.statSync(candidate).size > 500_000) {
+                                console.log(`[NativeSQLite Test] Found binary: ${candidate}`);
+                                return candidate;
+                            }
+                        } catch {
+                            // Skip inaccessible paths
+                        }
+                    }
+                }
+            } catch {
+                // Skip inaccessible paths
+            }
+
+            // Legacy flat layout: sqlite3-native/node_sqlite3.node (pre-versioning).
+            // Kept as a fallback so tests still pass on machines where migration
+            // hasn't run yet (e.g. a freshly-cloned repo before the extension
+            // has been launched in agent mode).
+            const legacyCandidate = realPath.join(sqliteParent, BINARY_NAME);
+            try {
+                if (realFs.existsSync(legacyCandidate) && realFs.statSync(legacyCandidate).size > 500_000) {
+                    console.log(`[NativeSQLite Test] Found legacy binary: ${legacyCandidate}`);
+                    return legacyCandidate;
                 }
             } catch {
                 // Skip inaccessible paths

--- a/src/utils/binaryIntegrityUtils.ts
+++ b/src/utils/binaryIntegrityUtils.ts
@@ -5,17 +5,13 @@
  * Provides:
  *  - SHA-256 file hashing
  *  - Marker file read/write for storing known-good hashes
- *  - Bounded retry counter backed by VS Code globalState
  */
 
-import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 
 const HASH_MARKER_FILENAME = "sha256.txt";
-const MAX_BINARY_RETRIES = 3;
-const RETRY_KEY_PREFIX = "binaryRetryCount";
 
 // ---------------------------------------------------------------------------
 // SHA-256 hashing
@@ -87,34 +83,3 @@ export const verifyIntegrity = async (
     }
 };
 
-// ---------------------------------------------------------------------------
-// Bounded retry counter (globalState-backed)
-// ---------------------------------------------------------------------------
-
-export const getRetryCount = (
-    context: vscode.ExtensionContext,
-    tool: string,
-): number =>
-    context.globalState.get<number>(`${RETRY_KEY_PREFIX}.${tool}`) ?? 0;
-
-export const incrementRetryCount = async (
-    context: vscode.ExtensionContext,
-    tool: string,
-): Promise<number> => {
-    const count = getRetryCount(context, tool) + 1;
-    await context.globalState.update(`${RETRY_KEY_PREFIX}.${tool}`, count);
-    return count;
-};
-
-export const resetRetryCount = async (
-    context: vscode.ExtensionContext,
-    tool: string,
-): Promise<void> => {
-    await context.globalState.update(`${RETRY_KEY_PREFIX}.${tool}`, 0);
-};
-
-export const hasExceededRetries = (
-    context: vscode.ExtensionContext,
-    tool: string,
-    max: number = MAX_BINARY_RETRIES,
-): boolean => getRetryCount(context, tool) >= max;

--- a/src/utils/ffmpegManager.ts
+++ b/src/utils/ffmpegManager.ts
@@ -29,6 +29,31 @@ interface BinaryInfo {
 
 let ffmpegInfo: BinaryInfo | null = null;
 
+/** Subdirectory name inside extension global storage for the FFmpeg binary */
+const FFMPEG_STORAGE_DIR = "ffmpeg";
+
+/**
+ * ============================================================================
+ * VERSION CONSTANTS — read carefully before changing
+ * ============================================================================
+ * Each platform has its own FFmpeg version string. These are used in TWO
+ * places:
+ *   1. The download URL (npm tarball from @ffmpeg-installer/{platform})
+ *   2. The storage folder name (where we save it on disk):
+ *      `{globalStorage}/ffmpeg/{version}/ffmpeg` (or `ffmpeg.exe` on Windows)
+ *
+ * To upgrade FFmpeg for a platform:
+ *   1. Change the version string for that platform below.
+ *   2. Verify the tarball exists at:
+ *      https://registry.npmjs.org/@ffmpeg-installer/{platform}/-/{platform}-{NEW_VERSION}.tgz
+ *   3. On next extension startup, users on that platform will download the
+ *      new version into a new subfolder:
+ *      globalStorage/ffmpeg/{NEW_VERSION}/
+ *   4. The old version folder is LEFT IN PLACE as a harmless orphan; only the
+ *      version matching the current constant is ever read at runtime.
+ *      Users can manually clean up old folders via the "Delete Binary" button.
+ * ============================================================================
+ */
 const PLATFORM_MAP: Record<string, string> = {
     "win32-x64": "4.1.0",
     "darwin-arm64": "4.1.5",
@@ -42,10 +67,43 @@ const PLATFORM_FALLBACK: Record<string, string> = {
     "win32-arm64": "win32-x64",
 };
 
-function getBinaryPath(context: vscode.ExtensionContext): string {
-    const storagePath = context.globalStorageUri.fsPath;
-    const binaryName = process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
-    return path.join(storagePath, "ffmpeg", binaryName);
+/** OS-appropriate executable filename for FFmpeg. */
+function getFfmpegExecutableName(): string {
+    return process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
+}
+
+/**
+ * Get the parent directory that contains all version subfolders.
+ * Used by the migration routine and by tooling that needs to detect legacy
+ * (unversioned) installs.
+ */
+function getParentStorageDir(context: vscode.ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, FFMPEG_STORAGE_DIR);
+}
+
+/**
+ * Get the versioned directory holding the FFmpeg binary for the current
+ * platform's pinned version, or null when this platform has no version.
+ */
+function getVersionedStorageDir(context: vscode.ExtensionContext): string | null {
+    const version = getPlatformVersion();
+    if (!version) {
+        return null;
+    }
+    return path.join(getParentStorageDir(context), version);
+}
+
+/**
+ * Get the absolute path to the FFmpeg binary for the current platform.
+ * Returns null when the platform has no pinned version in PLATFORM_MAP.
+ * This is the single source of truth for the binary's location.
+ */
+export function getFfmpegBinaryPath(context: vscode.ExtensionContext): string | null {
+    const versionedDir = getVersionedStorageDir(context);
+    if (!versionedDir) {
+        return null;
+    }
+    return path.join(versionedDir, getFfmpegExecutableName());
 }
 
 function getEffectivePlatformKey(): string {
@@ -61,14 +119,31 @@ function getPlatformVersion(): string | null {
 }
 
 /**
+ * Options for `downloadFFmpeg`.
+ */
+export interface DownloadFFmpegOptions {
+    /**
+     * When true, wraps the download in a VS Code progress notification
+     * ("Downloading Audio Tools…"). The Tools Status panel passes this so
+     * users who click "Download and Install" get the same feedback they get
+     * for the other tools. Startup omits the flag because the splash screen
+     * already indicates progress.
+     */
+    showProgress?: boolean;
+}
+
+/**
  * Ensure the extension-owned FFmpeg binary is present.
  * Downloads it if not already cached in extension global storage.
  * Returns the binary path on success, null on failure.
  */
 export async function downloadFFmpeg(
     context: vscode.ExtensionContext,
+    options: DownloadFFmpegOptions = {},
 ): Promise<string | null> {
-    return downloadFFmpegBinary(context);
+    return options.showProgress
+        ? downloadWithProgress(context)
+        : downloadFFmpegBinary(context);
 }
 
 
@@ -81,8 +156,130 @@ async function canExecute(binaryPath: string): Promise<boolean> {
     }
 }
 
+/** Matches a pure semver-ish directory name like `4.1.5`. */
+const VERSION_DIR_PATTERN = /^\d+(\.\d+)+$/;
+
+/**
+ * Migrate a legacy flat-layout FFmpeg install into a versioned subfolder.
+ *
+ * Before this change, binaries lived at:
+ *   `{globalStorage}/ffmpeg/ffmpeg` (or `ffmpeg.exe`)
+ * Now they live at:
+ *   `{globalStorage}/ffmpeg/{PLATFORM_MAP_version}/ffmpeg`
+ *
+ * Version identifier note: the `@ffmpeg-installer/*` npm package version
+ * (what `PLATFORM_MAP` holds) is NOT the same as the FFmpeg binary's
+ * internal version reported by `ffmpeg -version`. For example,
+ * `@ffmpeg-installer/darwin-arm64@4.1.5` contains a binary that reports
+ * `ffmpeg version 4.4`. The download code pins to the npm package version,
+ * and the storage folder name must match so existence checks succeed.
+ * A legacy flat binary was always obtained from the `PLATFORM_MAP` URL, so
+ * the correct destination for migration is `ffmpeg/{currentPlatformVersion}/`.
+ *
+ * Behavior:
+ *   - Current platform has a pinned version AND legacy binary executes →
+ *     move into `ffmpeg/{currentVersion}/` (reused as-is, no re-download).
+ *   - Legacy binary fails to execute, OR platform has no pinned version →
+ *     delete the orphan files; normal download path will handle it.
+ *   - Target versioned folder already exists (migration already ran, or
+ *     current version was freshly downloaded alongside the legacy file) →
+ *     clean up the legacy files, keep the existing versioned folder.
+ *   - Any IO error → silently fall through; the normal download path will
+ *     re-fetch into the correct versioned folder.
+ */
+async function migrateUnversionedFfmpeg(context: vscode.ExtensionContext): Promise<void> {
+    try {
+        const parentDir = getParentStorageDir(context);
+        const legacyBinary = path.join(parentDir, getFfmpegExecutableName());
+
+        if (!fs.existsSync(legacyBinary)) {
+            return;
+        }
+
+        const currentVersion = getPlatformVersion();
+        if (!currentVersion) {
+            console.warn(
+                "[ffmpegManager] Legacy unversioned binary found but no pinned version for this platform — removing orphan files"
+            );
+            await cleanupLegacyFiles(parentDir);
+            return;
+        }
+
+        if (!(await canExecute(legacyBinary))) {
+            console.warn(
+                "[ffmpegManager] Legacy unversioned binary is not executable — removing orphan files"
+            );
+            await cleanupLegacyFiles(parentDir);
+            return;
+        }
+
+        const targetDir = path.join(parentDir, currentVersion);
+        if (fs.existsSync(targetDir)) {
+            console.log(
+                `[ffmpegManager] Versioned folder ${currentVersion} already exists — cleaning up legacy files`
+            );
+            await cleanupLegacyFiles(parentDir);
+            return;
+        }
+
+        fs.mkdirSync(targetDir, { recursive: true });
+
+        const entries = fs.readdirSync(parentDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.isDirectory() && VERSION_DIR_PATTERN.test(entry.name)) {
+                continue;
+            }
+            const src = path.join(parentDir, entry.name);
+            const dst = path.join(targetDir, entry.name);
+            try {
+                fs.renameSync(src, dst);
+            } catch (err) {
+                console.warn(
+                    `[ffmpegManager] Could not move ${entry.name} during migration:`,
+                    err instanceof Error ? err.message : String(err)
+                );
+            }
+        }
+
+        console.log(
+            `[ffmpegManager] Migrated legacy binary into versioned folder v${currentVersion} — no re-download needed`
+        );
+    } catch (error) {
+        console.warn(
+            "[ffmpegManager] Migration of legacy binary failed — falling through to normal download logic:",
+            error instanceof Error ? error.message : String(error)
+        );
+    }
+}
+
+/**
+ * Remove leftover legacy files (binary + sha256 marker) directly inside the
+ * parent ffmpeg dir, without touching any version subdirectories.
+ */
+async function cleanupLegacyFiles(parentDir: string): Promise<void> {
+    try {
+        const entries = fs.readdirSync(parentDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.isDirectory() && VERSION_DIR_PATTERN.test(entry.name)) {
+                continue;
+            }
+            try {
+                fs.unlinkSync(path.join(parentDir, entry.name));
+            } catch { /* best-effort */ }
+        }
+    } catch { /* best-effort */ }
+}
+
+/**
+ * Maximum full-flow retry attempts (download + extract + verify) for the
+ * FFmpeg install. Matches git/dugite's `MAX_FULL_RETRIES = 3` so all three
+ * tools have consistent retry behavior visible to the user.
+ */
+const MAX_FULL_RETRIES = 3;
+
 async function downloadFFmpegBinary(
     context: vscode.ExtensionContext,
+    progress?: vscode.Progress<{ message?: string }>,
 ): Promise<string | null> {
     const { getAudioToolMode } = await import("./toolPreferences");
     if (getAudioToolMode() === "force-builtin") {
@@ -90,8 +287,23 @@ async function downloadFFmpegBinary(
         return null;
     }
 
-    const binaryPath = getBinaryPath(context);
-    const destDir = path.join(context.globalStorageUri.fsPath, "ffmpeg");
+    const version = getPlatformVersion();
+    if (!version) {
+        console.warn(
+            `[ffmpegManager] Platform ${process.platform}-${process.arch} not supported for ffmpeg`,
+        );
+        return null;
+    }
+
+    // Opportunistically migrate legacy flat-layout installs into versioned folders.
+    // Cheap in the common case (single existsSync) and idempotent.
+    await migrateUnversionedFfmpeg(context);
+
+    const binaryPath = getFfmpegBinaryPath(context);
+    if (!binaryPath) {
+        return null;
+    }
+    const destDir = path.dirname(binaryPath);
 
     if (fs.existsSync(binaryPath)) {
         const integrityOk = await verifyIntegrity(binaryPath, destDir);
@@ -113,14 +325,6 @@ async function downloadFFmpegBinary(
         return null;
     }
 
-    const version = getPlatformVersion();
-    if (!version) {
-        console.warn(
-            `[ffmpegManager] Platform ${process.platform}-${process.arch} not supported for ffmpeg`,
-        );
-        return null;
-    }
-
     const effectiveKey = getEffectivePlatformKey();
     const packageName = `@ffmpeg-installer/${effectiveKey}`;
 
@@ -130,28 +334,48 @@ async function downloadFFmpegBinary(
         // may already exist
     }
 
-    try {
-        await downloadAndExtractPackage(packageName, version, destDir);
-        if (process.platform !== "win32" && fs.existsSync(binaryPath)) {
-            fs.chmodSync(binaryPath, 0o755);
-        }
-        if (fs.existsSync(binaryPath)) {
+    // Full-flow retry loop with exponential backoff (2s/4s), mirroring the
+    // git/dugite manager so transient failures surface consistent retry
+    // messages and recover automatically. The persistent retry counter is
+    // bumped only once after ALL attempts are exhausted.
+    let lastError: Error | undefined;
+    for (let attempt = 1; attempt <= MAX_FULL_RETRIES; attempt++) {
+        try {
+            const prefix = attempt > 1 ? `Retry ${attempt}/${MAX_FULL_RETRIES} — ` : "";
+            progress?.report({ message: `${prefix}Downloading...` });
+            await downloadAndExtractPackage(packageName, version, destDir);
+            if (process.platform !== "win32" && fs.existsSync(binaryPath)) {
+                fs.chmodSync(binaryPath, 0o755);
+            }
+            if (!fs.existsSync(binaryPath)) {
+                throw new Error("Binary missing after extract");
+            }
+            progress?.report({ message: `${prefix}Installing...` });
             const hash = await computeFileHash(binaryPath);
             writeHashMarker(destDir, hash);
             console.log(`[ffmpegManager] SHA-256 of installed binary: ${hash}`);
             await resetRetryCount(context, "ffmpeg");
             console.log(`[ffmpegManager] Successfully downloaded ffmpeg: ${binaryPath}`);
             return binaryPath;
+        } catch (error) {
+            lastError = error instanceof Error ? error : new Error(String(error));
+            console.warn(
+                `[ffmpegManager] Full attempt ${attempt}/${MAX_FULL_RETRIES} failed: ${lastError.message}`,
+            );
+            if (attempt < MAX_FULL_RETRIES) {
+                const delay = 2000 * Math.pow(2, attempt - 1); // 2s, 4s
+                progress?.report({
+                    message: `Attempt ${attempt} failed — retrying in ${(delay / 1000).toFixed(0)}s...`,
+                });
+                await new Promise((r) => setTimeout(r, delay));
+            }
         }
-        return null;
-    } catch (error) {
-        await incrementRetryCount(context, "ffmpeg");
-        console.error(
-            `[ffmpegManager] Failed to download ffmpeg:`,
-            error instanceof Error ? error.message : String(error),
-        );
-        return null;
     }
+    await incrementRetryCount(context, "ffmpeg");
+    console.error(
+        `[ffmpegManager] All ${MAX_FULL_RETRIES} download attempts failed: ${lastError?.message ?? "unknown"}`,
+    );
+    return null;
 }
 
 /**
@@ -160,8 +384,8 @@ async function downloadFFmpegBinary(
 async function downloadWithProgress(
     context: vscode.ExtensionContext,
 ): Promise<string | null> {
-    const binaryPath = getBinaryPath(context);
-    if (fs.existsSync(binaryPath) && (await canExecute(binaryPath))) {
+    const binaryPath = getFfmpegBinaryPath(context);
+    if (binaryPath && fs.existsSync(binaryPath) && (await canExecute(binaryPath))) {
         await resetRetryCount(context, "ffmpeg");
         return binaryPath;
     }
@@ -169,14 +393,15 @@ async function downloadWithProgress(
     return vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: "Downloading audio processing tools...",
+            title: "Downloading Audio Tools",
             cancellable: false,
         },
         async (progress) => {
-            progress.report({ message: "This only happens once" });
             try {
-                progress.report({ message: "Downloading FFmpeg..." });
-                return await downloadFFmpegBinary(context);
+                // Forward the progress reporter so the retry loop inside
+                // `downloadFFmpegBinary` surfaces attempt/backoff messages
+                // (matching how git/dugite reports its retries).
+                return await downloadFFmpegBinary(context, progress);
             } catch (error) {
                 console.warn(`[ffmpegManager] Download failed: ${error instanceof Error ? error.message : String(error)}`);
                 return null;

--- a/src/utils/ffmpegManager.ts
+++ b/src/utils/ffmpegManager.ts
@@ -14,9 +14,6 @@ import {
     writeHashMarker,
     readHashMarker,
     verifyIntegrity,
-    hasExceededRetries,
-    incrementRetryCount,
-    resetRetryCount,
 } from "./binaryIntegrityUtils";
 
 const execFile = promisify(execFileCb);
@@ -116,6 +113,17 @@ function getEffectivePlatformKey(): string {
 
 function getPlatformVersion(): string | null {
     return PLATFORM_MAP[getEffectivePlatformKey()] ?? null;
+}
+
+/**
+ * Returns true when the current OS/arch has a prebuilt FFmpeg binary
+ * available (either directly or via `PLATFORM_FALLBACK`). Callers use
+ * this to decide whether to offer a "Download and install" button at
+ * all — on unsupported platforms, downloading is impossible and the UI
+ * should surface that fact instead of showing a no-op action.
+ */
+export function isFfmpegNativelySupported(): boolean {
+    return getPlatformVersion() !== null;
 }
 
 /**
@@ -272,10 +280,10 @@ async function cleanupLegacyFiles(parentDir: string): Promise<void> {
 
 /**
  * Maximum full-flow retry attempts (download + extract + verify) for the
- * FFmpeg install. Matches git/dugite's `MAX_FULL_RETRIES = 3` so all three
+ * FFmpeg install. Matches git/dugite's `MAX_FULL_RETRIES` so all three
  * tools have consistent retry behavior visible to the user.
  */
-const MAX_FULL_RETRIES = 3;
+const MAX_FULL_RETRIES = 2;
 
 async function downloadFFmpegBinary(
     context: vscode.ExtensionContext,
@@ -287,6 +295,10 @@ async function downloadFFmpegBinary(
         return null;
     }
 
+    // Unsupported platforms must NOT enter the retry loop or bump the retry
+    // counter — the bundled-or-limited fallback is used and re-evaluated next
+    // startup. "Unsupported" is a permanent condition for this machine, not
+    // a transient failure worth retrying with backoff.
     const version = getPlatformVersion();
     if (!version) {
         console.warn(
@@ -313,16 +325,10 @@ async function downloadFFmpegBinary(
             console.warn(`[ffmpegManager] SHA-256 mismatch — binary may be corrupt, re-downloading`);
         } else if (await canExecute(binaryPath)) {
             console.log(`[ffmpegManager] Downloaded ffmpeg verified: ${binaryPath}`);
-            await resetRetryCount(context, "ffmpeg");
             return binaryPath;
         } else {
             console.warn(`[ffmpegManager] Downloaded ffmpeg exists at ${binaryPath} but failed execution check — re-downloading`);
         }
-    }
-
-    if (hasExceededRetries(context, "ffmpeg")) {
-        console.warn("[ffmpegManager] Retry limit reached — audio features will use fallback");
-        return null;
     }
 
     const effectiveKey = getEffectivePlatformKey();
@@ -334,10 +340,9 @@ async function downloadFFmpegBinary(
         // may already exist
     }
 
-    // Full-flow retry loop with exponential backoff (2s/4s), mirroring the
+    // Full-flow retry loop with exponential backoff (2s), mirroring the
     // git/dugite manager so transient failures surface consistent retry
-    // messages and recover automatically. The persistent retry counter is
-    // bumped only once after ALL attempts are exhausted.
+    // messages and recover automatically.
     let lastError: Error | undefined;
     for (let attempt = 1; attempt <= MAX_FULL_RETRIES; attempt++) {
         try {
@@ -354,7 +359,6 @@ async function downloadFFmpegBinary(
             const hash = await computeFileHash(binaryPath);
             writeHashMarker(destDir, hash);
             console.log(`[ffmpegManager] SHA-256 of installed binary: ${hash}`);
-            await resetRetryCount(context, "ffmpeg");
             console.log(`[ffmpegManager] Successfully downloaded ffmpeg: ${binaryPath}`);
             return binaryPath;
         } catch (error) {
@@ -371,7 +375,6 @@ async function downloadFFmpegBinary(
             }
         }
     }
-    await incrementRetryCount(context, "ffmpeg");
     console.error(
         `[ffmpegManager] All ${MAX_FULL_RETRIES} download attempts failed: ${lastError?.message ?? "unknown"}`,
     );
@@ -386,7 +389,6 @@ async function downloadWithProgress(
 ): Promise<string | null> {
     const binaryPath = getFfmpegBinaryPath(context);
     if (binaryPath && fs.existsSync(binaryPath) && (await canExecute(binaryPath))) {
-        await resetRetryCount(context, "ffmpeg");
         return binaryPath;
     }
 

--- a/src/utils/sqliteNativeBinaryManager.ts
+++ b/src/utils/sqliteNativeBinaryManager.ts
@@ -22,7 +22,29 @@ import {
     resetRetryCount,
 } from "./binaryIntegrityUtils";
 
-/** Version of the TryGhost sqlite3 prebuilt binary we download */
+/**
+ * ============================================================================
+ * VERSION CONSTANT — read carefully before changing
+ * ============================================================================
+ * This version string is used in TWO places:
+ *   1. The download URL (what we fetch from GitHub releases)
+ *   2. The storage folder name (where we save it on disk):
+ *      `{globalStorage}/sqlite3-native/{SQLITE3_VERSION}/node_sqlite3.node`
+ *
+ * To upgrade SQLite:
+ *   1. Change the value below to the new TryGhost/node-sqlite3 release tag
+ *      (without the leading "v" — e.g. "5.1.8" not "v5.1.8")
+ *   2. Verify the release exists at:
+ *      https://github.com/TryGhost/node-sqlite3/releases/tag/v{NEW_VERSION}
+ *   3. Verify prebuilt binaries are published for all supported platforms
+ *      (darwin-arm64, darwin-x64, linux-arm64, linux-x64, linuxmusl-*, win32-*)
+ *   4. On next extension startup, users will download the new version into
+ *      a new subfolder: globalStorage/sqlite3-native/{NEW_VERSION}/
+ *   5. The old version folder is LEFT IN PLACE as a harmless orphan; only the
+ *      version matching the current constant is ever read at runtime.
+ *      Users can manually clean up old folders via the "Delete Binary" button.
+ * ============================================================================
+ */
 const SQLITE3_VERSION = "5.1.7";
 
 /** N-API version for the prebuilt binary (v6 is supported by all modern Node/Electron) */
@@ -40,8 +62,15 @@ const BINARY_NAME = "node_sqlite3.node";
 /** Minimum expected binary size in bytes — real binaries are ~2 MB; anything below this is corrupt/truncated */
 const MIN_BINARY_SIZE_BYTES = 500_000;
 
-/** Maximum download attempts before giving up */
+/** Maximum HTTP-level download attempts inside `withRetry` (per GET). */
 const MAX_DOWNLOAD_ATTEMPTS = 3;
+
+/**
+ * Maximum full-flow retry attempts (download + extract + verify). Matches
+ * git/dugite's `MAX_FULL_RETRIES = 3` so all three tools have consistent
+ * retry behavior visible to the user.
+ */
+const MAX_FULL_RETRIES = 3;
 
 /** Cached binary path (set after first successful resolution) */
 let cachedBinaryPath: string | null = null;
@@ -108,25 +137,38 @@ function getBinaryDownloadUrl(platformKey: string): string {
 }
 
 /**
- * Get the expected binary file path in extension global storage.
+ * Get the directory holding the SQLite binary for the current version.
+ * This is the single source of truth for the versioned storage folder.
  */
-function getBinaryStoragePath(context: vscode.ExtensionContext): string {
+function getVersionedStorageDir(context: vscode.ExtensionContext): string {
     return path.join(
         context.globalStorageUri.fsPath,
         SQLITE_STORAGE_DIR,
-        BINARY_NAME
+        SQLITE3_VERSION
     );
+}
+
+/**
+ * Get the parent directory that contains all version subfolders.
+ * Used by the migration routine and by callers that need to detect
+ * legacy (unversioned) installs.
+ */
+function getParentStorageDir(context: vscode.ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, SQLITE_STORAGE_DIR);
+}
+
+/**
+ * Get the expected binary file path in extension global storage.
+ */
+function getBinaryStoragePath(context: vscode.ExtensionContext): string {
+    return path.join(getVersionedStorageDir(context), BINARY_NAME);
 }
 
 /**
  * Get the path to the version marker file next to the binary.
  */
 function getVersionFilePath(context: vscode.ExtensionContext): string {
-    return path.join(
-        context.globalStorageUri.fsPath,
-        SQLITE_STORAGE_DIR,
-        "version.txt"
-    );
+    return path.join(getVersionedStorageDir(context), "version.txt");
 }
 
 /**
@@ -269,6 +311,98 @@ async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
 }
 
 /**
+ * Migrate a legacy flat-layout install into the new versioned folder.
+ *
+ * Before this change, binaries lived at:
+ *   `{globalStorage}/sqlite3-native/node_sqlite3.node`
+ * Now they live at:
+ *   `{globalStorage}/sqlite3-native/{SQLITE3_VERSION}/node_sqlite3.node`
+ *
+ * This function runs on every startup but only performs work when a legacy
+ * binary is detected. It always tries to preserve the existing binary by
+ * moving it into a correctly-named version subfolder, so no re-download is
+ * needed when the user's existing install matches the current version.
+ *
+ * Behavior:
+ *   - `version.txt` matches current `SQLITE3_VERSION` → move into versioned
+ *     folder (reused as-is, no re-download).
+ *   - `version.txt` says a different version → move into that version's
+ *     folder (preserved but inactive; current version downloaded fresh).
+ *   - `version.txt` is missing/unreadable → delete orphan files (can't
+ *     verify they're trustworthy).
+ *   - Any IO error → silently fall through; the normal download path will
+ *     re-fetch into the correct versioned folder.
+ */
+function migrateUnversionedSqlite(context: vscode.ExtensionContext): void {
+    try {
+        const parentDir = getParentStorageDir(context);
+        const legacyBinary = path.join(parentDir, BINARY_NAME);
+        const legacyVersionFile = path.join(parentDir, "version.txt");
+        const legacyHashFile = path.join(parentDir, "sha256.txt");
+
+        if (!fs.existsSync(legacyBinary)) {
+            return;
+        }
+
+        let foundVersion: string | null = null;
+        try {
+            foundVersion = fs.readFileSync(legacyVersionFile, "utf8").trim();
+            if (!foundVersion) {
+                foundVersion = null;
+            }
+        } catch {
+            foundVersion = null;
+        }
+
+        if (!foundVersion) {
+            console.warn(
+                "[SQLite] Legacy unversioned binary found but version.txt is missing/unreadable — removing orphan files"
+            );
+            try { fs.unlinkSync(legacyBinary); } catch { /* best-effort */ }
+            try { fs.unlinkSync(legacyHashFile); } catch { /* may not exist */ }
+            return;
+        }
+
+        const targetDir = path.join(parentDir, foundVersion);
+        if (fs.existsSync(targetDir)) {
+            console.log(
+                `[SQLite] Versioned folder ${foundVersion} already exists — skipping migration, cleaning up legacy files`
+            );
+            try { fs.unlinkSync(legacyBinary); } catch { /* best-effort */ }
+            try { fs.unlinkSync(legacyVersionFile); } catch { /* best-effort */ }
+            try { fs.unlinkSync(legacyHashFile); } catch { /* may not exist */ }
+            return;
+        }
+
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.renameSync(legacyBinary, path.join(targetDir, BINARY_NAME));
+        try {
+            fs.renameSync(legacyVersionFile, path.join(targetDir, "version.txt"));
+        } catch { /* version.txt move is best-effort; we can regenerate it */ }
+        try {
+            fs.renameSync(legacyHashFile, path.join(targetDir, "sha256.txt"));
+        } catch { /* sha256.txt move is best-effort; verifyIntegrity will return false if missing */ }
+
+        if (foundVersion === SQLITE3_VERSION) {
+            console.log(
+                `[SQLite] Migrated legacy binary (v${foundVersion}) into versioned folder — no re-download needed`
+            );
+        } else {
+            console.log(
+                `[SQLite] Migrated legacy binary (v${foundVersion}) into its own versioned folder; current version v${SQLITE3_VERSION} will be downloaded on demand`
+            );
+        }
+    } catch (error) {
+        // Any failure here is non-fatal: the normal download logic will run
+        // next and produce a correct versioned install from scratch.
+        console.warn(
+            "[SQLite] Migration of legacy binary failed — falling through to normal download logic:",
+            error instanceof Error ? error.message : String(error)
+        );
+    }
+}
+
+/**
  * Download and extract the SQLite native binary to extension storage.
  */
 async function downloadBinary(
@@ -278,7 +412,7 @@ async function downloadBinary(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const tar = require("tar");
     const downloadUrl = getBinaryDownloadUrl(platformKey);
-    const storageDir = path.join(context.globalStorageUri.fsPath, SQLITE_STORAGE_DIR);
+    const storageDir = getVersionedStorageDir(context);
     const binaryPath = path.join(storageDir, BINARY_NAME);
     const versionFilePath = getVersionFilePath(context);
     const tmpFile = path.join(os.tmpdir(), `sqlite3-native-${Date.now()}.tar.gz`);
@@ -337,14 +471,33 @@ async function downloadBinary(
 }
 
 /**
+ * Options for `ensureSqliteNativeBinary`.
+ */
+export interface EnsureSqliteOptions {
+    /**
+     * When true, suppress the standalone progress notification that normally
+     * appears at the bottom of the window during a download. The caller is
+     * expected to provide its own progress UI (for example, the "Downloading…"
+     * button state in the Tools Status panel). The startup path keeps the
+     * default (false) because nothing else indicates sqlite progress during
+     * activation.
+     */
+    suppressProgress?: boolean;
+}
+
+/**
  * Ensure the SQLite native binary is available, downloading it if necessary.
  * This should be called on extension startup BEFORE any database operations.
  *
- * Shows a blocking progress dialog if download is needed.
+ * By default shows a progress notification ("Setting up search…") if a
+ * download is needed. Callers that already surface a progress UI can pass
+ * `{ suppressProgress: true }` to opt out.
+ *
  * Returns the path to the .node binary file.
  */
 export async function ensureSqliteNativeBinary(
-    context: vscode.ExtensionContext
+    context: vscode.ExtensionContext,
+    options: EnsureSqliteOptions = {}
 ): Promise<string | null> {
     const { getSqliteToolMode } = await import("./toolPreferences");
     if (getSqliteToolMode() === "force-builtin") {
@@ -352,9 +505,13 @@ export async function ensureSqliteNativeBinary(
         return null;
     }
 
+    // Opportunistically migrate legacy flat-layout installs into versioned folders.
+    // This is cheap (single existsSync check in the common case) and idempotent.
+    migrateUnversionedSqlite(context);
+
     const binaryPath = getBinaryStoragePath(context);
     const versionFilePath = getVersionFilePath(context);
-    const storageDir = path.join(context.globalStorageUri.fsPath, SQLITE_STORAGE_DIR);
+    const storageDir = getVersionedStorageDir(context);
 
     // Fast path: in-memory cache still valid (same process, already verified)
     if (cachedBinaryPath && cachedBinaryPath === binaryPath && fs.existsSync(cachedBinaryPath)) {
@@ -412,32 +569,64 @@ export async function ensureSqliteNativeBinary(
         return downloadInProgress;
     }
 
-    downloadInProgress = Promise.resolve(
-        vscode.window.withProgress(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Setting up Codex Editor",
-                cancellable: false,
-            },
-            async (progress) => {
-                progress.report({
-                    message: "Setting up search... (one-time setup)",
-                });
-
-                try {
-                    const downloadedPath = await downloadBinary(context, platformKey);
-                    await resetRetryCount(context, "sqlite");
-                    progress.report({ message: "Search is ready!" });
-                    return downloadedPath;
-                } catch (error) {
-                    await incrementRetryCount(context, "sqlite");
-                    const msg = error instanceof Error ? error.message : String(error);
-                    console.warn(`[SQLite] Binary download failed: ${msg}`);
-                    return null;
+    // Shared body of the download operation. Reused whether or not we wrap
+    // the work in a progress notification, so error handling and retry-count
+    // bookkeeping stay identical across both paths.
+    //
+    // Runs a full-flow retry loop with exponential backoff (2s/4s) mirroring
+    // git/dugite's behavior, so a transient failure during download, extract,
+    // or verification can recover without user intervention. Each retry
+    // surfaces its state through the optional progress reporter, and the
+    // persistent retry counter is bumped only once after ALL attempts are
+    // exhausted (consistent with git).
+    const runDownload = async (
+        progress?: vscode.Progress<{ message?: string }>
+    ): Promise<string | null> => {
+        let lastError: Error | undefined;
+        for (let attempt = 1; attempt <= MAX_FULL_RETRIES; attempt++) {
+            try {
+                const prefix = attempt > 1 ? `Retry ${attempt}/${MAX_FULL_RETRIES} — ` : "";
+                progress?.report({ message: `${prefix}Downloading...` });
+                const downloadedPath = await downloadBinary(context, platformKey);
+                await resetRetryCount(context, "sqlite");
+                progress?.report({ message: "Search is ready!" });
+                return downloadedPath;
+            } catch (error) {
+                lastError = error instanceof Error ? error : new Error(String(error));
+                console.warn(
+                    `[SQLite] Full attempt ${attempt}/${MAX_FULL_RETRIES} failed: ${lastError.message}`,
+                );
+                if (attempt < MAX_FULL_RETRIES) {
+                    const delay = 2000 * Math.pow(2, attempt - 1); // 2s, 4s
+                    progress?.report({
+                        message: `Attempt ${attempt} failed — retrying in ${(delay / 1000).toFixed(0)}s...`,
+                    });
+                    await new Promise((r) => setTimeout(r, delay));
                 }
             }
-        )
-    );
+        }
+        await incrementRetryCount(context, "sqlite");
+        console.warn(
+            `[SQLite] All ${MAX_FULL_RETRIES} download attempts failed: ${lastError?.message ?? "unknown"}`,
+        );
+        return null;
+    };
+
+    if (options.suppressProgress) {
+        // Caller owns the progress UI; skip the standalone notification.
+        downloadInProgress = runDownload();
+    } else {
+        downloadInProgress = Promise.resolve(
+            vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: "Downloading AI Learning and Search Tools",
+                    cancellable: false,
+                },
+                async (progress) => runDownload(progress)
+            )
+        );
+    }
 
     try {
         const result = await downloadInProgress;

--- a/src/utils/sqliteNativeBinaryManager.ts
+++ b/src/utils/sqliteNativeBinaryManager.ts
@@ -17,9 +17,6 @@ import {
     writeHashMarker,
     readHashMarker,
     verifyIntegrity,
-    hasExceededRetries,
-    incrementRetryCount,
-    resetRetryCount,
 } from "./binaryIntegrityUtils";
 
 /**
@@ -67,10 +64,10 @@ const MAX_DOWNLOAD_ATTEMPTS = 3;
 
 /**
  * Maximum full-flow retry attempts (download + extract + verify). Matches
- * git/dugite's `MAX_FULL_RETRIES = 3` so all three tools have consistent
+ * git/dugite's `MAX_FULL_RETRIES` so all three tools have consistent
  * retry behavior visible to the user.
  */
-const MAX_FULL_RETRIES = 3;
+const MAX_FULL_RETRIES = 2;
 
 /** Cached binary path (set after first successful resolution) */
 let cachedBinaryPath: string | null = null;
@@ -107,6 +104,17 @@ function getPlatformKey(): string | null {
     }
 
     return null;
+}
+
+/**
+ * Returns true when the current OS/arch has a prebuilt SQLite native
+ * addon published in the TryGhost `node-sqlite3` release we pin to.
+ * Callers use this to decide whether to offer a "Download and install"
+ * button at all — on unsupported platforms, downloading is impossible
+ * and the UI should surface that fact instead of showing a no-op action.
+ */
+export function isSqliteNativelySupported(): boolean {
+    return getPlatformKey() !== null;
 }
 
 /**
@@ -521,44 +529,35 @@ export async function ensureSqliteNativeBinary(
     // Check if binary already exists in storage AND matches expected version/integrity
     if (fs.existsSync(binaryPath) && !shouldRedownload(binaryPath, versionFilePath)) {
         if (await shouldRedownloadAsync(binaryPath, storageDir)) {
-            if (hasExceededRetries(context, "sqlite")) {
-                console.warn("[SQLite] Retry limit reached — falling back to fts5-sql-bundle");
-                return null;
-            }
-            await incrementRetryCount(context, "sqlite");
             console.warn("[SQLite] Integrity check failed — deleting cached binary for re-download");
             try { fs.unlinkSync(binaryPath); } catch { /* best-effort */ }
         } else {
-            await resetRetryCount(context, "sqlite");
             cachedBinaryPath = binaryPath;
             console.log(`[SQLite] Using cached native binary v${SQLITE3_VERSION}: ${binaryPath}`);
             return binaryPath;
         }
     }
 
-    if (hasExceededRetries(context, "sqlite")) {
-        console.warn("[SQLite] Retry limit reached — falling back to fts5-sql-bundle");
-        return null;
-    }
-
+    // Unsupported platforms: no native asset exists for this OS/arch, so skip
+    // the download entirely. The fts5-sql-bundle fallback is used permanently.
     const platformKey = getPlatformKey();
     if (!platformKey) {
         console.warn(`[SQLite] Platform ${process.platform}-${process.arch} not supported — falling back to fts5-sql-bundle`);
         return null;
     }
 
-    // Fast-fail when offline
+    // Fast-fail when offline. Any HTTP response (even 4xx/5xx) means the
+    // network is reachable — only a network-level failure (DNS, timeout,
+    // connection refused) means we're truly offline. Checking resp.ok would
+    // incorrectly treat rate-limit (403/429) responses as "offline".
     try {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 3000);
-        const resp = await fetch("https://github.com", {
+        const timeout = setTimeout(() => controller.abort(), 5000);
+        await fetch("https://github.com", {
             method: "HEAD",
             signal: controller.signal,
         });
         clearTimeout(timeout);
-        if (!resp.ok) {
-            throw new Error("GitHub unreachable");
-        }
     } catch {
         console.warn("[SQLite] Offline — native binary unavailable, falling back to fts5-sql-bundle");
         return null;
@@ -573,12 +572,10 @@ export async function ensureSqliteNativeBinary(
     // the work in a progress notification, so error handling and retry-count
     // bookkeeping stay identical across both paths.
     //
-    // Runs a full-flow retry loop with exponential backoff (2s/4s) mirroring
+    // Runs a full-flow retry loop with exponential backoff (2s) mirroring
     // git/dugite's behavior, so a transient failure during download, extract,
     // or verification can recover without user intervention. Each retry
-    // surfaces its state through the optional progress reporter, and the
-    // persistent retry counter is bumped only once after ALL attempts are
-    // exhausted (consistent with git).
+    // surfaces its state through the optional progress reporter.
     const runDownload = async (
         progress?: vscode.Progress<{ message?: string }>
     ): Promise<string | null> => {
@@ -588,7 +585,6 @@ export async function ensureSqliteNativeBinary(
                 const prefix = attempt > 1 ? `Retry ${attempt}/${MAX_FULL_RETRIES} — ` : "";
                 progress?.report({ message: `${prefix}Downloading...` });
                 const downloadedPath = await downloadBinary(context, platformKey);
-                await resetRetryCount(context, "sqlite");
                 progress?.report({ message: "Search is ready!" });
                 return downloadedPath;
             } catch (error) {
@@ -605,7 +601,6 @@ export async function ensureSqliteNativeBinary(
                 }
             }
         }
-        await incrementRetryCount(context, "sqlite");
         console.warn(
             `[SQLite] All ${MAX_FULL_RETRIES} download attempts failed: ${lastError?.message ?? "unknown"}`,
         );

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -5,7 +5,8 @@ import * as fs from "fs";
 import { isNativeSqliteReady } from "./nativeSqlite";
 import { isDatabaseReady } from "./sqliteDatabaseFactory";
 import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "./toolPreferences";
-import { getFfmpegBinaryPath } from "./ffmpegManager";
+import { getFfmpegBinaryPath, isFfmpegNativelySupported } from "./ffmpegManager";
+import { isSqliteNativelySupported } from "./sqliteNativeBinaryManager";
 import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
 
 const execFile = promisify(execFileCb);
@@ -19,6 +20,17 @@ export interface ToolCheckResult {
     /** True only when the native node_sqlite3 binary is loaded. */
     nativeSqliteAvailable: boolean;
     ffmpeg: boolean;
+    /**
+     * Per-tool flag set to true when the CURRENT OS/arch has no prebuilt
+     * native asset available. On these platforms the "Download and install"
+     * action is a guaranteed no-op, so the UI should render "Not available
+     * on this platform" instead of a download button.
+     */
+    platformUnsupported: {
+        git: boolean;
+        sqlite: boolean;
+        ffmpeg: boolean;
+    };
 }
 
 const REQUIRED_TOOLS_FFMPEG_KEY = "requiredTools.ffmpeg";
@@ -55,7 +67,24 @@ export async function checkTools(
         console.error("[toolsManager] ffmpeg check threw:", e);
     }
 
-    return { git, nativeGitAvailable, sqlite, nativeSqliteAvailable, ffmpeg };
+    // Per-tool "unsupported on this platform" flags.  Treat a missing
+    // Frontier API method as "supported" (optimistic default) so older
+    // auth extensions keep working; the download path itself still
+    // no-ops safely on unsupported platforms.
+    const platformUnsupported = {
+        git: frontierApi?.isGitBinaryNativelySupported?.() === false,
+        sqlite: !isSqliteNativelySupported(),
+        ffmpeg: !isFfmpegNativelySupported(),
+    };
+
+    return {
+        git,
+        nativeGitAvailable,
+        sqlite,
+        nativeSqliteAvailable,
+        ffmpeg,
+        platformUnsupported,
+    };
 }
 
 /**

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import { execFile as execFileCb } from "child_process";
 import { promisify } from "util";
-import * as path from "path";
 import * as fs from "fs";
 import { isNativeSqliteReady } from "./nativeSqlite";
 import { isDatabaseReady } from "./sqliteDatabaseFactory";
 import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "./toolPreferences";
+import { getFfmpegBinaryPath } from "./ffmpegManager";
 import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
 
 const execFile = promisify(execFileCb);
@@ -100,26 +100,20 @@ export function isAudioToolRequired(
  * Verify that the extension-owned FFmpeg binary is present and executable.
  * Only checks the downloaded binary in extension globalStorage — never
  * falls back to system-installed binaries on the PATH.
+ *
+ * The path is resolved via `getFfmpegBinaryPath` in ffmpegManager, which is
+ * the single source of truth for the versioned binary location.
  */
 async function verifyBinaryAvailable(
     tool: "ffmpeg",
     context: vscode.ExtensionContext,
 ): Promise<boolean> {
-    const downloadedPath = getDownloadedBinaryPath(tool, context);
+    const downloadedPath = getFfmpegBinaryPath(context);
     if (downloadedPath && fs.existsSync(downloadedPath) && (await canExecute(downloadedPath))) {
         return true;
     }
 
     return false;
-}
-
-function getDownloadedBinaryPath(
-    tool: "ffmpeg",
-    context: vscode.ExtensionContext,
-): string {
-    const storagePath = context.globalStorageUri.fsPath;
-    const binaryName = process.platform === "win32" ? `${tool}.exe` : tool;
-    return path.join(storagePath, tool, binaryName);
 }
 
 async function canExecute(binaryPath: string): Promise<boolean> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2281,11 +2281,23 @@ export type AudioToolMode = "auto" | "builtin" | "force-builtin";
 export type GitToolMode = "auto" | "builtin" | "force-builtin";
 export type SqliteToolMode = "auto" | "builtin" | "force-builtin";
 
+/**
+ * Per-tool flag set to true when the CURRENT OS/arch has no prebuilt
+ * native asset. Surfaced to the Missing-Tools / Tools-Status webview so
+ * the UI can render "Not available on this platform" instead of a
+ * download button that can never succeed.
+ */
+export interface PlatformUnsupportedFlags {
+    git: boolean;
+    sqlite: boolean;
+    ffmpeg: boolean;
+}
+
 export type MessagesToMissingToolsWarning =
-    | { command: "showWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean }
-    | { command: "updateWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean }
-    | { command: "showToolsStatus"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; syncInProgress?: boolean; audioProcessingInProgress?: boolean }
-    | { command: "toolDownloadResult"; tool: "sqlite" | "git" | "ffmpeg"; success: boolean; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode }
+    | { command: "showWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags }
+    | { command: "updateWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags }
+    | { command: "showToolsStatus"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; syncInProgress?: boolean; audioProcessingInProgress?: boolean; platformUnsupported?: PlatformUnsupportedFlags }
+    | { command: "toolDownloadResult"; tool: "sqlite" | "git" | "ffmpeg"; success: boolean; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; platformUnsupported?: PlatformUnsupportedFlags }
     | { command: "audioModeChanged"; audioToolMode: AudioToolMode; ffmpeg: boolean }
     | { command: "gitModeChanged"; gitToolMode: GitToolMode; git: boolean; nativeGitAvailable?: boolean }
     | { command: "sqliteModeChanged"; sqliteToolMode: SqliteToolMode; sqlite: boolean; nativeSqliteAvailable?: boolean }

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useNetworkState } from "@uidotdev/usehooks";
 import { Button } from "../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
@@ -72,11 +72,39 @@ export const MissingToolsWarning: React.FC = () => {
     const [syncInProgress, setSyncInProgress] = useState(initial?.syncInProgress ?? false);
     const [audioProcessingInProgress, setAudioProcessingInProgress] = useState(initial?.audioProcessingInProgress ?? false);
     const [retrying, setRetrying] = useState(false);
-    const [downloading, setDownloading] = useState<Record<ToolKey, boolean>>({
-        sqlite: false,
-        git: false,
-        ffmpeg: false,
+    // Per-tool download state machine:
+    //   idle       – default, button shows "Download and Install"
+    //   downloading – user clicked, waiting for provider result
+    //   failed     – result came back unsuccessful; shown briefly before
+    //                auto-reverting to "idle" via a timeout (see failedTimers)
+    const [downloadState, setDownloadState] = useState<
+        Record<ToolKey, "idle" | "downloading" | "failed">
+    >({
+        sqlite: "idle",
+        git: "idle",
+        ffmpeg: "idle",
     });
+    // Per-tool revert timers for the "failed" state. Held in a ref (not
+    // state) so updates don't cause re-renders, and cleared on new clicks
+    // or unmount to prevent stale updates.
+    const failedTimers = useRef<Record<ToolKey, ReturnType<typeof setTimeout> | undefined>>({
+        sqlite: undefined,
+        git: undefined,
+        ffmpeg: undefined,
+    });
+
+    // Cleanup any outstanding revert timers when the panel is destroyed.
+    useEffect(() => {
+        const timers = failedTimers.current;
+        return () => {
+            (Object.keys(timers) as ToolKey[]).forEach((k) => {
+                if (timers[k]) {
+                    clearTimeout(timers[k]!);
+                    timers[k] = undefined;
+                }
+            });
+        };
+    }, []);
     const [deleteMode, setDeleteMode] = useState(false);
     const [forceBuiltinMode, setForceBuiltinMode] = useState(false);
     const [deletedTools, setDeletedTools] = useState<Set<ToolKey>>(new Set());
@@ -130,7 +158,25 @@ export const MissingToolsWarning: React.FC = () => {
                 if (message.sqliteToolMode) {
                     setSqliteToolMode(message.sqliteToolMode);
                 }
-                setDownloading((prev) => ({ ...prev, [message.tool]: false }));
+                // Transition the button: success → back to "idle" (card
+                // flips to green and typically hides the button). Failure →
+                // "failed" for a brief visible flash before reverting.
+                const tool = message.tool as ToolKey;
+                // Clear any stale revert timer (e.g. user clicked again
+                // during the previous fail-revert window).
+                if (failedTimers.current[tool]) {
+                    clearTimeout(failedTimers.current[tool]!);
+                    failedTimers.current[tool] = undefined;
+                }
+                if (message.success) {
+                    setDownloadState((prev) => ({ ...prev, [tool]: "idle" }));
+                } else {
+                    setDownloadState((prev) => ({ ...prev, [tool]: "failed" }));
+                    failedTimers.current[tool] = setTimeout(() => {
+                        setDownloadState((prev) => ({ ...prev, [tool]: "idle" }));
+                        failedTimers.current[tool] = undefined;
+                    }, 1500);
+                }
             } else if (message?.command === "audioModeChanged") {
                 setAudioToolMode(message.audioToolMode);
                 setStatus((prev) => prev ? { ...prev, ffmpeg: message.ffmpeg } : prev);
@@ -183,7 +229,13 @@ export const MissingToolsWarning: React.FC = () => {
     }, []);
 
     const handleDownloadTool = useCallback((tool: ToolKey) => {
-        setDownloading((prev) => ({ ...prev, [tool]: true }));
+        // If a previous failure timer is still counting, clear it so the
+        // button doesn't revert from "downloading" back to "idle" mid-flow.
+        if (failedTimers.current[tool]) {
+            clearTimeout(failedTimers.current[tool]!);
+            failedTimers.current[tool] = undefined;
+        }
+        setDownloadState((prev) => ({ ...prev, [tool]: "downloading" }));
         vscode.postMessage({ command: "downloadTool", tool });
     }, []);
 
@@ -229,7 +281,7 @@ export const MissingToolsWarning: React.FC = () => {
                 sqliteToolMode={sqliteToolMode}
                 syncInProgress={syncInProgress}
                 audioProcessingInProgress={audioProcessingInProgress}
-                downloading={downloading}
+                downloadState={downloadState}
                 deleteMode={deleteMode}
                 forceBuiltinMode={forceBuiltinMode}
                 deletedTools={deletedTools}
@@ -290,7 +342,7 @@ interface ToolsStatusViewProps {
     sqliteToolMode: SqliteToolMode;
     syncInProgress: boolean;
     audioProcessingInProgress: boolean;
-    downloading: Record<ToolKey, boolean>;
+    downloadState: Record<ToolKey, "idle" | "downloading" | "failed">;
     deleteMode: boolean;
     forceBuiltinMode: boolean;
     deletedTools: Set<ToolKey>;
@@ -312,7 +364,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
     sqliteToolMode,
     syncInProgress,
     audioProcessingInProgress,
-    downloading,
+    downloadState,
     deleteMode,
     forceBuiltinMode,
     deletedTools,
@@ -335,10 +387,13 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
     const getToolState = (mode: string, nativeAvailable: boolean) => {
         const forced = isForced(mode);
         const usingBuiltIn = isBuiltinMode(mode) || !nativeAvailable;
+        // Severity priority: a missing native binary is always an error
+        // (unless admin has locked us into force-builtin, which is a softer
+        // "warning" state). Only when the binary is installed does the
+        // user's "builtin" preference downgrade to a warning.
         const severity: "ok" | "warning" | "error" =
-            forced ? "warning"
+            !nativeAvailable && !forced ? "error"
             : isBuiltinMode(mode) ? "warning"
-            : !nativeAvailable ? "error"
             : "ok";
         const statusLabel =
             forced ? "Running Fallback Tools (locked)"
@@ -350,7 +405,12 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
             : nativeAvailable && usingBuiltIn ? "Use Native Tools"
             : nativeAvailable ? "Use Fallback Tools"
             : undefined;
-        const showDownload = !isBuiltinMode(mode) && !nativeAvailable;
+        // A "builtin" preference must not hide the download button: if the
+        // native binary isn't installed, the user should always be able to
+        // install it (the download handler flips mode back to "auto" so the
+        // newly-installed binary is actually used). Only force-builtin (admin
+        // lock) hides the option.
+        const showDownload = !forced && !nativeAvailable;
         const showToggle = forced || nativeAvailable;
 
         return { forced, usingBuiltIn, severity, statusLabel, toggleLabel, showDownload, showToggle };
@@ -368,7 +428,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         className="text-2xl font-bold"
                         style={{ color: "var(--foreground)" }}
                     >
-                        Status
+                        Tools Status
                     </h1>
                     <p
                         className="text-sm"
@@ -391,7 +451,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         severity={!status.sqlite && !sqlite.forced ? "error" : sqlite.severity}
                         statusLabelOverride={!status.sqlite && !sqlite.forced ? undefined : sqlite.statusLabel}
                         isOnline={isOnline}
-                        downloading={downloading.sqlite}
+                        downloadState={downloadState.sqlite}
                         onDownload={sqlite.showDownload ? () => onDownloadTool("sqlite") : undefined}
                         toggleLabel={sqlite.toggleLabel}
                         onToggle={sqlite.showToggle ? onToggleSqliteMode : undefined}
@@ -411,7 +471,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         severity={git.severity}
                         statusLabelOverride={git.statusLabel}
                         isOnline={isOnline}
-                        downloading={downloading.git}
+                        downloadState={downloadState.git}
                         onDownload={git.showDownload ? () => onDownloadTool("git") : undefined}
                         toggleLabel={git.toggleLabel}
                         onToggle={git.showToggle ? onToggleGitMode : undefined}
@@ -433,7 +493,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         severity={audio.severity}
                         statusLabelOverride={audio.statusLabel}
                         isOnline={isOnline}
-                        downloading={downloading.ffmpeg}
+                        downloadState={downloadState.ffmpeg}
                         onDownload={audio.showDownload ? () => onDownloadTool("ffmpeg") : undefined}
                         toggleLabel={audio.toggleLabel}
                         onToggle={audio.showToggle ? onToggleAudioMode : undefined}
@@ -700,7 +760,14 @@ interface StatusCardProps {
     severity: "ok" | "warning" | "error";
     statusLabelOverride?: string;
     isOnline?: boolean;
-    downloading?: boolean;
+    /**
+     * Current state of the download button for this tool:
+     *   "idle"        – default, shows "Download and Install"
+     *   "downloading" – user clicked, awaiting result
+     *   "failed"      – most recent attempt failed; briefly shown before
+     *                    the parent auto-reverts to "idle"
+     */
+    downloadState?: "idle" | "downloading" | "failed";
     onDownload?: () => void;
     toggleLabel?: string;
     onToggle?: () => void;
@@ -718,7 +785,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
     severity,
     statusLabelOverride,
     isOnline = true,
-    downloading = false,
+    downloadState = "idle",
     onDownload,
     toggleLabel,
     onToggle,
@@ -729,6 +796,8 @@ const StatusCard: React.FC<StatusCardProps> = ({
     deleted = false,
     nativeInstalled = true,
 }) => {
+    const downloading = downloadState === "downloading";
+    const failed = downloadState === "failed";
     const borderColor =
         severity === "ok"
             ? "var(--chart-2)"
@@ -804,15 +873,25 @@ const StatusCard: React.FC<StatusCardProps> = ({
                                 variant="outline"
                                 size="sm"
                                 onClick={isOnline ? onDownload : undefined}
-                                disabled={!isOnline || downloading}
+                                disabled={!isOnline || downloading || failed}
                                 className="h-7 text-xs"
                             >
-                                {downloading ? (
+                                {downloading && (
                                     <>
                                         <i className="codicon codicon-loading codicon-modifier-spin mr-1.5" />
                                         Downloading…
                                     </>
-                                ) : (
+                                )}
+                                {failed && (
+                                    <>
+                                        <i
+                                            className="codicon codicon-error mr-1.5"
+                                            style={{ color: "var(--destructive)" }}
+                                        />
+                                        Download failed
+                                    </>
+                                )}
+                                {!downloading && !failed && (
                                     <>
                                         <i className="codicon codicon-cloud-download mr-1.5" />
                                         Download and Install

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -11,12 +11,24 @@ declare function acquireVsCodeApi(): {
 
 const vscode = acquireVsCodeApi();
 
+interface PlatformUnsupportedFlags {
+    git: boolean;
+    sqlite: boolean;
+    ffmpeg: boolean;
+}
+
 interface ToolStatus {
     git: boolean;
     nativeGitAvailable: boolean;
     sqlite: boolean;
     nativeSqliteAvailable: boolean;
     ffmpeg: boolean;
+    /**
+     * Per-tool flag set to true when the current OS/arch has no prebuilt
+     * native asset. On these platforms the download button is hidden and
+     * replaced with a "Not available on this platform" indicator.
+     */
+    platformUnsupported: PlatformUnsupportedFlags;
 }
 
 type ViewMode = "warnings" | "status";
@@ -34,6 +46,25 @@ interface InitialState {
     audioProcessingInProgress: boolean;
 }
 
+const EMPTY_UNSUPPORTED: PlatformUnsupportedFlags = {
+    git: false,
+    sqlite: false,
+    ffmpeg: false,
+};
+
+function readPlatformUnsupported(source: unknown): PlatformUnsupportedFlags {
+    const raw = (source as { platformUnsupported?: Partial<PlatformUnsupportedFlags> })
+        ?.platformUnsupported;
+    if (!raw) {
+        return EMPTY_UNSUPPORTED;
+    }
+    return {
+        git: raw.git === true,
+        sqlite: raw.sqlite === true,
+        ffmpeg: raw.ffmpeg === true,
+    };
+}
+
 function getInitialState(): InitialState | null {
     try {
         const data = (window as any).initialData;
@@ -45,6 +76,7 @@ function getInitialState(): InitialState | null {
                     sqlite: data.sqlite,
                     nativeSqliteAvailable: data.nativeSqliteAvailable ?? data.sqlite,
                     ffmpeg: data.ffmpeg ?? false,
+                    platformUnsupported: readPlatformUnsupported(data),
                 },
                 mode: data.mode === "status" ? "status" : "warnings",
                 audioToolMode: data.audioToolMode ?? "auto",
@@ -124,6 +156,7 @@ export const MissingToolsWarning: React.FC = () => {
                     sqlite: message.sqlite,
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
+                    platformUnsupported: readPlatformUnsupported(message),
                 });
                 setMode("warnings");
                 setRetrying(false);
@@ -134,6 +167,7 @@ export const MissingToolsWarning: React.FC = () => {
                     sqlite: message.sqlite,
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
+                    platformUnsupported: readPlatformUnsupported(message),
                 });
                 setAudioToolMode(message.audioToolMode ?? "auto");
                 setGitToolMode(message.gitToolMode ?? "auto");
@@ -148,6 +182,7 @@ export const MissingToolsWarning: React.FC = () => {
                     sqlite: message.sqlite,
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
+                    platformUnsupported: readPlatformUnsupported(message),
                 });
                 if (message.audioToolMode) {
                     setAudioToolMode(message.audioToolMode);
@@ -384,7 +419,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         && status.nativeGitAvailable && !isBuiltinMode(gitToolMode)
         && status.ffmpeg && !isBuiltinMode(audioToolMode);
 
-    const getToolState = (mode: string, nativeAvailable: boolean) => {
+    const getToolState = (mode: string, nativeAvailable: boolean, unsupported: boolean) => {
         const forced = isForced(mode);
         const usingBuiltIn = isBuiltinMode(mode) || !nativeAvailable;
         // Severity priority: a missing native binary is always an error
@@ -396,7 +431,8 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
             : isBuiltinMode(mode) ? "warning"
             : "ok";
         const statusLabel =
-            forced ? "Running Fallback Tools (locked)"
+            unsupported ? "Not available on this platform"
+            : forced ? "Running Fallback Tools (locked)"
             : nativeAvailable && !usingBuiltIn ? "Installed and Running Native Tools"
             : nativeAvailable && usingBuiltIn ? "Installed and Running Fallback Tools"
             : "Not Installed \u2013 Running Fallback Tools";
@@ -409,16 +445,18 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         // native binary isn't installed, the user should always be able to
         // install it (the download handler flips mode back to "auto" so the
         // newly-installed binary is actually used). Only force-builtin (admin
-        // lock) hides the option.
-        const showDownload = !forced && !nativeAvailable;
+        // lock) or an unsupported platform hides the option — on unsupported
+        // platforms the download can never succeed, so we render a passive
+        // "Not available" badge instead.
+        const showDownload = !forced && !nativeAvailable && !unsupported;
         const showToggle = forced || nativeAvailable;
 
         return { forced, usingBuiltIn, severity, statusLabel, toggleLabel, showDownload, showToggle };
     };
 
-    const sqlite = getToolState(sqliteToolMode, status.nativeSqliteAvailable);
-    const git = getToolState(gitToolMode, status.nativeGitAvailable);
-    const audio = getToolState(audioToolMode, status.ffmpeg);
+    const sqlite = getToolState(sqliteToolMode, status.nativeSqliteAvailable, status.platformUnsupported.sqlite);
+    const git = getToolState(gitToolMode, status.nativeGitAvailable, status.platformUnsupported.git);
+    const audio = getToolState(audioToolMode, status.ffmpeg, status.platformUnsupported.ffmpeg);
 
     return (
         <div className="flex items-center justify-center min-h-screen p-6">
@@ -444,15 +482,18 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                     <StatusCard
                         title={TOOL_INFO.sqlite.name}
                         description={
-                            sqlite.usingBuiltIn
-                                ? (status.sqlite ? TOOL_INFO.sqlite.descriptions.builtinActive : TOOL_INFO.sqlite.descriptions.missing)
-                                : TOOL_INFO.sqlite.descriptions.available
+                            status.platformUnsupported.sqlite
+                                ? "The native AI learning and search tools are not available on this platform. Codex is using its built-in fallback."
+                                : sqlite.usingBuiltIn
+                                    ? (status.sqlite ? TOOL_INFO.sqlite.descriptions.builtinActive : TOOL_INFO.sqlite.descriptions.missing)
+                                    : TOOL_INFO.sqlite.descriptions.available
                         }
                         severity={!status.sqlite && !sqlite.forced ? "error" : sqlite.severity}
-                        statusLabelOverride={!status.sqlite && !sqlite.forced ? undefined : sqlite.statusLabel}
+                        statusLabelOverride={!status.sqlite && !sqlite.forced && !status.platformUnsupported.sqlite ? undefined : sqlite.statusLabel}
                         isOnline={isOnline}
                         downloadState={downloadState.sqlite}
                         onDownload={sqlite.showDownload ? () => onDownloadTool("sqlite") : undefined}
+                        platformUnsupported={status.platformUnsupported.sqlite}
                         toggleLabel={sqlite.toggleLabel}
                         onToggle={sqlite.showToggle ? onToggleSqliteMode : undefined}
                         onDelete={deleteMode ? () => onDeleteTool("sqlite") : undefined}
@@ -464,15 +505,18 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                     <StatusCard
                         title={TOOL_INFO.git.name}
                         description={
-                            git.usingBuiltIn
-                                ? TOOL_INFO.git.descriptions.builtinActive
-                                : TOOL_INFO.git.descriptions.available
+                            status.platformUnsupported.git
+                                ? "Native sync tools are not available on this platform. Codex is using its built-in fallback; syncing and collaboration may be limited."
+                                : git.usingBuiltIn
+                                    ? TOOL_INFO.git.descriptions.builtinActive
+                                    : TOOL_INFO.git.descriptions.available
                         }
                         severity={git.severity}
                         statusLabelOverride={git.statusLabel}
                         isOnline={isOnline}
                         downloadState={downloadState.git}
                         onDownload={git.showDownload ? () => onDownloadTool("git") : undefined}
+                        platformUnsupported={status.platformUnsupported.git}
                         toggleLabel={git.toggleLabel}
                         onToggle={git.showToggle ? onToggleGitMode : undefined}
                         toggleDisabled={syncInProgress}
@@ -486,15 +530,18 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                     <StatusCard
                         title={TOOL_INFO.ffmpeg.name}
                         description={
-                            audio.usingBuiltIn
-                                ? TOOL_INFO.ffmpeg.descriptions.limited
-                                : TOOL_INFO.ffmpeg.descriptions.available
+                            status.platformUnsupported.ffmpeg
+                                ? "Native audio tools are not available on this platform. Codex is using its built-in fallback with limited format support (.wav only)."
+                                : audio.usingBuiltIn
+                                    ? TOOL_INFO.ffmpeg.descriptions.limited
+                                    : TOOL_INFO.ffmpeg.descriptions.available
                         }
                         severity={audio.severity}
                         statusLabelOverride={audio.statusLabel}
                         isOnline={isOnline}
                         downloadState={downloadState.ffmpeg}
                         onDownload={audio.showDownload ? () => onDownloadTool("ffmpeg") : undefined}
+                        platformUnsupported={status.platformUnsupported.ffmpeg}
                         toggleLabel={audio.toggleLabel}
                         onToggle={audio.showToggle ? onToggleAudioMode : undefined}
                         toggleDisabled={audioProcessingInProgress}
@@ -769,6 +816,13 @@ interface StatusCardProps {
      */
     downloadState?: "idle" | "downloading" | "failed";
     onDownload?: () => void;
+    /**
+     * When true, the download button is suppressed entirely and a passive
+     * "Not available on this platform" indicator is shown in its place.
+     * The current OS/arch has no prebuilt native asset, so attempting a
+     * download would be a guaranteed no-op.
+     */
+    platformUnsupported?: boolean;
     toggleLabel?: string;
     onToggle?: () => void;
     toggleDisabled?: boolean;
@@ -787,6 +841,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
     isOnline = true,
     downloadState = "idle",
     onDownload,
+    platformUnsupported = false,
     toggleLabel,
     onToggle,
     toggleDisabled = false,
@@ -848,6 +903,19 @@ const StatusCard: React.FC<StatusCardProps> = ({
                     {description}
                 </p>
                 <div className="flex items-center gap-2 flex-wrap">
+                    {platformUnsupported && (
+                        <span
+                            className="inline-flex items-center h-7 px-2 text-xs rounded border"
+                            style={{
+                                color: "var(--muted-foreground)",
+                                borderColor: "var(--border)",
+                                backgroundColor: "var(--muted)",
+                            }}
+                        >
+                            <i className="codicon codicon-circle-slash mr-1.5" />
+                            Not available on this platform
+                        </span>
+                    )}
                     {onDownload && (
                         !isOnline && !downloading ? (
                             <Tooltip>

--- a/webviews/codex-webviews/src/StartupFlow/types.ts
+++ b/webviews/codex-webviews/src/StartupFlow/types.ts
@@ -193,6 +193,12 @@ export interface FrontierAPI {
     isGitBinaryAvailable?: () => boolean;
     /** Returns true when git operations can succeed (native binary OR isomorphic-git fallback). */
     isGitAvailable?: () => boolean;
+    /**
+     * Returns true when the current OS/arch has a prebuilt dugite-native
+     * asset in the release we pin to. When false, any "Download and install"
+     * UI should be hidden — the download can never succeed on this platform.
+     */
+    isGitBinaryNativelySupported?: () => boolean;
     retryGitBinaryDownload?: () => Promise<boolean>;
     /** Delete the downloaded git binary directory so it is re-downloaded on next reload. */
     deleteGitBinary?: () => Promise<boolean>;


### PR DESCRIPTION
# Binary Management Overhaul

## Test Project: 905-Binaries-in-versioned-folders-and-fixing-download-options-retries-and-more-mkhzc7shy0ngueqdt4eq39

## Summary

Brings SQLite and FFmpeg binary storage in line with the already-versioned Git binary, introduces a consistent per-session retry system across all three tools, and overhauls the "Tools Status" webview UI. The cross-session `globalState` retry counters that permanently blocked re-download attempts have been removed.

---

## codex-editor — `binaries-in-versioned-folders`

### Changes

**Versioned storage & migration**
- `sqliteNativeBinaryManager.ts`: Binaries now stored at `{globalStorage}/sqlite3-native/{SQLITE3_VERSION}/node_sqlite3.node`. On first run, any existing flat binary is migrated into the versioned subfolder rather than re-downloaded.
- `ffmpegManager.ts`: Same pattern — `{globalStorage}/ffmpeg/{platform-version}/ffmpeg`. Migration reads the version from `PLATFORM_MAP`, not from `ffmpeg -version` output (which can differ from the package version).

**Consistent retry logic**
- All three tools now run up to `MAX_FULL_RETRIES = 2` full download attempts per session with exponential backoff and detailed progress notifications.
- Removed the `globalState`-backed `binaryRetryCount.*` counter system entirely from `binaryIntegrityUtils.ts`. Tools that previously exhausted their persistent counter and silently stopped retrying will now attempt a fresh download on every extension activation.

**Startup behavior**
- `extension.ts`: The "Tools Status" webview no longer auto-opens on startup. A `showErrorMessage` toast is shown only for critical SQLite failures.
- Tool status logging now reports one of five distinct states: `native`, `available but using fallback`, `missing and using fallback`, `available but forced to fallback`, `missing and forced to fallback`.

**Tools Status UI (`MissingToolsWarning.tsx` / `MissingToolsWarningProvider.ts`)**
- Download button uses a state machine: `idle → downloading → (Attempt N / failed) → idle`.
- A tool in `builtin` mode with a missing native binary now shows `error` severity and a visible "Download and Install" button (previously it was hidden).
- On a successful download, the tool mode auto-switches from `builtin` → `auto` so the newly installed binary is used immediately without a manual settings change.

**Types**
- `types/index.d.ts` and `StartupFlow/types.ts` updated for new tool state and download result message shapes.

---

## frontier-authentication — `git-overhaul`

### Changes

**New `gitBinaryManager.ts`**
- Downloads and manages the `dugite-native` Git binary at `{globalStorage}/git/{DUGITE_NATIVE_TAG}/`.
- Verifies integrity via SHA-256 marker file on every startup.
- `MAX_FULL_RETRIES = 2` outer retry loop with exponential backoff, plus separate `MAX_API_ATTEMPTS = 2` and `MAX_DOWNLOAD_ATTEMPTS = 2` for the GitHub API and tarball fetch.
- All cross-session retry counter logic removed; `deleteGitBinary` and `retryGitBinaryDownload` no longer call any reset functions.

**Native + fallback Git routing**
- `dugiteGitNative.ts`: Full native git implementation via `dugite`.
- `isomorphicGitAdapter.ts`: Isomorphic-git fallback for when the native binary is unavailable.
- `dugiteGit.ts`: Router that selects native vs. fallback at runtime.

**Offline handling**
- Connectivity check changed from `api.github.com` (which returns non-`ok` under rate limiting, treating it as offline) to `github.com`, with timeout increased to 5 s.

---

## Testing Checklist

### Binary versioning & migration
- [ ] Fresh install: SQLite, FFmpeg, and Git binaries download into their versioned subfolders (`sqlite3-native/5.1.7/`, `ffmpeg/4.1.5/`, `git/v2.47.3-1/`)
- [ ] Upgrade simulation: manually place a binary in the old flat location; confirm it is moved (not re-downloaded) to the versioned folder on activation
- [ ] Version mismatch: corrupt or delete `version.txt` inside a versioned folder; confirm a re-download is triggered

### Retry behavior
- [ ] With no network, confirm each tool attempts the download exactly 2 times before giving up, then tries again on the next activation (no permanent block)
- [ ] With network restored after a failure, confirm a full download succeeds on the next activation without needing a manual trigger

### Tools Status UI
- [ ] With all tools missing, confirm "Download and Install" buttons are visible for all three tools
- [ ] Click a download button; confirm the button cycles through `Attempt 1 of 2`, `Download Failed` (on failure), back to `Download and Install`
- [ ] After a successful download, confirm the tool's mode switches from `builtin` → `auto` and severity updates without reloading
- [ ] Confirm the webview does NOT auto-open on startup; a toast appears only for a critical SQLite failure

### Tool status logging
- [ ] Confirm log line reports `native` when binary is present and mode is `auto`
- [ ] Confirm log line reports `available but using fallback` when binary exists but mode is `builtin`
- [ ] Confirm log line reports `missing and using fallback` when binary is absent and mode is `auto`

### Git binary (frontier-authentication)
- [ ] On a clean machine, Git binary downloads to `{globalStorage}/git/v2.47.3-1/`
- [ ] `git --version` executes correctly from the installed path
- [ ] With the native binary absent, isomorphic-git fallback handles basic sync operations
- [ ] Offline at startup: download is skipped cleanly with no hang; retry succeeds when back online