### PR TITLE
Vtt importer remove html fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "codex-editor-extension",
-    "version": "0.25.0",
+    "version": "0.26.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "codex-editor-extension",
-            "version": "0.25.0",
+            "version": "0.26.0",
             "license": "MIT",
             "dependencies": {
                 "@types/csv-parse": "^1.2.5",

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -393,6 +393,16 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 }
                 break;
             }
+            case "setEnforceHtmlStructure": {
+                try {
+                    const { bookAbbr, enforceHtmlStructure } = message.content;
+                    await this.setEnforceHtmlStructure(bookAbbr, enforceHtmlStructure);
+                } catch (error) {
+                    console.error("Error setting HTML enforcement:", error);
+                    vscode.window.showErrorMessage(`Failed to update HTML enforcement: ${error}`);
+                }
+                break;
+            }
             case "editCorpusMarker": {
                 try {
                     const { corpusLabel, newCorpusName } = message.content;
@@ -627,6 +637,7 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 },
                 sortOrder,
                 fileDisplayName: metadata?.fileDisplayName,
+                enforceHtmlStructure: metadata?.enforceHtmlStructure ?? false,
             };
         } catch (error: any) {
             // Don't log warnings for files that don't exist (FileNotFound/ENOENT errors)
@@ -1167,6 +1178,69 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
         } catch (error) {
             console.error("Error updating book name:", error);
             vscode.window.showErrorMessage(`Failed to update book name: ${error}`);
+        }
+    }
+
+    private async setEnforceHtmlStructure(bookAbbr: string, enforceHtmlStructure: boolean): Promise<void> {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders?.length) {
+            vscode.window.showErrorMessage("No project folder found.");
+            return;
+        }
+
+        try {
+            const { matchingUris } = await findCodexFilesByBookAbbr(bookAbbr, { readMetadata: true });
+
+            const updateFile = async (uri: vscode.Uri) => {
+                const content = await vscode.workspace.fs.readFile(uri);
+                const notebookData = await this.serializer.deserializeNotebook(
+                    content,
+                    new vscode.CancellationTokenSource().token
+                );
+
+                if (!notebookData.metadata) {
+                    notebookData.metadata = {} as CustomNotebookMetadata;
+                }
+
+                notebookData.metadata = {
+                    ...notebookData.metadata,
+                    enforceHtmlStructure,
+                };
+
+                const updatedContent = await this.serializer.serializeNotebook(
+                    notebookData,
+                    new vscode.CancellationTokenSource().token
+                );
+                await vscode.workspace.fs.writeFile(uri, updatedContent);
+            };
+
+            for (const uri of matchingUris) {
+                try {
+                    await updateFile(uri);
+
+                    const sourceUri = getCorrespondingSourceUri(uri);
+                    if (sourceUri) {
+                        try {
+                            await vscode.workspace.fs.stat(sourceUri);
+                            await updateFile(sourceUri);
+                        } catch {
+                            // Source file doesn't exist, skip
+                        }
+                    }
+                } catch (error) {
+                    console.error(`Error updating enforceHtmlStructure for ${uri.fsPath}:`, error);
+                }
+            }
+
+            await this.buildInitialData();
+
+            const stateLabel = enforceHtmlStructure ? "enabled" : "disabled";
+            vscode.window.showInformationMessage(
+                `HTML structure enforcement ${stateLabel} for "${bookAbbr}"`
+            );
+        } catch (error) {
+            console.error("Error setting HTML enforcement:", error);
+            vscode.window.showErrorMessage(`Failed to update HTML enforcement: ${error}`);
         }
     }
 

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -28,6 +28,7 @@ interface CodexMetadata {
     corpusMarker?: string;
     progress?: number;
     fileDisplayName?: string;
+    enforceHtmlStructure?: boolean;
 }
 
 interface BibleBookInfo {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1416,6 +1416,7 @@ type ProjectManagerMessageFromWebview =
     | { command: "triggerSync"; }
     | { command: "downloadSyncRuntime"; }
     | { command: "editBookName"; content: { bookAbbr: string; newBookName: string; }; }
+    | { command: "setEnforceHtmlStructure"; content: { bookAbbr: string; enforceHtmlStructure: boolean; }; }
     | { command: "editCorpusMarker"; content: { corpusLabel: string; newCorpusName: string; }; }
     | {
         command: "deleteCorpusMarker";
@@ -1837,6 +1838,7 @@ interface CodexItem {
     };
     sortOrder?: string;
     fileDisplayName?: string;
+    enforceHtmlStructure?: boolean;
 }
 type EditorReceiveMessages =
     | {

--- a/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
@@ -435,7 +435,10 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                 return { borderColor: "red" };
             }
             if (htmlStructureError) {
-                return { borderColor: "var(--vscode-charts-yellow, #ca8a04)" };
+                return {
+                    borderColor: "var(--vscode-charts-yellow, #ca8a04)",
+                    animation: "htmlStructureErrorGlowFade 1.5s ease-out forwards",
+                };
             }
 
             // Explicitly reset border properties when no translation state
@@ -640,6 +643,7 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                     isScrollHighlighted ? "cell-scroll-highlight" : ""
                 }`}
                 style={{
+                    border: "1px solid transparent",
                     backgroundColor: getBackgroundColor(),
                     direction: textDirection,
                     ...getBorderStyle(),
@@ -648,7 +652,6 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                     gap: isSourceText ? "0.25rem" : "0.0625rem",
                     padding: "0.25rem",
                     cursor: isSourceText && !isCorrectionEditorMode ? "default" : "pointer",
-                    border: "1px solid transparent",
                     borderRadius: "4px",
                     overflow: "visible",
                     maxWidth: "100%",

--- a/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
@@ -1025,7 +1025,13 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                                     border: "1px solid rgba(202, 138, 4, 0.25)",
                                 }}
                             >
-                                <i className={`codicon ${isResolvingStructure ? "codicon-loading codicon-modifier-spin" : "codicon-warning"}`} />
+                                <i
+                                    className={`codicon ${
+                                        isResolvingStructure
+                                            ? "codicon-loading codicon-modifier-spin"
+                                            : "codicon-warning"
+                                    }`}
+                                />
                                 <span style={{ flex: 1 }}>
                                     {isResolvingStructure
                                         ? "Resolving structure..."
@@ -1035,7 +1041,11 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                                     variant="outline"
                                     size="sm"
                                     disabled={isResolvingStructure}
-                                    style={{ height: "1.4rem", fontSize: "0.75rem", padding: "0 0.4rem" }}
+                                    style={{
+                                        height: "1.4rem",
+                                        fontSize: "0.75rem",
+                                        padding: "0 0.4rem",
+                                    }}
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setIsResolvingStructure(true);

--- a/webviews/codex-webviews/src/CodexCellEditor/TranslationAnimations.css
+++ b/webviews/codex-webviews/src/CodexCellEditor/TranslationAnimations.css
@@ -127,3 +127,14 @@
     animation: scrollHighlightFlash 1.5s ease-out;
     border-radius: 4px;
 }
+
+@keyframes htmlStructureErrorGlowFade {
+    0% {
+        border-color: var(--vscode-charts-yellow, #ca8a04);
+        box-shadow: 0 0 14px 3px rgba(202, 138, 4, 0.45);
+    }
+    100% {
+        border-color: rgba(202, 138, 4, 0);
+        box-shadow: 0 0 0 0 rgba(202, 138, 4, 0);
+    }
+}

--- a/webviews/codex-webviews/src/NavigationView/index.tsx
+++ b/webviews/codex-webviews/src/NavigationView/index.tsx
@@ -1237,7 +1237,7 @@ function NavigationView() {
                             structure. Mismatches are flagged during editing and export.
                         </DialogDescription>
                     </DialogHeader>
-                    <div className="flex justify-end items-center gap-3 mt-4 mb-4">
+                    <div className="flex items-center gap-3 mt-4 mb-4">
                         <Label
                             htmlFor="html-enforcement-toggle"
                             className="cursor-pointer font-medium"

--- a/webviews/codex-webviews/src/NavigationView/index.tsx
+++ b/webviews/codex-webviews/src/NavigationView/index.tsx
@@ -577,27 +577,26 @@ function NavigationView() {
     };
 
     const handleHtmlEnforcementToggle = (checked: boolean) => {
-        setState((prev) => ({
-            ...prev,
-            htmlEnforcementModal: {
-                ...prev.htmlEnforcementModal,
-                enforceHtmlStructure: checked,
-            },
-        }));
-    };
+        setState((prev) => {
+            const { item } = prev.htmlEnforcementModal;
+            if (item) {
+                vscode.postMessage({
+                    command: "setEnforceHtmlStructure",
+                    content: {
+                        bookAbbr: item.label,
+                        enforceHtmlStructure: checked,
+                    },
+                });
+            }
 
-    const handleHtmlEnforcementSave = () => {
-        const { item, enforceHtmlStructure } = state.htmlEnforcementModal;
-        if (!item) return;
-
-        vscode.postMessage({
-            command: "setEnforceHtmlStructure",
-            content: {
-                bookAbbr: item.label,
-                enforceHtmlStructure,
-            },
+            return {
+                ...prev,
+                htmlEnforcementModal: {
+                    ...prev.htmlEnforcementModal,
+                    enforceHtmlStructure: checked,
+                },
+            };
         });
-        handleHtmlEnforcementClose();
     };
 
     const handleRenameModalClose = () => {
@@ -1218,7 +1217,11 @@ function NavigationView() {
                     <DialogHeader className="text-left">
                         <DialogTitle
                             className="text-base font-semibold mb-2"
-                            style={{ fontSize: "16px", fontWeight: "600", color: "var(--vscode-foreground)" }}
+                            style={{
+                                fontSize: "16px",
+                                fontWeight: "600",
+                                color: "var(--vscode-foreground)",
+                            }}
                         >
                             HTML Enforcement
                         </DialogTitle>
@@ -1234,33 +1237,25 @@ function NavigationView() {
                             structure. Mismatches are flagged during editing and export.
                         </DialogDescription>
                     </DialogHeader>
-                    <div className="flex items-center gap-3 mt-4 mb-4">
-                        <Switch
-                            id="html-enforcement-toggle"
-                            checked={state.htmlEnforcementModal.enforceHtmlStructure}
-                            onCheckedChange={handleHtmlEnforcementToggle}
-                        />
+                    <div className="flex justify-end items-center gap-3 mt-4 mb-4">
                         <Label
                             htmlFor="html-enforcement-toggle"
                             className="cursor-pointer font-medium"
                             style={{ color: "var(--vscode-foreground)" }}
                         >
-                            {state.htmlEnforcementModal.enforceHtmlStructure ? "Enabled" : "Disabled"}
+                            {state.htmlEnforcementModal.enforceHtmlStructure
+                                ? "Enabled"
+                                : "Disabled"}
                         </Label>
-                        <ShieldCheck
-                            className={`h-4 w-4 ml-auto ${
-                                state.htmlEnforcementModal.enforceHtmlStructure
-                                    ? "text-primary"
-                                    : "text-muted-foreground"
-                            }`}
+                        <Switch
+                            id="html-enforcement-toggle"
+                            checked={state.htmlEnforcementModal.enforceHtmlStructure}
+                            onCheckedChange={handleHtmlEnforcementToggle}
                         />
                     </div>
                     <DialogFooter className="flex gap-3 justify-end">
                         <Button variant="secondary" onClick={handleHtmlEnforcementClose}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleHtmlEnforcementSave}>
-                            Save
+                            Close
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/webviews/codex-webviews/src/NavigationView/index.tsx
+++ b/webviews/codex-webviews/src/NavigationView/index.tsx
@@ -12,7 +12,9 @@ import {
 } from "../components/ui/dropdown-menu";
 import "../tailwind.css";
 import { CodexItem } from "types";
-import { Languages, Mic } from "lucide-react";
+import { Languages, Mic, ShieldCheck } from "lucide-react";
+import { Switch } from "../components/ui/switch";
+import { Label } from "../components/ui/label";
 import { RenameModal } from "../components/RenameModal";
 import {
     Dialog,
@@ -61,6 +63,11 @@ interface State {
         displayName: string;
         typedName: string;
         isCorpus: boolean;
+    };
+    htmlEnforcementModal: {
+        isOpen: boolean;
+        item: CodexItem | null;
+        enforceHtmlStructure: boolean;
     };
 }
 
@@ -212,6 +219,11 @@ function NavigationView() {
             displayName: "",
             typedName: "",
             isCorpus: false,
+        },
+        htmlEnforcementModal: {
+            isOpen: false,
+            item: null,
+            enforceHtmlStructure: false,
         },
     });
 
@@ -542,6 +554,52 @@ function NavigationView() {
         handleDeleteModalClose();
     };
 
+    const handleOpenHtmlEnforcement = (item: CodexItem) => {
+        setState((prev) => ({
+            ...prev,
+            htmlEnforcementModal: {
+                isOpen: true,
+                item,
+                enforceHtmlStructure: item.enforceHtmlStructure ?? false,
+            },
+        }));
+    };
+
+    const handleHtmlEnforcementClose = () => {
+        setState((prev) => ({
+            ...prev,
+            htmlEnforcementModal: {
+                isOpen: false,
+                item: null,
+                enforceHtmlStructure: false,
+            },
+        }));
+    };
+
+    const handleHtmlEnforcementToggle = (checked: boolean) => {
+        setState((prev) => ({
+            ...prev,
+            htmlEnforcementModal: {
+                ...prev.htmlEnforcementModal,
+                enforceHtmlStructure: checked,
+            },
+        }));
+    };
+
+    const handleHtmlEnforcementSave = () => {
+        const { item, enforceHtmlStructure } = state.htmlEnforcementModal;
+        if (!item) return;
+
+        vscode.postMessage({
+            command: "setEnforceHtmlStructure",
+            content: {
+                bookAbbr: item.label,
+                enforceHtmlStructure,
+            },
+        });
+        handleHtmlEnforcementClose();
+    };
+
     const handleRenameModalClose = () => {
         setState((prev) => ({
             ...prev,
@@ -801,6 +859,17 @@ function NavigationView() {
                                             >
                                                 <i className="codicon codicon-edit mr-2" />
                                                 Edit Book Name
+                                            </DropdownMenuItem>
+                                        )}
+                                        {item.type === "codexDocument" && (
+                                            <DropdownMenuItem
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleOpenHtmlEnforcement(item);
+                                                }}
+                                            >
+                                                <i className="codicon codicon-shield mr-2" />
+                                                HTML Enforcement
                                             </DropdownMenuItem>
                                         )}
                                         {item.type === "corpus" && (
@@ -1128,6 +1197,70 @@ function NavigationView() {
                             disabled={state.deleteModal.typedName !== state.deleteModal.displayName}
                         >
                             Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* HTML Enforcement Modal */}
+            <Dialog
+                open={state.htmlEnforcementModal.isOpen}
+                onOpenChange={(isOpen) => !isOpen && handleHtmlEnforcementClose()}
+            >
+                <DialogContent
+                    showCloseButton={false}
+                    className="bg-vscode-editor-background border-vscode-editorWidget-border min-w-[300px] max-w-[400px] p-5 shadow-[0_8px_32px_rgba(0,0,0,0.3)]"
+                    style={{
+                        backgroundColor: "var(--vscode-editor-background)",
+                        borderColor: "var(--vscode-editorWidget-border)",
+                    }}
+                >
+                    <DialogHeader className="text-left">
+                        <DialogTitle
+                            className="text-base font-semibold mb-2"
+                            style={{ fontSize: "16px", fontWeight: "600", color: "var(--vscode-foreground)" }}
+                        >
+                            HTML Enforcement
+                        </DialogTitle>
+                        <DialogDescription
+                            className="text-sm text-left leading-relaxed"
+                            style={{
+                                fontSize: "14px",
+                                color: "var(--vscode-descriptionForeground)",
+                                lineHeight: "1.5",
+                            }}
+                        >
+                            When enabled, translated cells are validated against the source HTML
+                            structure. Mismatches are flagged during editing and export.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex items-center gap-3 mt-4 mb-4">
+                        <Switch
+                            id="html-enforcement-toggle"
+                            checked={state.htmlEnforcementModal.enforceHtmlStructure}
+                            onCheckedChange={handleHtmlEnforcementToggle}
+                        />
+                        <Label
+                            htmlFor="html-enforcement-toggle"
+                            className="cursor-pointer font-medium"
+                            style={{ color: "var(--vscode-foreground)" }}
+                        >
+                            {state.htmlEnforcementModal.enforceHtmlStructure ? "Enabled" : "Disabled"}
+                        </Label>
+                        <ShieldCheck
+                            className={`h-4 w-4 ml-auto ${
+                                state.htmlEnforcementModal.enforceHtmlStructure
+                                    ? "text-primary"
+                                    : "text-muted-foreground"
+                            }`}
+                        />
+                    </div>
+                    <DialogFooter className="flex gap-3 justify-end">
+                        <Button variant="secondary" onClick={handleHtmlEnforcementClose}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleHtmlEnforcementSave}>
+                            Save
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/subtitles/SubtitlesImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/subtitles/SubtitlesImporterForm.tsx
@@ -100,6 +100,5 @@ export const SubtitlesImporterForm: React.FC<ImporterComponentProps> = (props) =
         processFiles={processSubtitleFiles}
         importerProps={props}
         cellAligner={subtitlesImporterPlugin.cellAligner}
-        showEnforceStructure
     />
 );

--- a/webviews/codex-webviews/src/components/ui/switch.tsx
+++ b/webviews/codex-webviews/src/components/ui/switch.tsx
@@ -6,10 +6,11 @@ interface SwitchProps {
     onCheckedChange?: (checked: boolean) => void;
     disabled?: boolean;
     className?: string;
+    id?: string;
 }
 
 const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
-    ({ className, checked, onCheckedChange, disabled, ...props }, ref) => {
+    ({ className, checked, onCheckedChange, disabled, id, ...props }, ref) => {
         return (
             <label
                 className={cn(
@@ -22,6 +23,7 @@ const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
                 )}
             >
                 <input
+                    id={id}
                     type="checkbox"
                     className="sr-only"
                     checked={checked}


### PR DESCRIPTION
Removed the HTML enforcement checkbox option from the VTT importer.

Added a feature too every file menu opened by three dots in the navigation, saying "HTML Enforcement" where user may enable or disable it. It works instantly when enabled/disabled :D