### PR TITLE
Prevent requiredExtensions ratchet during Conductor pin-sync window

### DIFF
--- a/src/test/suite/metadataManager.test.ts
+++ b/src/test/suite/metadataManager.test.ts
@@ -291,6 +291,173 @@ suite('MetadataManager Tests', () => {
             assert.strictEqual(versions.versions?.codexEditor, '0.22.90');       // suppressed
             assert.strictEqual(versions.versions?.frontierAuthentication, '0.4.25'); // ratcheted
         });
+
+        suite('Conductor-effective pins (mid-sync window)', () => {
+            const CONDUCTOR_CMD = 'codex.conductor.getEffectivePinnedExtensions';
+            type PinMap = Record<string, { version: string; url?: string; }> | undefined;
+            let originalExecuteCommand: typeof vscode.commands.executeCommand;
+            let conductorResponse: PinMap | (() => Promise<PinMap>) | 'throw';
+
+            setup(() => {
+                originalExecuteCommand = vscode.commands.executeCommand;
+                conductorResponse = undefined;
+                (vscode.commands as any).executeCommand = async (cmd: string, ...args: any[]) => {
+                    if (cmd === CONDUCTOR_CMD) {
+                        if (conductorResponse === 'throw') {
+                            throw new Error('Conductor unavailable (test stub)');
+                        }
+                        return typeof conductorResponse === 'function'
+                            ? await conductorResponse()
+                            : conductorResponse;
+                    }
+                    return originalExecuteCommand.call(vscode.commands, cmd, ...args);
+                };
+            });
+
+            teardown(() => {
+                (vscode.commands as any).executeCommand = originalExecuteCommand;
+            });
+
+            test('Conductor pin suppresses ratchet when disk has no pinnedExtensions (bug repro)', async () => {
+                // Simulates the post-reload, pre-merge window: metadata.json on disk has
+                // no pinnedExtensions, but Conductor storage has the remote pin.
+                const initial = {
+                    meta: { requiredExtensions: { codexEditor: '0.24.0' } }
+                };
+                await vscode.workspace.fs.writeFile(metadataPath,
+                    new TextEncoder().encode(JSON.stringify(initial, null, 4)));
+
+                conductorResponse = {
+                    'project-accelerate.codex-editor-extension': {
+                        version: '0.28.5',
+                        url: 'https://example.invalid/ext.vsix'
+                    }
+                };
+
+                const result = await MetadataManager.updateExtensionVersions(testWorkspaceUri, {
+                    codexEditor: '0.28.5'
+                });
+
+                assert.strictEqual(result.success, true);
+                const versions = await MetadataManager.getExtensionVersions(testWorkspaceUri);
+                // Must NOT have ratcheted — Conductor says this ext is pinned.
+                assert.strictEqual(versions.versions?.codexEditor, '0.24.0');
+            });
+
+            test('Conductor throws → falls back to on-disk pins', async () => {
+                const initial = {
+                    meta: {
+                        requiredExtensions: { codexEditor: '0.22.90' },
+                        pinnedExtensions: {
+                            'project-accelerate.codex-editor-extension': { version: '0.22.90', url: '' }
+                        }
+                    }
+                };
+                await vscode.workspace.fs.writeFile(metadataPath,
+                    new TextEncoder().encode(JSON.stringify(initial, null, 4)));
+
+                conductorResponse = 'throw';
+
+                const result = await MetadataManager.updateExtensionVersions(testWorkspaceUri, {
+                    codexEditor: '0.22.91'
+                });
+
+                assert.strictEqual(result.success, true);
+                const versions = await MetadataManager.getExtensionVersions(testWorkspaceUri);
+                // Suppressed via on-disk fallback pin.
+                assert.strictEqual(versions.versions?.codexEditor, '0.22.90');
+            });
+
+            test('Conductor returns empty object and disk has no pins → ratchet proceeds', async () => {
+                const initial = {
+                    meta: { requiredExtensions: { codexEditor: '0.22.0' } }
+                };
+                await vscode.workspace.fs.writeFile(metadataPath,
+                    new TextEncoder().encode(JSON.stringify(initial, null, 4)));
+
+                conductorResponse = {};
+
+                const result = await MetadataManager.updateExtensionVersions(testWorkspaceUri, {
+                    codexEditor: '0.22.91'
+                });
+
+                assert.strictEqual(result.success, true);
+                const versions = await MetadataManager.getExtensionVersions(testWorkspaceUri);
+                assert.strictEqual(versions.versions?.codexEditor, '0.22.91');
+            });
+
+            test('Conductor state flipped while queued → uses fresh pins (race guard)', async () => {
+                // Reproduces the race where updateExtensionVersions snapshots the
+                // Conductor *before* acquiring the per-workspace write queue slot.
+                // If another write is ahead of us in the queue, the Conductor state
+                // can change between our snapshot and our callback running. The
+                // callback must read pins fresh inside the queue.
+                const initial = {
+                    meta: { requiredExtensions: { codexEditor: '0.24.0' } }
+                };
+                await vscode.workspace.fs.writeFile(metadataPath,
+                    new TextEncoder().encode(JSON.stringify(initial, null, 4)));
+
+                // Conductor starts unpinned.
+                conductorResponse = {};
+
+                // Hold the queue with a slow write we control.
+                let releaseSlowWrite: () => void = () => { };
+                const slowWritePromise = MetadataManager.safeUpdateMetadata(
+                    testWorkspaceUri,
+                    async (m: any) => {
+                        await new Promise<void>(resolve => { releaseSlowWrite = resolve; });
+                        return m;
+                    }
+                );
+
+                // Kick off the ratchet call. It queues behind the slow write.
+                const updatePromise = MetadataManager.updateExtensionVersions(
+                    testWorkspaceUri,
+                    { codexEditor: '0.28.5' }
+                );
+
+                // Simulate Frontier flipping Conductor storage to "pinned" while
+                // the ratchet call is parked in the queue.
+                await new Promise(resolve => setTimeout(resolve, 20));
+                conductorResponse = {
+                    'project-accelerate.codex-editor-extension': { version: '0.28.5', url: '' }
+                };
+
+                // Release the queue; the ratchet callback now runs and MUST see
+                // the current Conductor state, not the stale pre-queue snapshot.
+                releaseSlowWrite();
+                await slowWritePromise;
+                await updatePromise;
+
+                const versions = await MetadataManager.getExtensionVersions(testWorkspaceUri);
+                assert.strictEqual(versions.versions?.codexEditor, '0.24.0');
+            });
+
+            test('Conductor pins only frontier → codexEditor still ratchets', async () => {
+                const initial = {
+                    meta: {
+                        requiredExtensions: { codexEditor: '0.24.0', frontierAuthentication: '0.4.0' }
+                    }
+                };
+                await vscode.workspace.fs.writeFile(metadataPath,
+                    new TextEncoder().encode(JSON.stringify(initial, null, 4)));
+
+                conductorResponse = {
+                    'frontier-rnd.frontier-authentication': { version: '0.4.0', url: '' }
+                };
+
+                const result = await MetadataManager.updateExtensionVersions(testWorkspaceUri, {
+                    codexEditor: '0.28.5',
+                    frontierAuthentication: '0.4.25'
+                });
+
+                assert.strictEqual(result.success, true);
+                const versions = await MetadataManager.getExtensionVersions(testWorkspaceUri);
+                assert.strictEqual(versions.versions?.codexEditor, '0.28.5');          // ratcheted
+                assert.strictEqual(versions.versions?.frontierAuthentication, '0.4.0'); // suppressed
+            });
+        });
     });
 
     suite('User version tracking (users array)', () => {

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -52,6 +52,9 @@ interface MetadataUpdateOptions {
     author?: string;
 }
 
+type PinEntry = { version: string; url?: string; };
+type PinMap = Record<string, PinEntry>;
+
 export class MetadataManager {
     /**
      * Track pending write operations to ensure they complete before critical operations
@@ -307,10 +310,38 @@ export class MetadataManager {
     }
 
     /**
+     * Returns the currently effective pin map. Prefers the Conductor (which
+     * resolves admin intent → remote pins in workspace storage → on-disk
+     * metadata.json), and falls back to `fallbackPins` when the Conductor
+     * command is unavailable (older Codex shell) or returns undefined.
+     *
+     * Ratchet suppression must consult this, not metadata.json on disk alone,
+     * because during a pin-sync cycle Frontier writes remote pins to the
+     * Conductor's storage and aborts the merge before metadata.json lands on
+     * disk. Reading disk pins in that window would miss the active pin and
+     * inflate requiredExtensions.
+     */
+    private static async getEffectivePinnedExtensions(
+        fallbackPins?: PinMap
+    ): Promise<PinMap> {
+        try {
+            const pins = await vscode.commands.executeCommand<PinMap | undefined>(
+                "codex.conductor.getEffectivePinnedExtensions"
+            );
+            if (pins) {
+                return pins;
+            }
+        } catch {
+            // Conductor command not registered (older Codex shell or non-Codex host) — fall back.
+        }
+        return fallbackPins ?? {};
+    }
+
+    /**
      * Update extension versions in metadata.json
      * This is the main entry point for both codex-editor internal use
      * and for frontier-authentication (via command)
-     * 
+     *
      * IMPORTANT: Only updates if the new version is greater than or equal to the existing version.
      * This prevents downgrading versions (e.g., if someone with an older extension opens the project).
      */
@@ -323,7 +354,7 @@ export class MetadataManager {
     ): Promise<{ success: boolean; error?: string }> {
         const result = await this.safeUpdateMetadata<ProjectMetadata>(
             workspaceUri,
-            (metadata) => {
+            async (metadata) => {
                 if (!metadata.meta) {
                     metadata.meta = {};
                 }
@@ -331,8 +362,14 @@ export class MetadataManager {
                     metadata.meta.requiredExtensions = {};
                 }
 
-                const pinnedExtensions: Record<string, { version: string; url: string }> =
-                    metadata.meta.pinnedExtensions ?? {};
+                // Resolve effective pins INSIDE the queued callback — after the
+                // per-workspace write queue slot is acquired. Querying before the
+                // queue would snapshot Conductor state too early; a Frontier sync
+                // could update pins while we're waiting behind another write, and
+                // the stale {} snapshot would ratchet anyway.
+                const pinnedExtensions = await this.getEffectivePinnedExtensions(
+                    metadata.meta.pinnedExtensions
+                );
 
                 // Only update codexEditor if new version is greater or missing,
                 // AND no codex-editor pin is active (the Conductor owns the floor while active).
@@ -419,8 +456,13 @@ export class MetadataManager {
             const existingVersions = result.metadata?.meta?.requiredExtensions || {};
             const versionsToUpdate: { codexEditor?: string; frontierAuthentication?: string } = {};
 
-            // Suppress ratchet if a pin exists (The Conductor is in charge)
-            const pinnedExtensions = result.metadata?.meta?.pinnedExtensions || {};
+            // Suppress ratchet if a pin exists (the Conductor is in charge). Query the
+            // Conductor for the authoritative pin set so we correctly suppress during
+            // the pin-sync window where remote pins are live in Conductor storage but
+            // metadata.json on disk has not yet merged.
+            const pinnedExtensions = await this.getEffectivePinnedExtensions(
+                result.metadata?.meta?.pinnedExtensions
+            );
 
             // Check codexEditor - update if missing or if installed version is newer
             if (codexEditorVersion && !pinnedExtensions['project-accelerate.codex-editor-extension']) {


### PR DESCRIPTION
Prevent requiredExtensions from ratcheting up to a Conductor-pinned version during the mid-sync window when metadata.json on disk has no pinnedExtensions yet.

The ratchet suppression in `MetadataManager` read `pinnedExtensions` from `metadata.json` on disk. Per the pin-enforcement design (Scenario 2 in `codex-arch/2026-03-pin-enforcement-scenarios.md`), Frontier writes remote pins into the Conductor's workspace storage and **aborts the merge** before disk is updated. After the user reloads into the pinned profile, the running version matches the pin and `codex-editor` activates normally — but `metadata.json` on disk still has no `pinnedExtensions`. The ratchet guard saw no pin and bumped `requiredExtensions` up to the running (pinned) version. When the pin was later removed and the user reverted to Default, the inflated `requiredExtensions` blocked sync indefinitely.

The Conductor already exposes `codex.conductor.getEffectivePinnedExtensions` (admin intent → remote pins in storage → on-disk fallback) and is consumed by `failsPinMatchGate` and Frontier's sync gate. The ratchet now consults the same source.

## Changes

- Add `MetadataManager.getEffectivePinnedExtensions()` helper that queries the Conductor command and falls back to a caller-supplied disk pin map (covers older Codex shells without the command registered).
- `ensureExtensionVersionsRecorded`: use the helper for its short-circuit pin check.
- `updateExtensionVersions`: query the Conductor **inside** the `safeUpdateMetadata` queued callback so the pin snapshot reflects state after the per-workspace write-queue slot is acquired. Fixes a race where a Frontier write between the pre-queue snapshot and the actual write would still inflate `requiredExtensions`.
- Extend the "Pin-aware ratchet" test suite with a `vscode.commands.executeCommand` stub and 5 new cases:
  - Conductor-only pin suppresses ratchet when disk has no pins (bug repro).
  - Conductor throws → falls back to on-disk pins.
  - Conductor returns `{}` and disk has no pins → ratchet proceeds.
  - Conductor pins only frontier → codexEditor still ratchets.
  - Race guard: holds a slow `safeUpdateMetadata` open, enqueues `updateExtensionVersions` behind it, flips the Conductor stub mid-wait, asserts no ratchet.

Existing broken projects (already-inflated `requiredExtensions` on origin) are out of scope. Manual admin edit of `metadata.json` is the unblock; a separate `-pr` suffix fail-open in Frontier's sync gate is being considered for the PR-pin majority case.

## Test plan

- [ ] `npm run compile` clean (modulo the pre-existing `dugite` module-resolution error unrelated to this change).
- [ ] `npm run test` — new "Conductor-effective pins" sub-suite passes; existing Pin-aware ratchet cases still pass.
- [x] Manual E2E reproducing the user-reported flow:
  - Open project with no pins on Default profile (codex-editor v0.24.0). Confirm `requiredExtensions.codexEditor === "0.24.0"`.
  - Admin pins to v0.28.5, pushes.
  - User syncs → Frontier "sync paused" notification + Conductor "Reload Codex" prompt. `metadata.json` on disk unchanged.
  - Reload into the v0.28.5 profile. Inspect `metadata.json`: `requiredExtensions.codexEditor` is still \`"0.24.0"\` (pre-fix: inflated to \`"0.28.5"\`).
  - Sync completes; `pinnedExtensions` lands on disk; `requiredExtensions.codexEditor` still \`"0.24.0"\`.
  - Admin removes pins, user syncs, reloads to Default.
  - Subsequent sync passes: required \`0.24.0\` ≤ installed \`0.24.0\`.