### PR TITLE
902 start translating button should open the imported file

### DIFF
--- a/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
+++ b/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
@@ -31,6 +31,8 @@ import { processNewlyImportedFiles } from "../../projectManager/utils/migrationU
 import { migrateLocalizedBooksToMetadata as migrateLocalizedBooks } from "./localizedBooksMigration/localizedBooksMigration";
 import { removeLocalizedBooksJsonIfPresent as removeLocalizedBooksJson } from "./localizedBooksMigration/removeLocalizedBooksJson";
 import { getAttachmentDocumentSegmentFromUri } from "../../utils/attachmentFolderUtils";
+import { MetadataManager } from "../../utils/metadataManager";
+import { openCodexDocumentWithSourcePair } from "../../utils/openCodexDocumentWithSourcePair";
 // import { parseRtfWithPandoc as parseRtfNode } from "../../../webviews/codex-webviews/src/NewSourceUploader/importers/rtf/pandocNodeBridge";
 
 const execAsync = promisify(exec);
@@ -704,13 +706,10 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                         });
                     }
                 } else if (message.command === "startTranslating") {
-                    // Handle start translating - same as Welcome View's "Open Translation File"
-
+                    // Fallback: focus the navigation view and close the upload panel.
+                    // Used when no specific imported file is available to open.
                     try {
-                        // Focus the navigation view (same as Welcome View's handleOpenTranslationFile)
                         await vscode.commands.executeCommand("codex-editor.navigation.focus");
-
-                        // Close the current webview panel
                         webviewPanel.dispose();
                     } catch (error) {
                         console.error("Error opening navigation:", error);
@@ -718,6 +717,30 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                             command: "notification",
                             type: "error",
                             message: error instanceof Error ? error.message : "Failed to open navigation"
+                        });
+                    }
+                } else if (message.command === "openImportedFile") {
+                    // Open the just-imported codex file (with its source pair) in split view,
+                    // then close the upload panel.
+                    try {
+                        const codexUriString = (message as { codexUri?: string }).codexUri;
+                        if (!codexUriString) {
+                            await vscode.commands.executeCommand("codex-editor.navigation.focus");
+                            webviewPanel.dispose();
+                            return;
+                        }
+                        const codexUri = vscode.Uri.file(codexUriString);
+                        await openCodexDocumentWithSourcePair(
+                            codexUri,
+                            vscode.workspace.workspaceFolders?.[0]?.uri
+                        );
+                        webviewPanel.dispose();
+                    } catch (error) {
+                        console.error("Error opening imported file:", error);
+                        webviewPanel.webview.postMessage({
+                            command: "notification",
+                            type: "error",
+                            message: error instanceof Error ? error.message : "Failed to open imported file"
                         });
                     }
                 } else if (message.command === "selectAudioFile") {
@@ -846,10 +869,11 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                         });
                     }
                 } else if (message.command === "systemMessage.save") {
-                    // Save system message to metadata
+                    // Save system message to metadata and mark the AI instructions step
+                    // as completed so future imports skip the SystemMessageStep.
                     try {
-                        const { MetadataManager } = await import("../../utils/metadataManager");
                         await MetadataManager.setChatSystemMessage(message.message);
+                        await MetadataManager.setAIInstructionsCompleted(true);
                         webviewPanel.webview.postMessage({
                             command: "systemMessage.saved",
                         });
@@ -1316,7 +1340,14 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
             );
         }
 
-        webviewPanel.webview.postMessage({ command: "importComplete" });
+        const importedCodexUris = createdFiles.map(f => f.codexUri.fsPath);
+        const aiInstructionsCompleted = await MetadataManager.getAIInstructionsCompleted();
+
+        webviewPanel.webview.postMessage({
+            command: "importComplete",
+            importedCodexUris,
+            aiInstructionsCompleted,
+        });
     }
 
     /**
@@ -1617,6 +1648,15 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         webviewPanel.webview.postMessage({ command: "notification", type: "success", message: "Notebooks and attachments created successfully!" });
         const inventory = await this.fetchProjectInventory();
         webviewPanel.webview.postMessage({ command: "projectInventory", inventory });
+
+        const importedCodexUris = createdFiles.map(f => f.codexUri.fsPath);
+        const aiInstructionsCompleted = await MetadataManager.getAIInstructionsCompleted();
+
+        webviewPanel.webview.postMessage({
+            command: "importComplete",
+            importedCodexUris,
+            aiInstructionsCompleted,
+        });
     }
 
     /**

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -15,6 +15,7 @@ import { getAuthApi } from "../../extension";
 import { CustomNotebookMetadata, ProjectMetadata } from "../../../types";
 import { getCorrespondingSourceUri, findCodexFilesByBookAbbr } from "../../utils/codexNotebookUtils";
 import { CodexCellEditorProvider } from "../codexCellEditorProvider/codexCellEditorProvider";
+import { openCodexDocumentWithSourcePair } from "../../utils/openCodexDocumentWithSourcePair";
 
 interface CodexMetadata {
     id: string;
@@ -111,71 +112,10 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                     const uri = vscode.Uri.file(normalizedPath);
 
                     if (message.type === "codexDocument") {
-                        // First, find and open the corresponding source file
-                        try {
-                            const workspaceFolderUri =
-                                vscode.workspace.workspaceFolders?.[0].uri;
-                            if (workspaceFolderUri) {
-                                const baseFileName = path.basename(normalizedPath);
-                                const sourceFileName = baseFileName.replace(
-                                    ".codex",
-                                    ".source"
-                                );
-                                const sourceUri = vscode.Uri.joinPath(
-                                    workspaceFolderUri,
-                                    ".project",
-                                    "sourceTexts",
-                                    sourceFileName
-                                );
-
-                                // Open the source file in the left-most group (ViewColumn.One)
-                                await vscode.commands.executeCommand(
-                                    "vscode.openWith",
-                                    sourceUri,
-                                    "codex.cellEditor",
-                                    { viewColumn: vscode.ViewColumn.One }
-                                );
-
-                                // Wait for source webview to be ready before opening target
-                                try {
-                                    const { CodexCellEditorProvider } = await import("../codexCellEditorProvider/codexCellEditorProvider");
-                                    const provider = CodexCellEditorProvider.getInstance();
-                                    if (provider) {
-                                        await provider.waitForWebviewReady(sourceUri.toString(), 3000);
-                                    } else {
-                                        // Fallback: small delay if provider not yet initialized
-                                        await new Promise(resolve => setTimeout(resolve, 100));
-                                    }
-                                } catch (e) {
-                                    // Fallback: small delay on error
-                                    await new Promise(resolve => setTimeout(resolve, 100));
-                                }
-
-                                // Open the codex file in the right-most group (ViewColumn.Two)
-                                await vscode.commands.executeCommand(
-                                    "vscode.openWith",
-                                    uri,
-                                    "codex.cellEditor",
-                                    { viewColumn: vscode.ViewColumn.Two }
-                                );
-                            } else {
-                                // Fallback if no workspace folder is found
-                                await vscode.commands.executeCommand(
-                                    "vscode.openWith",
-                                    uri,
-                                    "codex.cellEditor"
-                                );
-                            }
-                        } catch (sourceError) {
-                            console.warn("Could not open source file:", sourceError);
-                            // If source file opening fails, just open the codex file in the right-most group
-                            await vscode.commands.executeCommand(
-                                "vscode.openWith",
-                                uri,
-                                "codex.cellEditor",
-                                { viewColumn: vscode.ViewColumn.Two }
-                            );
-                        }
+                        await openCodexDocumentWithSourcePair(
+                            uri,
+                            vscode.workspace.workspaceFolders?.[0]?.uri
+                        );
                     } else {
                         const doc = await vscode.workspace.openTextDocument(uri);
                         await vscode.window.showTextDocument(doc);

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -24,6 +24,7 @@ interface ProjectMetadata {
     edits?: any[];
     users?: ProjectUserVersionEntry[];
     chatSystemMessage?: string;
+    aiInstructionsCompleted?: boolean;
     [key: string]: unknown;
 }
 
@@ -609,6 +610,80 @@ export class MetadataManager {
                         metadata.edits = [];
                     }
                     addProjectMetadataEdit(metadata, ["chatSystemMessage"], value, currentAuthor);
+                }
+
+                return metadata;
+            },
+            { author: currentAuthor }
+        );
+
+        return { success: result.success, error: result.error };
+    }
+
+    /**
+     * Get aiInstructionsCompleted flag from metadata.json. Indicates whether the user
+     * has completed the one-time AI translation instructions / system message setup
+     * for this project. Defaults to false.
+     */
+    static async getAIInstructionsCompleted(workspaceFolderUri?: vscode.Uri): Promise<boolean> {
+        const workspaceFolder = workspaceFolderUri || vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!workspaceFolder) {
+            return false;
+        }
+
+        const result = await this.safeReadMetadata<ProjectMetadata>(workspaceFolder);
+
+        if (result.success && result.metadata) {
+            return Boolean((result.metadata as any).aiInstructionsCompleted);
+        }
+
+        return false;
+    }
+
+    /**
+     * Set aiInstructionsCompleted flag in metadata.json with edit tracking.
+     */
+    static async setAIInstructionsCompleted(
+        value: boolean,
+        workspaceFolderUri?: vscode.Uri,
+        author?: string
+    ): Promise<{ success: boolean; error?: string }> {
+        const workspaceFolder = workspaceFolderUri || vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!workspaceFolder) {
+            return { success: false, error: "No workspace folder found" };
+        }
+
+        let currentAuthor = author;
+        if (!currentAuthor) {
+            try {
+                const { getAuthApi } = await import("../extension");
+                const authApi = await getAuthApi();
+                const userInfo = await authApi?.getUserInfo();
+                if (userInfo?.username) {
+                    currentAuthor = userInfo.username;
+                }
+            } catch (error) {
+                // Silent fallback
+            }
+            currentAuthor = currentAuthor || "unknown";
+        }
+
+        const result = await this.safeUpdateMetadata<ProjectMetadata>(
+            workspaceFolder,
+            (metadata) => {
+                const original = (metadata as any).aiInstructionsCompleted;
+                (metadata as any).aiInstructionsCompleted = value;
+
+                if (original !== value) {
+                    if (!metadata.edits) {
+                        metadata.edits = [];
+                    }
+                    addProjectMetadataEdit(
+                        metadata,
+                        ["aiInstructionsCompleted"],
+                        value,
+                        currentAuthor
+                    );
                 }
 
                 return metadata;

--- a/src/utils/openCodexDocumentWithSourcePair.ts
+++ b/src/utils/openCodexDocumentWithSourcePair.ts
@@ -1,0 +1,65 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+/**
+ * Opens the paired source (.source) and target (.codex) notebooks in split editors
+ * (source in ViewColumn.One, target in ViewColumn.Two). Matches navigation webview behavior.
+ */
+export async function openCodexDocumentWithSourcePair(
+    codexUri: vscode.Uri,
+    workspaceFolderUri: vscode.Uri | undefined
+): Promise<void> {
+    const normalizedPath = codexUri.fsPath.replace(/\\/g, "/");
+
+    if (!workspaceFolderUri) {
+        await vscode.commands.executeCommand("vscode.openWith", codexUri, "codex.cellEditor");
+        return;
+    }
+
+    try {
+        const baseFileName = path.basename(normalizedPath);
+        const sourceFileName = baseFileName.replace(".codex", ".source");
+        const sourceUri = vscode.Uri.joinPath(
+            workspaceFolderUri,
+            ".project",
+            "sourceTexts",
+            sourceFileName
+        );
+
+        await vscode.commands.executeCommand(
+            "vscode.openWith",
+            sourceUri,
+            "codex.cellEditor",
+            { viewColumn: vscode.ViewColumn.One }
+        );
+
+        try {
+            const { CodexCellEditorProvider } = await import(
+                "../providers/codexCellEditorProvider/codexCellEditorProvider"
+            );
+            const provider = CodexCellEditorProvider.getInstance();
+            if (provider) {
+                await provider.waitForWebviewReady(sourceUri.toString(), 3000);
+            } else {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+            }
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        await vscode.commands.executeCommand(
+            "vscode.openWith",
+            codexUri,
+            "codex.cellEditor",
+            { viewColumn: vscode.ViewColumn.Two }
+        );
+    } catch (sourceError) {
+        console.warn("Could not open source file:", sourceError);
+        await vscode.commands.executeCommand(
+            "vscode.openWith",
+            codexUri,
+            "codex.cellEditor",
+            { viewColumn: vscode.ViewColumn.Two }
+        );
+    }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -992,6 +992,8 @@ type ProjectUserVersionEntry = {
 type ProjectMetadata = {
     projectName?: string;
     projectId?: string;
+    /** Set to true once the user has completed the AI translation instructions / system message setup for this project. Used to gate the SystemMessageStep so it is only shown once. */
+    aiInstructionsCompleted?: boolean;
     format: string;
     /** Registry of original imported files (hash, fileName, referencedBy) - stored in metadata.json for sync/merge */
     originalFilesHashes?: {

--- a/webviews/codex-webviews/src/NewSourceUploader/NewSourceUploader.startTranslating.test.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/NewSourceUploader.startTranslating.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * Covers the NewSourceUploader flow: the "AI Translation Instructions" step (system message
+ * with generate / save), appearing on "Start Translating" when AI project setup is incomplete;
+ * skipping to open the codex when setup is complete; and using the latest import URI after a
+ * second import ("Import More Files").
+ */
+import React from "react";
+import { render, screen, waitFor, act, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom";
+import type { NotebookPair } from "./types/common";
+import type { ProcessedNotebookMetadata } from "./types/processedNotebookMetadata";
+import type { ImporterComponentProps, ImporterPlugin } from "./types/plugin";
+
+/** Minimal valid pair for exercising `handleComplete` / provider messages in tests. */
+function stubNotebookPair(): NotebookPair {
+    const metadata = (overrides: { id: string; sourceFile: string }): ProcessedNotebookMetadata =>
+        ({
+            id: overrides.id,
+            originalFileName: "BookA",
+            sourceFile: overrides.sourceFile,
+            importerType: "plaintext",
+            createdAt: "2020-01-01T00:00:00.000Z",
+        }) as ProcessedNotebookMetadata;
+
+    return {
+        source: { name: "BookA", cells: [], metadata: metadata({ id: "stub-src", sourceFile: "BookA.source" }) },
+        codex: { name: "BookA", cells: [], metadata: metadata({ id: "stub-cdx", sourceFile: "BookA.codex" }) },
+    };
+}
+
+const hoisted = vi.hoisted(() => {
+    const TestImporter = (props: ImporterComponentProps) => (
+        <button
+            type="button"
+            data-testid="mock-import-complete"
+            onClick={() => {
+                if (!props.onComplete) {
+                    throw new Error("TestImporter: onComplete is required for this test path");
+                }
+                props.onComplete(stubNotebookPair());
+            }}
+        >
+            Complete import
+        </button>
+    );
+
+    const testPlugin: ImporterPlugin = {
+        id: "test-importer",
+        name: "Test Importer",
+        description: "Test-only stub importer",
+        icon: () => null,
+        component: TestImporter,
+        enabled: true,
+        supportedExtensions: [".txt"],
+        tags: ["Essential", "Test"],
+    };
+
+    return { testPlugin, TestImporter };
+});
+
+vi.mock("./importers/registry.tsx", () => ({
+    importerPlugins: [hoisted.testPlugin],
+    getImporterById: (id: string) => (id === "test-importer" ? hoisted.testPlugin : undefined),
+    getEssentialImporters: (targetOnly?: boolean) => (targetOnly ? [] : [hoisted.testPlugin]),
+    getSpecializedImporters: () => [],
+    searchPlugins: (query: string, plugins: ImporterPlugin[]) => {
+        if (!query.trim()) {
+            return plugins;
+        }
+        return plugins.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()));
+    },
+}));
+
+vi.mock("./components/ExportOptionsPreviewPanel", () => ({
+    ExportOptionsPreviewPanel: () => null,
+}));
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+    VSCodeButton: ({ children, onClick, disabled }: { children?: React.ReactNode; onClick?: () => void; disabled?: boolean }) => (
+        <button type="button" onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    ),
+    VSCodeTextArea: ({ id, value, onInput, disabled, placeholder }: { id?: string; value?: string; onInput?: (e: { target: { value: string } }) => void; disabled?: boolean; placeholder?: string }) => (
+        <textarea id={id} value={value} onChange={(e) => onInput?.(e as unknown as { target: { value: string } })} disabled={disabled} placeholder={placeholder} />
+    ),
+}));
+
+function dispatchHostMessage(data: object): void {
+    window.dispatchEvent(
+        new MessageEvent("message", {
+            bubbles: true,
+            data,
+        })
+    );
+}
+
+describe("NewSourceUploader — Start Translating & AI Translation Instructions", () => {
+    let postMessage: ReturnType<typeof vi.fn>;
+    let NewSourceUploader: React.FC;
+
+    beforeAll(async () => {
+        postMessage = vi.fn();
+        (window as unknown as { vscodeApi: { postMessage: typeof postMessage } }).vscodeApi = {
+            postMessage,
+        };
+        const mod = await import("./NewSourceUploader");
+        NewSourceUploader = mod.default;
+    });
+
+    beforeEach(() => {
+        postMessage.mockClear();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    const inventoryWithSources = (count: number) => ({
+        sourceFiles: Array.from({ length: count }, (_, i) => ({
+            name: `Book${i}`,
+            path: `file:///ws/.project/sourceTexts/Book${i}.source`,
+            type: "usfm" as const,
+            cellCount: 1,
+        })),
+        targetFiles: [] as { path: string; name: string }[],
+        translationPairs: [] as { sourcePath: string; targetPath: string }[],
+    });
+
+    async function goToImportComplete(options: { codexUri: string; aiInstructionsCompleted: boolean }): Promise<void> {
+        await act(async () => {
+            dispatchHostMessage({
+                command: "projectInventory",
+                inventory: inventoryWithSources(1),
+            });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Test Importer")).toBeInTheDocument();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("Test Importer"));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId("mock-import-complete"));
+        });
+
+        await act(async () => {
+            dispatchHostMessage({
+                command: "projectInventory",
+                inventory: inventoryWithSources(1),
+            });
+            dispatchHostMessage({
+                command: "importComplete",
+                importedCodexUris: [options.codexUri],
+                aiInstructionsCompleted: options.aiInstructionsCompleted,
+            });
+        });
+
+        await waitFor(() => {
+            const btn = screen.getByRole("button", { name: /Start Translating/i });
+            expect(btn).not.toBeDisabled();
+        });
+    }
+
+    it('shows "AI Translation Instructions" (system message step) when Start Translating runs and AI setup is not completed', async () => {
+        render(<NewSourceUploader />);
+
+        await goToImportComplete({
+            codexUri: "file:///ws/files/First.codex",
+            aiInstructionsCompleted: false,
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Start Translating/i }));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole("heading", { name: /AI Translation Instructions/i })).toBeInTheDocument();
+        });
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ command: "metadata.check" })
+        );
+    });
+
+    it('opens the imported codex file when AI setup is already completed; does not show "AI Translation Instructions"', async () => {
+        render(<NewSourceUploader />);
+
+        const targetUri = "file:///ws/files/AfterSetup.codex";
+
+        await goToImportComplete({
+            codexUri: targetUri,
+            aiInstructionsCompleted: true,
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Start Translating/i }));
+        });
+
+        await waitFor(() => {
+            expect(postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ command: "openImportedFile", codexUri: targetUri })
+            );
+        });
+
+        expect(screen.queryByRole("heading", { name: /AI Translation Instructions/i })).toBeNull();
+    });
+
+    it("after a second import, Start Translating opens the latest imported file", async () => {
+        render(<NewSourceUploader />);
+
+        await goToImportComplete({
+            codexUri: "file:///ws/files/FirstImport.codex",
+            aiInstructionsCompleted: true,
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Import More Files/i }));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Test Importer")).toBeInTheDocument();
+        });
+
+        postMessage.mockClear();
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("Test Importer"));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByTestId("mock-import-complete"));
+        });
+
+        const secondUri = "file:///ws/files/SecondImport.codex";
+        await act(async () => {
+            dispatchHostMessage({
+                command: "projectInventory",
+                inventory: inventoryWithSources(2),
+            });
+            dispatchHostMessage({
+                command: "importComplete",
+                importedCodexUris: [secondUri],
+                aiInstructionsCompleted: true,
+            });
+        });
+
+        await waitFor(() => {
+            const btn = screen.getByRole("button", { name: /Start Translating/i });
+            expect(btn).not.toBeDisabled();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: /Start Translating/i }));
+        });
+
+        await waitFor(() => {
+            expect(postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ command: "openImportedFile", codexUri: secondUri })
+            );
+        });
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/NewSourceUploader.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/NewSourceUploader.tsx
@@ -65,6 +65,8 @@ const NewSourceUploader: React.FC = () => {
     const [systemMessage, setSystemMessage] = useState<string>("");
     const [isWaitingForMessage, setIsWaitingForMessage] = useState(false);
     const [importComplete, setImportComplete] = useState(false);
+    const [lastImportedCodexUris, setLastImportedCodexUris] = useState<string[]>([]);
+    const [aiInstructionsCompleted, setAiInstructionsCompleted] = useState(false);
 
     // State for managing alignment requests
     const [alignmentRequests, setAlignmentRequests] = useState<
@@ -142,6 +144,12 @@ const NewSourceUploader: React.FC = () => {
                 });
             } else if (message.command === "importComplete") {
                 setImportComplete(true);
+                if (Array.isArray(message.importedCodexUris)) {
+                    setLastImportedCodexUris(message.importedCodexUris);
+                }
+                if (typeof message.aiInstructionsCompleted === "boolean") {
+                    setAiInstructionsCompleted(message.aiInstructionsCompleted);
+                }
                 setWizardState((prev) => {
                     if (prev.currentStep !== "importing") return prev;
                     return {
@@ -502,30 +510,42 @@ const NewSourceUploader: React.FC = () => {
         setIsDirty(false);
     }, []);
 
+    const openImportedFileOrFallback = useCallback(() => {
+        const codexUri = lastImportedCodexUris[0];
+        if (codexUri) {
+            vscode.postMessage({ command: "openImportedFile", codexUri });
+        } else {
+            vscode.postMessage({ command: "startTranslating" });
+        }
+    }, [lastImportedCodexUris]);
+
     const handleStartTranslating = useCallback(() => {
-        // Navigate to system message step
-        // Request metadata to get current system message (may have been generated earlier)
-        setIsWaitingForMessage(true); // Set flag that we're waiting for message
+        // If the user has already completed the AI instructions / system message setup
+        // for this project, skip the system message step and open the imported file directly.
+        if (aiInstructionsCompleted) {
+            openImportedFileOrFallback();
+            return;
+        }
+
+        // First time in this project: show the SystemMessageStep so the user can set up
+        // the AI translation instructions.
+        setIsWaitingForMessage(true);
         vscode.postMessage({ command: "metadata.check" });
         setWizardState((prev) => ({
             ...prev,
             currentStep: "system-message",
         }));
-    }, []);
+    }, [aiInstructionsCompleted, openImportedFileOrFallback]);
 
     const handleSystemMessageContinue = useCallback(() => {
-        // After system message is saved, actually start translating
-        vscode.postMessage({
-            command: "startTranslating",
-        });
-    }, []);
+        // After system message is saved, open the imported file directly.
+        openImportedFileOrFallback();
+    }, [openImportedFileOrFallback]);
 
     const handleSystemMessageSkip = useCallback(() => {
-        // Skip system message and start translating
-        vscode.postMessage({
-            command: "startTranslating",
-        });
-    }, []);
+        // Skip system message and open the imported file directly.
+        openImportedFileOrFallback();
+    }, [openImportedFileOrFallback]);
 
     const handleBack = useCallback(() => {
         setWizardState((prev) => {

--- a/webviews/codex-webviews/src/NewSourceUploader/types/plugin.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/types/plugin.ts
@@ -500,6 +500,26 @@ export interface StartTranslatingMessage {
     command: 'startTranslating';
 }
 
+export interface OpenImportedFileMessage {
+    command: 'openImportedFile';
+    /** Absolute filesystem path to the imported codex file to open in split view. */
+    codexUri: string;
+}
+
+/**
+ * Sent from the provider to the webview after an import finishes successfully.
+ * Includes references to the just-imported notebooks and a per-project flag
+ * indicating whether the AI translation instructions / system message setup
+ * has already been completed for this project.
+ */
+export interface ImportCompleteMessage {
+    command: 'importComplete';
+    /** Absolute filesystem paths of the codex notebooks created by this import. */
+    importedCodexUris?: string[];
+    /** Whether the user has already completed the one-time AI instructions setup for this project. */
+    aiInstructionsCompleted?: boolean;
+}
+
 export interface SelectAudioFileMessage {
     command: 'selectAudioFile';
     thresholdDb?: number;
@@ -640,4 +660,4 @@ export interface AudioUriResponseMessage {
     error?: string;
 }
 
-export type ProviderMessage = WriteNotebooksMessage | WriteTranslationMessage | NotificationMessage | ImportBookNamesMessage | ImportStartedMessage | ImportEndedMessage | OverwriteConfirmationMessage | OverwriteResponseMessage | DownloadResourceMessage | DownloadResourceProgressMessage | DownloadResourceCompleteMessage | StartTranslatingMessage | SaveFileMessage | SelectAudioFileMessage | ReprocessAudioFileMessage | AudioFileSelectedMessage | AudioFileForProcessingMessage | ReprocessAudioInWebviewMessage | AudioProcessingCompleteMessage | RequestAudioSegmentMessage | AudioSegmentResponseMessage | RequestAudioUriMessage | AudioUriResponseMessage | FinalizeAudioImportMessage | AudioImportProgressMessage | AudioImportCompleteMessage | UpdateAudioSegmentsMessage | AudioSegmentsUpdatedMessage;
+export type ProviderMessage = WriteNotebooksMessage | WriteTranslationMessage | NotificationMessage | ImportBookNamesMessage | ImportStartedMessage | ImportEndedMessage | OverwriteConfirmationMessage | OverwriteResponseMessage | DownloadResourceMessage | DownloadResourceProgressMessage | DownloadResourceCompleteMessage | StartTranslatingMessage | OpenImportedFileMessage | SaveFileMessage | SelectAudioFileMessage | ReprocessAudioFileMessage | AudioFileSelectedMessage | AudioFileForProcessingMessage | ReprocessAudioInWebviewMessage | AudioProcessingCompleteMessage | RequestAudioSegmentMessage | AudioSegmentResponseMessage | RequestAudioUriMessage | AudioUriResponseMessage | FinalizeAudioImportMessage | AudioImportProgressMessage | AudioImportCompleteMessage | UpdateAudioSegmentsMessage | AudioSegmentsUpdatedMessage;

--- a/webviews/codex-webviews/vitest.config.ts
+++ b/webviews/codex-webviews/vitest.config.ts
@@ -4,7 +4,8 @@ import { resolve } from 'path';
 export default defineConfig({
     resolve: {
         alias: {
-            '@sharedUtils': resolve(__dirname, '../../sharedUtils/index.ts'),
+            // Directory (not index.ts) so `@sharedUtils/exportOptionsEligibility` resolves like Vite
+            '@sharedUtils': resolve(__dirname, '../../sharedUtils'),
             'types': resolve(__dirname, '../../types'),
         },
     },


### PR DESCRIPTION
**Due to this PR requiring creating a new project to test, I will not attach a project to this. Please create a new project when following the Testing Checklist.**

Closes #902 

## Summary

Fixes the New Source Uploader **Start Translating** flow so the user lands on the **imported `.codex`** (with the same source/codex split behavior as the navigation webview), tracks **AI translation instructions** completion in project metadata, and adds Vitest coverage for the webview behavior (including **Import more files** using the latest URI).

## What changed

- **`openCodexDocumentWithSourcePair`** (`src/utils/openCodexDocumentWithSourcePair.ts`): shared helper to open the paired `.source` and `.codex` in split columns (aligned with navigation webview); falls back to opening only the codex when needed.
- **`navigationWebviewProvider`**: delegates to that helper instead of duplicating open logic.
- **`NewSourceUploaderProvider`**: `startTranslating` / `openImportedFile` paths use the same helper; `importComplete` messaging carries **`aiInstructionsCompleted`** so the webview can branch correctly after import.
- **`metadataManager`**: read/write **`aiInstructionsCompleted`** on `metadata.json` (with edit-map tracking).
- **`types/index.d.ts`**: message/type updates for the new field where applicable.
- **`NewSourceUploader.tsx` / `types/plugin.ts`**: **Start Translating** posts `startTranslating` when appropriate; respects AI-instructions gate vs direct open; keeps **latest imported codex URI** when importing again.
- **Tests**: `NewSourceUploader.startTranslating.test.tsx` (mock importer, inventory + import flow).
- **`vitest.config.ts`**: Vitest resolve aliases for `@sharedUtils` and `types` so those imports work in tests.

## Testing checklist

- [ ] Open **New Source Uploader**, complete an import, click **Start Translating** when **AI translation instructions are not** boolean is false in the metadata.json: confirm the **AI Translation Instructions** step appears (system message flow), not a silent wrong document.
- [ ] With AI instructions **already** completed (or after finishing them): **Start Translating** opens the **imported `.codex`** and the **matching `.source`** in the expected split layout (source primary column, codex secondary), consistent with opening from the **navigation** webview.
- [ ] **Import more files**, complete a second import, then **Start Translating**: the editor opens the **most recently imported** `.codex` (not the first one).
- [ ] Regression: opening a book/file from the **navigation** webview still opens source + codex as before.
- [ ] No workspace folder edge case: if behavior without a workspace folder is relevant to your flows, confirm codex-only fallback still works without errors.
- [ ] Sync the project and have someone else open and try to import to make sure that the ai generation prompt is skipped and the importer opens the file immediately.