### PR TITLE
Json save error fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -358,24 +358,40 @@ export async function activate(context: vscode.ExtensionContext) {
         console.error("[Extension] Failed to initialize cellId state store:", e);
     }
 
-    // One-shot cleanup of the orphaned cellId row inside the
-    // project-accelerate.shared-state-store extension's globalState. That row
-    // was the source of the mainThreadStorage >5 MB warning. The flag lives
-    // in globalStorageUri/migrations.json so the cleanup runs exactly once
-    // (and retries on the next activation if it threw).
+    // One-shot cleanup of orphaned rows inside the project-accelerate.shared-state-store
+    // extension's globalState. Historically codex-editor wrote `sourceCellMap` (full
+    // source-cell content keyed by reference) and `cellId` to that store; the writers
+    // were removed long ago (sourceCellMap in 0.6.1, cellId in the local-store
+    // migration), but the data has been sitting in state.vscdb ever since, triggering
+    // the mainThreadStorage >5 MB warning and bloating activation memory.
+    //
+    // The flag lives in globalStorageUri/migrations.json so the cleanup runs exactly
+    // once per machine (and retries on the next activation if it threw). The ID is
+    // bumped to V2 because V1 only wiped `cellId` (negligible) and missed the real
+    // offender, `sourceCellMap`.
     try {
-        await runOnce(context, "sharedStateStoreCellIdCleanupV1", async () => {
+        await runOnce(context, "sharedStateStoreOrphanCleanupV2", async () => {
             const ext = vscode.extensions.getExtension("project-accelerate.shared-state-store");
             if (!ext) return;
             const api = await ext.activate();
             if (!api || typeof api.updateStoreState !== "function") return;
             // Setting value to undefined causes the underlying
-            // globalState.update(key, undefined) to delete the row.
-            api.updateStoreState({ key: "cellId", value: undefined });
+            // globalState.update(key, undefined) to delete the key from the row.
+            const orphanKeys = ["cellId", "sourceCellMap"] as const;
+            for (const key of orphanKeys) {
+                try {
+                    api.updateStoreState({ key, value: undefined });
+                } catch (innerErr) {
+                    console.warn(
+                        `[Extension] Failed to wipe '${key}' from shared-state-store:`,
+                        innerErr
+                    );
+                }
+            }
         });
     } catch (e) {
         console.warn(
-            "[Extension] sharedStateStoreCellIdCleanupV1 cleanup failed; will retry on next activation.",
+            "[Extension] sharedStateStoreOrphanCleanupV2 cleanup failed; will retry on next activation.",
             e
         );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,8 @@ import { openCellLabelImporter } from "./cellLabelImporter/cellLabelImporter";
 import { openCodexMigrationTool } from "./codexMigrationTool/codexMigrationTool";
 import { CodexCellEditorProvider } from "./providers/codexCellEditorProvider/codexCellEditorProvider";
 import { checkForUpdatesOnStartup, registerUpdateCommands } from "./utils/updateChecker";
+import { initializeStateStore } from "./stateStore";
+import { runOnce } from "./utils/oneTimeMigrations";
 import { fileExists } from "./utils/webviewUtils";
 import { checkIfProjectIsInitialized } from "./projectManager/utils/projectUtils";
 import { CommentsMigrator } from "./utils/commentsMigrationUtils";
@@ -345,6 +347,38 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     initToolPreferences(context);
+
+    // Construct the singleton cellId state store (file-backed under
+    // globalStorageUri). Must run before providers register so that any
+    // subsequent initializeStateStore() calls inside providers reuse the
+    // same instance.
+    try {
+        await initializeStateStore(context);
+    } catch (e) {
+        console.error("[Extension] Failed to initialize cellId state store:", e);
+    }
+
+    // One-shot cleanup of the orphaned cellId row inside the
+    // project-accelerate.shared-state-store extension's globalState. That row
+    // was the source of the mainThreadStorage >5 MB warning. The flag lives
+    // in globalStorageUri/migrations.json so the cleanup runs exactly once
+    // (and retries on the next activation if it threw).
+    try {
+        await runOnce(context, "sharedStateStoreCellIdCleanupV1", async () => {
+            const ext = vscode.extensions.getExtension("project-accelerate.shared-state-store");
+            if (!ext) return;
+            const api = await ext.activate();
+            if (!api || typeof api.updateStoreState !== "function") return;
+            // Setting value to undefined causes the underlying
+            // globalState.update(key, undefined) to delete the row.
+            api.updateStoreState({ key: "cellId", value: undefined });
+        });
+    } catch (e) {
+        console.warn(
+            "[Extension] sharedStateStoreCellIdCleanupV1 cleanup failed; will retry on next activation.",
+            e
+        );
+    }
 
     // Save tab layout and close all editors before showing splash screen
     try {

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -1757,6 +1757,11 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                         author: user,
                         validatedBy: []
                     });
+                    // updateCellData() above already fired the change event, which can
+                    // synchronously trigger updateWebview() → getText() and repopulate
+                    // the per-cell cache with the mid-mutation state. Re-invalidate now
+                    // so the upcoming save() re-serializes the cell with the unmerge edit.
+                    document.markCellMutated(cellId);
                 }
             } catch (e) {
                 console.warn("Failed to record unmerge edit entry on source cell", e);
@@ -3179,9 +3184,12 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 }
             }
 
-            // Mark the document as dirty manually since we bypassed the normal update methods
+            // Mark the document as dirty manually since we bypassed the normal update methods.
+            // Use markCellMutated so the per-cell serialization cache is invalidated too;
+            // direct `_dirtyCellIds.add` would leave the previous-cell cache pointing at
+            // its pre-merge state and the next save() would write stale bytes for it.
             (document as any)._isDirty = true;
-            (document as any)._dirtyCellIds.add(previousCellId);
+            document.markCellMutated(previousCellId);
 
             // 6. Mark current cell as merged by updating its data
             const currentCellData = document.getCellData(currentCellId) || {};
@@ -3204,6 +3212,12 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                     author: currentUser,
                     validatedBy: []
                 });
+                // updateCellData() above already fired the change event, which can
+                // synchronously trigger updateWebview() → getText() and repopulate
+                // the per-cell cache with the mid-mutation state (merged flag set,
+                // but the merge edit not yet pushed). Re-invalidate now so the
+                // upcoming save() re-serializes the cell with the merge edit.
+                document.markCellMutated(currentCellId);
             }
 
             // Save the document

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -3035,6 +3035,11 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                         author: "anonymous",
                         validatedBy: []
                     });
+                    // updateCellData() above already fired the change event, which can
+                    // synchronously trigger updateWebview() → getText() and repopulate
+                    // the per-cell cache with the mid-mutation state. Re-invalidate now
+                    // so the upcoming save() re-serializes the cell with the unmerge edit.
+                    targetDocument.markCellMutated(cellIdToUnmerge);
                 }
             } catch (e) {
                 console.warn("Failed to append merged=false edit on target during unmerge", e);

--- a/src/providers/codexCellEditorProvider/codexDocument.ts
+++ b/src/providers/codexCellEditorProvider/codexDocument.ts
@@ -26,6 +26,7 @@ import { getSQLiteIndexManager, isDBShuttingDown } from "../../activationHelpers
 import { getCellValueData, cellHasAudioUsingAttachments, computeValidationStats, computeProgressPercents, shouldExcludeCellFromProgress, shouldExcludeQuillCellFromProgress, countActiveValidations, hasTextContent } from "../../../sharedUtils";
 import { extractParentCellIdFromParatext, convertCellToQuillContent } from "./utils/cellUtils";
 import { formatJsonForNotebookFile, normalizeNotebookFileText } from "../../utils/notebookFileFormattingUtils";
+import { serializeNotebookWithCellCache } from "./utils/cachedNotebookSerializer";
 import { atomicWriteUriText, readExistingFileOrThrow } from "../../utils/notebookSafeSaveUtils";
 
 // Define debug function locally
@@ -69,6 +70,24 @@ export class CodexCellDocument implements vscode.CustomDocument {
     // Track cell IDs that have been modified since last save to avoid re-indexing ALL cells.
     // Only cells in this set will be synced to the database on save.
     private _dirtyCellIds: Set<string> = new Set();
+
+    // Per-cell serialized JSON cache, keyed by cell.metadata.id. Avoids
+    // re-stringifying every cell on every save when only a handful changed.
+    // Invalidated by markCellMutated(); cleared on revert.
+    private _serializedCellCache: Map<string, string> = new Map();
+
+    // Last text we successfully wrote to disk. When the on-disk content still
+    // matches this value at the start of the next save, no concurrent writer
+    // has touched the file and we can skip the merge step entirely.
+    // Reset to null after a merge-write since _documentData no longer fully
+    // reflects what landed on disk.
+    private _lastWrittenContent: string | null = null;
+
+    // Save coalescing: a single in-flight save chain handles concurrent
+    // saveCustomDocument() callers, with at most one extra save queued behind
+    // the in-flight one to capture changes that arrived during the save.
+    private _saveChainPromise: Promise<void> | null = null;
+    private _pendingSaveRequested: boolean = false;
 
     // Pending index operations that failed because the index manager was unavailable.
     // These are replayed when the index manager becomes available again, ensuring
@@ -117,6 +136,11 @@ export class CodexCellDocument implements vscode.CustomDocument {
         try {
             this._documentData = JSON.parse(initialContent);
             this._edits = [];
+            // Seed the "last written" content with the on-disk text we just
+            // loaded. As long as no concurrent writer touches the file, the
+            // first save can short-circuit the merge step (existing.content
+            // will byte-equal this snapshot).
+            this._lastWrittenContent = initialContent;
             debug(
                 "Constructed CodexCellDocument from json document, cells count: ",
                 this._documentData.cells.length
@@ -364,7 +388,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
             // This avoids side effects (e.g., merge logic using edit history) from updating the stored value.
             // If the UI needs to reflect the preview, it should use a separate webview-only channel.
             this._isDirty = true;
-            this._dirtyCellIds.add(cellId);
+            this.markCellMutated(cellId);
             // Notify both VS Code and the webview that edits changed, so the provider can mark dirty and VS Code can autosave
             this._onDidChangeForVsCodeAndWebview.fire({
                 edits: [{ cellId, newContent, editType }],
@@ -481,7 +505,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Set dirty flag and notify listeners about the change
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ cellId, newContent, editType }],
         });
@@ -571,6 +595,28 @@ export class CodexCellDocument implements vscode.CustomDocument {
      */
     private invalidateIndexCaches(): void {
         this._cachedFileId = null;
+    }
+
+    /**
+     * Record that a cell has been mutated. Adds the cell to the dirty set
+     * (so it will be re-synced to the SQLite index on the next save) and
+     * invalidates its cached serialization (so the next save re-stringifies
+     * it instead of using the stale cached JSON).
+     *
+     * This is the centralized replacement for `this._dirtyCellIds.add(cellId)`;
+     * always prefer this helper over touching `_dirtyCellIds` directly so that
+     * the serialization cache stays consistent with the in-memory state.
+     *
+     * Public so callers that perform direct cell mutations (bypassing the
+     * normal update methods — e.g. the cell-merge handler in
+     * `codexCellEditorMessagehandling.ts`) can mark their writes. Skipping
+     * this call after a direct mutation will leak stale serializations into
+     * the next `save()` / `getText()` and silently drop the mutation from
+     * what's written to disk.
+     */
+    public markCellMutated(cellId: string): void {
+        this._dirtyCellIds.add(cellId);
+        this._serializedCellCache.delete(cellId);
     }
 
     /**
@@ -782,15 +828,85 @@ export class CodexCellDocument implements vscode.CustomDocument {
         return { ...this._documentData, metadata };
     }
 
+    /**
+     * Produce the canonical on-disk text for this document, using the
+     * per-cell serialization cache to avoid re-stringifying unchanged cells.
+     *
+     * Output is byte-identical to
+     * `formatJsonForNotebookFile(this.getDocumentDataForSerialization())`.
+     */
+    private serializeForDisk(): string {
+        return serializeNotebookWithCellCache(
+            this.getDocumentDataForSerialization(),
+            this._serializedCellCache
+        );
+    }
+
+    /**
+     * Public save entry point. Coalesces concurrent callers so at most one
+     * save is in flight at a time, with a single coalesced follow-up save if
+     * any new caller arrives while a save is running. This prevents redundant
+     * work when, for example, a webview save lands while a sync-triggered
+     * save is already partway through serialization.
+     */
     public async save(cancellation: vscode.CancellationToken): Promise<void> {
-        const ourContent = formatJsonForNotebookFile(this.getDocumentDataForSerialization());
+        if (this._saveChainPromise) {
+            // A save is already running. Mark a follow-up so the running
+            // chain will do one more save after it completes, capturing any
+            // mutations that arrived while the current save was in-flight.
+            this._pendingSaveRequested = true;
+            return this._saveChainPromise;
+        }
+
+        this._saveChainPromise = this._runSaveChain(cancellation);
+        try {
+            await this._saveChainPromise;
+        } finally {
+            this._saveChainPromise = null;
+        }
+    }
+
+    /**
+     * Drive a save loop that runs the actual save once, then keeps running
+     * additional saves as long as new mutations arrive (signalled by
+     * `_pendingSaveRequested`). The loop terminates when no new save was
+     * requested during the previous iteration.
+     */
+    private async _runSaveChain(cancellation: vscode.CancellationToken): Promise<void> {
+        do {
+            this._pendingSaveRequested = false;
+            await this._doSave(cancellation);
+        } while (this._pendingSaveRequested);
+    }
+
+    /**
+     * The actual save logic. Do NOT call directly — go through `save()` so
+     * coalescing is honoured.
+     */
+    private async _doSave(cancellation: vscode.CancellationToken): Promise<void> {
+        const ourContent = this.serializeForDisk();
 
         // If a file exists but can't be read, we must not overwrite (this can permanently nuke data).
         const existing = await readExistingFileOrThrow(this.uri);
 
+        // Skip-merge fast path: if the on-disk content byte-equals what we
+        // last successfully wrote, no concurrent writer has touched the file
+        // and `ourContent` is a valid superset of the on-disk state. We can
+        // skip `resolveCodexCustomMerge` entirely (which involves parsing
+        // both sides and walking every cell) and go straight to writing.
+        const canSkipMerge =
+            existing.kind === "readable" &&
+            this._lastWrittenContent !== null &&
+            existing.content === this._lastWrittenContent;
+
         if (existing.kind === "missing") {
             // Initial write when file does not yet exist
             await atomicWriteUriText(this.uri, ourContent);
+            this._lastWrittenContent = ourContent;
+        } else if (canSkipMerge) {
+            // Disk reflects our last write; safe to write our state directly.
+            await atomicWriteUriText(this.uri, ourContent);
+            this._lastWrittenContent = ourContent;
         } else {
             const { resolveCodexCustomMerge } = await import("../../projectManager/utils/merge/resolvers");
             const mergedContent = await resolveCodexCustomMerge(ourContent, existing.content);
@@ -815,6 +931,15 @@ export class CodexCellDocument implements vscode.CustomDocument {
             }
 
             await atomicWriteUriText(this.uri, candidate);
+
+            // After a merge, the on-disk content may include "their" edits
+            // that aren't in our `_documentData` — so we cannot use it as
+            // the next-save fast-path baseline (writing `ourContent`
+            // directly would silently drop those edits). Fall back to the
+            // conservative path: null out the baseline so the next save
+            // re-merges. The save after that one (assuming no new
+            // concurrent writer) will re-establish the fast path.
+            this._lastWrittenContent = null;
         }
 
         // Record save timestamp to prevent file watcher from reverting our own save
@@ -833,7 +958,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
         cancellation: vscode.CancellationToken,
         backup: boolean = false
     ): Promise<void> {
-        const text = formatJsonForNotebookFile(this.getDocumentDataForSerialization());
+        const text = this.serializeForDisk();
         await atomicWriteUriText(targetResource, text);
 
         // Sync only modified cells for non-backup saves
@@ -856,12 +981,20 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
     public async revert(cancellation?: vscode.CancellationToken): Promise<void> {
         const diskContent = await vscode.workspace.fs.readFile(this.uri);
-        this._documentData = JSON.parse(diskContent.toString());
+        const diskText = diskContent.toString();
+        this._documentData = JSON.parse(diskText);
         // Invalidate milestone index cache since document was reverted from disk
         this.invalidateMilestoneIndexCache();
         this._edits = [];
         this._isDirty = false; // Reset dirty flag
         this._dirtyCellIds.clear(); // Discard stale dirty IDs — document is back to saved state
+        // Reset the per-cell serialization cache: every cell object was just
+        // replaced with a fresh parse, so the cached strings keyed by id no
+        // longer match the in-memory references.
+        this._serializedCellCache.clear();
+        // Disk now reflects what we have in memory; the next save can
+        // skip-merge as long as no other writer touches the file in between.
+        this._lastWrittenContent = diskText;
         this._onDidChangeForWebview.fire({
             content: this.getText(),
             edits: [],
@@ -880,7 +1013,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
     }
 
     public getText(): string {
-        return formatJsonForNotebookFile(this.getDocumentDataForSerialization());
+        return this.serializeForDisk();
     }
 
     public getCellContent(cellId: string): QuillCellContent | undefined {
@@ -1016,7 +1149,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Set dirty flag and notify listeners about the change
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ cellId, timestamps }],
         });
@@ -1091,7 +1224,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
         });
 
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ cellId, deleted: true }],
         });
@@ -1157,7 +1290,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Set dirty flag and notify listeners about the change
         this._isDirty = true;
-        this._dirtyCellIds.add(newCellId);
+        this.markCellMutated(newCellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ newCellId, referenceCellId, cellType, data }],
         });
@@ -2231,7 +2364,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Set dirty flag and notify listeners about the change
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ cellId, newLabel }],
         });
@@ -2311,7 +2444,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Set dirty flag and notify listeners about the change
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: [{ cellId, isLocked }],
         });
@@ -2454,7 +2587,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark document as dirty
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
 
         // Notify listeners that the document has changed
         this._onDidChangeForVsCodeAndWebview.fire({
@@ -2564,7 +2697,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark document as dirty
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
 
         // Notify listeners that the document has changed
         this._onDidChangeForVsCodeAndWebview.fire({
@@ -2660,7 +2793,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
                     edit.validatedBy = finalValidatedBy;
                     changesDetected = true;
                     if (cell.metadata?.id) {
-                        this._dirtyCellIds.add(cell.metadata.id);
+                        this.markCellMutated(cell.metadata.id);
                     }
                 }
             }
@@ -2949,7 +3082,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
         }
 
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
 
         // Emit change events
         this._onDidChangeForVsCodeAndWebview.fire({
@@ -3021,7 +3154,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify listeners
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });
@@ -3069,7 +3202,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify both VS Code and webview so the change is persisted
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });
@@ -3199,7 +3332,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify VS Code (so the file is persisted) and the webview
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });
@@ -3250,7 +3383,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify VS Code (so the file is persisted) and the webview
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });
@@ -3288,7 +3421,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify listeners
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });
@@ -3350,7 +3483,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
                     }
                     hasChanges = true;
                     if (cell.metadata?.id) {
-                        this._dirtyCellIds.add(cell.metadata.id);
+                        this.markCellMutated(cell.metadata.id);
                     }
                 }
             }
@@ -3405,7 +3538,7 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
         // Mark as dirty and notify listeners
         this._isDirty = true;
-        this._dirtyCellIds.add(cellId);
+        this.markCellMutated(cellId);
         this._onDidChangeForVsCodeAndWebview.fire({
             edits: this._edits,
         });

--- a/src/providers/codexCellEditorProvider/utils/cachedNotebookSerializer.ts
+++ b/src/providers/codexCellEditorProvider/utils/cachedNotebookSerializer.ts
@@ -1,0 +1,121 @@
+/**
+ * Cached notebook serializer for `.codex` / `.source` files.
+ *
+ * Background: a typical `.codex` document contains thousands of cells (often
+ * 3,000–6,000) and weighs several megabytes. Re-running
+ * `JSON.stringify(documentData, null, 2)` on every save dominates save latency
+ * because most cells are unchanged between saves but still get re-stringified.
+ *
+ * Strategy: keep a per-cell cache of `JSON.stringify(cell, null, 2)` keyed by
+ * the cell's id. On each save we walk the cells in order, use the cached
+ * string when present, and only re-stringify cells whose entries have been
+ * invalidated (typically by a mutation to that cell). The owner of the cache
+ * is responsible for invalidating cell entries when a cell's contents change.
+ *
+ * This produces byte-identical output to
+ * `formatJsonForNotebookFile(notebookAsJson)` for the same input — the cache
+ * is purely a CPU optimisation, not a format change.
+ */
+
+import {
+    ensureSingleTrailingNewline,
+    normalizeNewlines,
+} from "../../../utils/notebookFileFormattingUtils";
+
+interface CellLike {
+    metadata?: { id?: string; };
+}
+
+interface NotebookLike<TCell> {
+    cells?: TCell[];
+    metadata?: unknown;
+}
+
+/**
+ * Serialize a notebook-shaped object using a per-cell string cache.
+ *
+ * The output is byte-identical to `formatJsonForNotebookFile(data)` for any
+ * input that has `JSON.stringify`-stable key ordering on `data`,
+ * `data.cells[*]`, and `data.metadata`.
+ */
+export function serializeNotebookWithCellCache<TCell extends CellLike>(
+    data: NotebookLike<TCell>,
+    cellCache: Map<string, string>
+): string {
+    const cells = data.cells ?? [];
+
+    // Build the cells block. JSON.stringify(value, null, 2) outputs an empty
+    // array as `[]` (no newlines), so reproduce that for parity.
+    let cellsBlock: string;
+    if (cells.length === 0) {
+        cellsBlock = `"cells": []`;
+    } else {
+        const cellLines: string[] = [];
+        for (const cell of cells) {
+            cellLines.push(serializeCellWithCache(cell, cellCache));
+        }
+        cellsBlock = `"cells": [\n${cellLines.join(",\n")}\n  ]`;
+    }
+
+    // Metadata is always stringified fresh — it is small, contains no nested
+    // hot loops, and any growth (e.g. metadata.edits[]) is bounded compared to
+    // the cells array.
+    const metadataJson = JSON.stringify(data.metadata, null, 2);
+    const metadataBlock = `"metadata": ${indentLinesAfterFirst(metadataJson, "  ")}`;
+
+    const body = `{\n  ${cellsBlock},\n  ${metadataBlock}\n}`;
+    return ensureSingleTrailingNewline(normalizeNewlines(body));
+}
+
+/**
+ * Serialize a single cell using the cache. Returns the cell's JSON
+ * representation indented to be embedded inside the parent's `cells` array
+ * (i.e. each line prefixed with 4 spaces, matching JSON.stringify's depth-2
+ * indentation).
+ *
+ * The cache stores the *already-indented* string so cache hits are an O(1)
+ * Map lookup with no further string work — this is the whole point of the
+ * cache, since `String.prototype.split` + `.map` + `.join` over a cell's
+ * JSON costs roughly the same as `JSON.stringify` of the cell itself.
+ */
+function serializeCellWithCache<TCell extends CellLike>(
+    cell: TCell,
+    cellCache: Map<string, string>
+): string {
+    const id = cell?.metadata?.id;
+
+    if (typeof id === "string" && id.length > 0) {
+        const cached = cellCache.get(id);
+        if (cached !== undefined) return cached;
+        const fresh = indentEveryLine(JSON.stringify(cell, null, 2), "    ");
+        cellCache.set(id, fresh);
+        return fresh;
+    }
+
+    // Cells without a stable id cannot be cached safely.
+    return indentEveryLine(JSON.stringify(cell, null, 2), "    ");
+}
+
+/**
+ * Prefix every line in `text` with `prefix`. Used for embedding a serialized
+ * cell into the parent document's `cells` array at depth 2 (4-space indent).
+ */
+function indentEveryLine(text: string, prefix: string): string {
+    if (prefix.length === 0) return text;
+    if (!text.includes("\n")) return prefix + text;
+    return text
+        .split("\n")
+        .map((line) => prefix + line)
+        .join("\n");
+}
+
+/**
+ * Prefix every line in `text` EXCEPT the first with `prefix`. Used for
+ * embedding `metadata` into the parent document at depth 1 (2-space indent),
+ * where the first line follows `"metadata": ` directly on the same line.
+ */
+function indentLinesAfterFirst(text: string, prefix: string): string {
+    if (prefix.length === 0 || !text.includes("\n")) return text;
+    const lines = text.split("\n");
+    return lines.map((line, idx) => (idx === 0 ? line : prefix + line)).join("\n");
+}

--- a/src/stateStore.ts
+++ b/src/stateStore.ts
@@ -1,46 +1,83 @@
 import * as vscode from "vscode";
 import { CellIdGlobalState } from "../types";
+import { LocalCellIdStore } from "./utils/cellIdStore";
+
+/**
+ * State store for cross-component cell-id coordination.
+ *
+ * Historically this delegated to the external `project-accelerate.shared-state-store`
+ * extension, which persisted everything to `globalState`. That row grew large
+ * enough to trigger VS Code's `mainThreadStorage` size warning, so we now own
+ * the persistence ourselves via a small JSON file under
+ * `context.globalStorageUri` (see `LocalCellIdStore`). The returned API shape
+ * is unchanged so existing consumers do not need to be updated.
+ */
+
 type StateStoreUpdate =
-    | { key: "cellId"; value: CellIdGlobalState };
+    | { key: "cellId"; value: CellIdGlobalState | undefined };
 
 type StateStoreKey = StateStoreUpdate["key"];
-type StateStoreValue<K extends StateStoreKey> = Extract<StateStoreUpdate, { key: K }>["value"];
-
-const extensionId = "project-accelerate.shared-state-store";
+type StateStoreValue<K extends StateStoreKey> = K extends "cellId" ? CellIdGlobalState : never;
 
 type DisposeFunction = () => void;
-export async function initializeStateStore() {
-    let storeListener: <K extends StateStoreKey>(
-        keyForListener: K,
-        callBack: (value: StateStoreValue<K> | undefined) => void
-    ) => DisposeFunction = () => () => undefined;
 
-    let updateStoreState: (update: StateStoreUpdate) => void = () => undefined;
-    let getStoreState: <K extends StateStoreKey>(
-        key: K
-    ) => Promise<StateStoreValue<K> | undefined> = () => Promise.resolve(undefined);
+let storeInstance: LocalCellIdStore | null = null;
 
-    const extension = vscode.extensions.getExtension(extensionId);
-    if (extension) {
-        const api = await extension.activate();
-        if (!api) {
-            console.log(`Extension ${extensionId} does not expose an API.`);
-        } else {
-            storeListener = api.storeListener;
-
-            updateStoreState = api.updateStoreState;
-            getStoreState = api.getStoreState;
-            return {
-                storeListener,
-                updateStoreState,
-                getStoreState,
-            };
+/**
+ * Constructs (or reuses) the singleton state store. Should be called once at
+ * activation with the extension context. Subsequent calls without a context
+ * return the existing instance.
+ *
+ * If callers somehow invoke this before activation has set up the context,
+ * we return a no-op store that mirrors the public shape so call sites do
+ * not need defensive null-checks.
+ */
+export async function initializeStateStore(context?: vscode.ExtensionContext) {
+    if (!storeInstance) {
+        if (!context) {
+            console.error(
+                "[stateStore] initializeStateStore called before extension context was provided; returning a no-op store."
+            );
+            return makeNoopStore();
         }
+        storeInstance = new LocalCellIdStore(context);
     }
-    console.error(`Extension ${extensionId} not found.`);
+
+    const store = storeInstance;
     return {
-        storeListener,
-        updateStoreState,
-        getStoreState,
+        storeListener: <K extends StateStoreKey>(
+            keyForListener: K,
+            callBack: (value: StateStoreValue<K> | undefined) => void
+        ): DisposeFunction => store.listen(keyForListener, callBack),
+
+        updateStoreState: (update: StateStoreUpdate): void => {
+            store.update(update);
+        },
+
+        getStoreState: <K extends StateStoreKey>(
+            key: K
+        ): Promise<StateStoreValue<K> | undefined> => store.get(key),
     };
+}
+
+function makeNoopStore() {
+    const dispose: DisposeFunction = () => undefined;
+    return {
+        storeListener: <K extends StateStoreKey>(
+            _keyForListener: K,
+            _callBack: (value: StateStoreValue<K> | undefined) => void
+        ): DisposeFunction => dispose,
+        updateStoreState: (_update: StateStoreUpdate): void => undefined,
+        getStoreState: <K extends StateStoreKey>(
+            _key: K
+        ): Promise<StateStoreValue<K> | undefined> => Promise.resolve(undefined),
+    };
+}
+
+/**
+ * Test-only: clear the singleton so each test can construct a fresh store
+ * with its own ExtensionContext fixture. Production code does not call this.
+ */
+export function _resetStateStoreForTests(): void {
+    storeInstance = null;
 }

--- a/src/stateStore.ts
+++ b/src/stateStore.ts
@@ -14,7 +14,7 @@ import { LocalCellIdStore } from "./utils/cellIdStore";
  */
 
 type StateStoreUpdate =
-    | { key: "cellId"; value: CellIdGlobalState | undefined };
+    | { key: "cellId"; value: CellIdGlobalState | undefined; };
 
 type StateStoreKey = StateStoreUpdate["key"];
 type StateStoreValue<K extends StateStoreKey> = K extends "cellId" ? CellIdGlobalState : never;

--- a/src/test/suite/cachedNotebookSerializer.test.ts
+++ b/src/test/suite/cachedNotebookSerializer.test.ts
@@ -1,0 +1,169 @@
+import * as assert from "assert";
+import { serializeNotebookWithCellCache } from "../../providers/codexCellEditorProvider/utils/cachedNotebookSerializer";
+import { formatJsonForNotebookFile } from "../../utils/notebookFileFormattingUtils";
+
+/**
+ * Byte-equivalence tests for the cached serializer.
+ *
+ * The cache is a CPU optimisation, not a format change: the bytes written to
+ * disk must remain identical to what `formatJsonForNotebookFile` produces, so
+ * we compare them on a representative range of inputs.
+ */
+
+function makeCell(id: string, value = "<p>Hello</p>", extra: Record<string, unknown> = {}) {
+    return {
+        kind: 2,
+        value,
+        languageId: "html",
+        metadata: {
+            id,
+            type: "text",
+            edits: [],
+            data: {},
+            ...extra,
+        },
+    };
+}
+
+suite("cachedNotebookSerializer", () => {
+    test("matches formatJsonForNotebookFile for an empty document", () => {
+        const data = { cells: [], metadata: { id: "doc-1" } };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+    });
+
+    test("matches formatJsonForNotebookFile for a single-cell document", () => {
+        const data = {
+            cells: [makeCell("c1")],
+            metadata: { id: "doc-2", originalName: "Doc Two" },
+        };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+    });
+
+    test("matches formatJsonForNotebookFile for a multi-cell document", () => {
+        const data = {
+            cells: [
+                makeCell("a"),
+                makeCell("b", "<p>World</p>"),
+                makeCell("c", "<p>Third</p>", {
+                    edits: [
+                        {
+                            editMap: ["value"],
+                            value: "<p>edit</p>",
+                            timestamp: 123,
+                            type: "user-edit",
+                            author: "alice",
+                            validatedBy: [],
+                        },
+                    ],
+                }),
+            ],
+            metadata: {
+                id: "doc-3",
+                originalName: "Doc Three",
+                navigation: [],
+                edits: [
+                    { editMap: ["metadata", "originalName"], value: "Doc Three", timestamp: 1 },
+                ],
+            },
+        };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+    });
+
+    test("matches formatJsonForNotebookFile for nested objects with arrays", () => {
+        const data = {
+            cells: [
+                makeCell("x", "<p>Nested</p>", {
+                    attachments: {
+                        "audio-1": { url: "files/foo.wav", type: "audio" },
+                    },
+                    data: {
+                        startTime: 1.5,
+                        endTime: 3.25,
+                        globalReferences: ["ref1", "ref2"],
+                    },
+                }),
+            ],
+            metadata: {
+                id: "doc-4",
+                navigation: [
+                    { kind: "book", label: "Genesis", children: [] },
+                ],
+            },
+        };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+    });
+
+    test("populates the cache on first call", () => {
+        const data = {
+            cells: [makeCell("a"), makeCell("b")],
+            metadata: { id: "doc-5" },
+        };
+        const cache = new Map<string, string>();
+        serializeNotebookWithCellCache(data, cache);
+        assert.strictEqual(cache.size, 2);
+        assert.ok(cache.has("a"));
+        assert.ok(cache.has("b"));
+    });
+
+    test("reuses cached entries on subsequent calls", () => {
+        const data = {
+            cells: [makeCell("a"), makeCell("b")],
+            metadata: { id: "doc-6" },
+        };
+        const cache = new Map<string, string>();
+        const first = serializeNotebookWithCellCache(data, cache);
+
+        // Mutate cell 'a' in place but DO NOT invalidate the cache.
+        // Output must still reflect the previous (cached) value of cell 'a'.
+        data.cells[0].value = "<p>changed but cache stale</p>";
+        const second = serializeNotebookWithCellCache(data, cache);
+        assert.strictEqual(second, first, "cache should win when entry not invalidated");
+
+        // Now invalidate the cache for cell 'a' and re-serialize. Output should
+        // reflect the mutation.
+        cache.delete("a");
+        const third = serializeNotebookWithCellCache(data, cache);
+        assert.notStrictEqual(third, first, "cache invalidation should pick up mutation");
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(third, reference);
+    });
+
+    test("handles cells without an id by skipping the cache", () => {
+        const data = {
+            cells: [
+                { kind: 2, value: "anonymous", languageId: "html", metadata: {} },
+            ],
+            metadata: { id: "doc-7" },
+        };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+        assert.strictEqual(cache.size, 0, "cells without ids should not enter the cache");
+    });
+
+    test("handles multi-line embedded values (HTML in cell value)", () => {
+        const data = {
+            cells: [
+                makeCell("ml", "<p>line1</p>\n<p>line2</p>\n<p>line3</p>"),
+            ],
+            metadata: { id: "doc-8" },
+        };
+        const cache = new Map<string, string>();
+        const ours = serializeNotebookWithCellCache(data, cache);
+        const reference = formatJsonForNotebookFile(data);
+        assert.strictEqual(ours, reference);
+    });
+});

--- a/src/test/suite/cellIdStore.test.ts
+++ b/src/test/suite/cellIdStore.test.ts
@@ -1,0 +1,194 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as os from "os";
+import * as path from "path";
+import { LocalCellIdStore } from "../../utils/cellIdStore";
+import type { CellIdGlobalState } from "../../../types";
+
+function makeContextForTests(): vscode.ExtensionContext {
+    const dir = path.join(
+        os.tmpdir(),
+        `codex-cellid-store-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    // @ts-expect-error - partial context for tests
+    const context: vscode.ExtensionContext = {
+        globalStorageUri: vscode.Uri.file(dir),
+        subscriptions: [],
+    } as vscode.ExtensionContext;
+    return context;
+}
+
+async function safeDelete(uri: vscode.Uri): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(uri, { recursive: true, useTrash: false });
+    } catch {
+        // ignore
+    }
+}
+
+function makeCellIdState(cellId: string, uri = "file:///tmp/test.codex"): CellIdGlobalState {
+    return {
+        cellId,
+        globalReferences: [],
+        uri,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+suite("cellIdStore.LocalCellIdStore", () => {
+    test("get returns undefined when the backing file does not exist yet", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            const value = await store.get("cellId");
+            assert.strictEqual(value, undefined);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("update then get round-trips a value through disk", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            const payload = makeCellIdState("cell-1");
+
+            store.update({ key: "cellId", value: payload });
+            await store.flushNow();
+
+            // Force a re-read from disk so we know we're not just reading the
+            // in-memory cache.
+            store._resetCacheForTests();
+            const value = await store.get("cellId");
+            assert.deepStrictEqual(value, payload);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("a fresh store reads the value persisted by a previous instance", async () => {
+        const context = makeContextForTests();
+        try {
+            const writer = new LocalCellIdStore(context);
+            const payload = makeCellIdState("cell-2");
+            writer.update({ key: "cellId", value: payload });
+            await writer.flushNow();
+
+            const reader = new LocalCellIdStore(context);
+            const value = await reader.get("cellId");
+            assert.deepStrictEqual(value, payload);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("listen is notified on update and dispose stops further notifications", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            const received: Array<CellIdGlobalState | undefined> = [];
+            const dispose = store.listen("cellId", (value) => received.push(value));
+
+            const a = makeCellIdState("cell-A");
+            store.update({ key: "cellId", value: a });
+            await store.flushNow();
+
+            // Dispose, then update again — listener should not see the second.
+            dispose();
+            const b = makeCellIdState("cell-B");
+            store.update({ key: "cellId", value: b });
+            await store.flushNow();
+
+            assert.strictEqual(received.length, 1, "only the pre-dispose update should be observed");
+            assert.deepStrictEqual(received[0], a);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("multiple rapid updates coalesce into a single persisted value", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            for (let i = 0; i < 10; i++) {
+                store.update({ key: "cellId", value: makeCellIdState(`cell-${i}`) });
+            }
+            await store.flushNow();
+
+            // Re-read from disk; the persisted value should be the last update.
+            store._resetCacheForTests();
+            const value = await store.get("cellId");
+            assert.ok(value, "value should be defined");
+            assert.strictEqual(value!.cellId, "cell-9");
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("update with value undefined deletes the key from the persisted file", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            store.update({ key: "cellId", value: makeCellIdState("cell-X") });
+            await store.flushNow();
+
+            store.update({ key: "cellId", value: undefined });
+            await store.flushNow();
+
+            store._resetCacheForTests();
+            const value = await store.get("cellId");
+            assert.strictEqual(value, undefined);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("backing file lives at globalStorageUri/state.json (cross-platform)", async () => {
+        const context = makeContextForTests();
+        try {
+            const store = new LocalCellIdStore(context);
+            const payload = makeCellIdState("cell-path-check");
+            store.update({ key: "cellId", value: payload });
+            await store.flushNow();
+
+            const expectedUri = vscode.Uri.joinPath(context.globalStorageUri, "state.json");
+            const stat = await vscode.workspace.fs.stat(expectedUri);
+            assert.ok(stat.size > 0, "state.json should be written and non-empty");
+
+            // Verify the content is valid JSON containing the cellId object.
+            const bytes = await vscode.workspace.fs.readFile(expectedUri);
+            const text = new TextDecoder("utf-8").decode(bytes);
+            const parsed = JSON.parse(text);
+            assert.deepStrictEqual(parsed.cellId, payload);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("malformed state.json is treated as empty and overwritten on next update", async () => {
+        const context = makeContextForTests();
+        try {
+            // Pre-seed a malformed file.
+            await vscode.workspace.fs.createDirectory(context.globalStorageUri);
+            const fileUri = vscode.Uri.joinPath(context.globalStorageUri, "state.json");
+            await vscode.workspace.fs.writeFile(
+                fileUri,
+                new TextEncoder().encode("this is not json")
+            );
+
+            const store = new LocalCellIdStore(context);
+            const valueBefore = await store.get("cellId");
+            assert.strictEqual(valueBefore, undefined, "malformed file → empty cache");
+
+            const payload = makeCellIdState("cell-recovered");
+            store.update({ key: "cellId", value: payload });
+            await store.flushNow();
+
+            store._resetCacheForTests();
+            const valueAfter = await store.get("cellId");
+            assert.deepStrictEqual(valueAfter, payload);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+});

--- a/src/test/suite/oneTimeMigrations.test.ts
+++ b/src/test/suite/oneTimeMigrations.test.ts
@@ -1,0 +1,120 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as os from "os";
+import * as path from "path";
+import { runOnce, loadFlags, isFlagSet, setFlag } from "../../utils/oneTimeMigrations";
+
+function makeContextForTests(): vscode.ExtensionContext {
+    const dir = path.join(
+        os.tmpdir(),
+        `codex-onetime-migrations-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    // @ts-expect-error - partial context for tests
+    const context: vscode.ExtensionContext = {
+        globalStorageUri: vscode.Uri.file(dir),
+        subscriptions: [],
+    } as vscode.ExtensionContext;
+    return context;
+}
+
+async function safeDelete(uri: vscode.Uri): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(uri, { recursive: true, useTrash: false });
+    } catch {
+        // ignore
+    }
+}
+
+suite("oneTimeMigrations", () => {
+    test("loadFlags returns empty when migrations.json is missing", async () => {
+        const context = makeContextForTests();
+        try {
+            const flags = await loadFlags(context);
+            assert.deepStrictEqual(flags, {});
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("runOnce executes fn the first time and persists the flag", async () => {
+        const context = makeContextForTests();
+        try {
+            let calls = 0;
+            await runOnce(context, "demoMigrationV1", async () => {
+                calls += 1;
+            });
+            assert.strictEqual(calls, 1);
+            const flagged = await isFlagSet(context, "demoMigrationV1");
+            assert.strictEqual(flagged, true);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("runOnce skips fn on a second invocation with the same id", async () => {
+        const context = makeContextForTests();
+        try {
+            let calls = 0;
+            await runOnce(context, "demoMigrationV1", async () => {
+                calls += 1;
+            });
+            await runOnce(context, "demoMigrationV1", async () => {
+                calls += 1;
+            });
+            assert.strictEqual(calls, 1, "fn should run exactly once");
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("runOnce does NOT mark the flag if fn throws (so the migration retries)", async () => {
+        const context = makeContextForTests();
+        try {
+            await assert.rejects(
+                runOnce(context, "flakyMigration", async () => {
+                    throw new Error("boom");
+                })
+            );
+            const flagged = await isFlagSet(context, "flakyMigration");
+            assert.strictEqual(flagged, false);
+
+            // Subsequent successful run should set the flag normally.
+            let calls = 0;
+            await runOnce(context, "flakyMigration", async () => {
+                calls += 1;
+            });
+            assert.strictEqual(calls, 1);
+            assert.strictEqual(await isFlagSet(context, "flakyMigration"), true);
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("multiple migrations coexist in the same migrations.json", async () => {
+        const context = makeContextForTests();
+        try {
+            await runOnce(context, "migrationA", async () => undefined);
+            await runOnce(context, "migrationB", async () => undefined);
+            const flags = await loadFlags(context);
+            assert.ok(flags.migrationA, "migrationA flag should be set");
+            assert.ok(flags.migrationB, "migrationB flag should be set");
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+
+    test("setFlag is idempotent and overwrites the timestamp", async () => {
+        const context = makeContextForTests();
+        try {
+            await setFlag(context, "manualFlag");
+            const before = (await loadFlags(context)).manualFlag.ranAt;
+            // Wait a tick to ensure the second timestamp differs.
+            await new Promise((r) => setTimeout(r, 10));
+            await setFlag(context, "manualFlag");
+            const after = (await loadFlags(context)).manualFlag.ranAt;
+            assert.ok(before !== after, "ranAt should refresh on re-set");
+        } finally {
+            await safeDelete(context.globalStorageUri);
+        }
+    });
+});

--- a/src/utils/cellIdStore.ts
+++ b/src/utils/cellIdStore.ts
@@ -1,0 +1,230 @@
+import * as vscode from "vscode";
+import { EventEmitter } from "events";
+import { CellIdGlobalState } from "../../types";
+
+/**
+ * File-backed replacement for the `project-accelerate.shared-state-store`
+ * extension's `cellId` channel.
+ *
+ * Why this exists:
+ * - shared-state-store persists everything to `globalState`, which lives in
+ *   `state.vscdb` and is hydrated synchronously on activation. With many
+ *   updates over time the row grew large enough to trigger VS Code's
+ *   `mainThreadStorage` >5 MB warning.
+ * - The only consumer of the `cellId` key is codex-editor itself, so we own
+ *   the state internally and persist it to a small JSON file under
+ *   `context.globalStorageUri` instead. This file is lazily loaded, so it
+ *   adds zero activation cost and has no size warning.
+ *
+ * Cross-platform note: all paths come from `vscode.Uri.joinPath` and all I/O
+ * goes through `vscode.workspace.fs`. There is no `path.join`, no SQLite
+ * reach-in, and no native dependency.
+ */
+
+export type CellIdStateStoreUpdate = { key: "cellId"; value: CellIdGlobalState | undefined };
+export type CellIdStateStoreKey = CellIdStateStoreUpdate["key"];
+export type CellIdStateStoreValue<K extends CellIdStateStoreKey> = K extends "cellId" ? CellIdGlobalState : never;
+
+type DisposeFunction = () => void;
+
+interface StoreShape {
+    cellId?: CellIdGlobalState;
+}
+
+export class LocalCellIdStore {
+    private readonly fileUri: vscode.Uri;
+    private readonly tmpUri: vscode.Uri;
+    private readonly emitter = new EventEmitter();
+
+    private cache: StoreShape | null = null;
+    private loading: Promise<void> | null = null;
+
+    private flushTimer: ReturnType<typeof setTimeout> | null = null;
+    private flushPromise: Promise<void> | null = null;
+    private dirty = false;
+
+    /**
+     * Tail of the chain of in-flight `update()` calls. Each `update()` queues
+     * its in-memory mutation onto this chain so we have a single awaitable
+     * that resolves once *all* pending mutations have been applied. `flushNow`
+     * uses this to guarantee writes are observable in tests where callers
+     * cannot await `update()` itself (its public API returns void).
+     */
+    private applyChain: Promise<void> = Promise.resolve();
+
+    private static readonly FLUSH_DEBOUNCE_MS = 150;
+
+    constructor(private readonly context: vscode.ExtensionContext) {
+        this.fileUri = vscode.Uri.joinPath(context.globalStorageUri, "state.json");
+        this.tmpUri = vscode.Uri.joinPath(context.globalStorageUri, "state.json.tmp");
+    }
+
+    private async ensureLoaded(): Promise<void> {
+        if (this.cache !== null) return;
+        if (this.loading) {
+            await this.loading;
+            return;
+        }
+        this.loading = this.loadFromDisk();
+        try {
+            await this.loading;
+        } finally {
+            this.loading = null;
+        }
+    }
+
+    private async loadFromDisk(): Promise<void> {
+        try {
+            const bytes = await vscode.workspace.fs.readFile(this.fileUri);
+            const text = new TextDecoder("utf-8").decode(bytes);
+            const parsed = JSON.parse(text);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                this.cache = parsed as StoreShape;
+                return;
+            }
+        } catch {
+            // File missing, unreadable, or malformed — start with empty state.
+        }
+        this.cache = {};
+    }
+
+    public async get<K extends CellIdStateStoreKey>(
+        key: K
+    ): Promise<CellIdStateStoreValue<K> | undefined> {
+        await this.ensureLoaded();
+        const value = (this.cache as StoreShape)[key];
+        return value as CellIdStateStoreValue<K> | undefined;
+    }
+
+    /**
+     * Fire-and-forget update. Matches the shape of the previous external
+     * shared-state-store API (which also returned void). Persistence happens
+     * asynchronously via a debounced flush to coalesce bursts of cell-click
+     * updates into a single disk write.
+     *
+     * Updates are serialized onto `applyChain` so they apply in call order
+     * even when the cache is still loading. `flushNow()` awaits that chain
+     * to guarantee durability.
+     */
+    public update(payload: CellIdStateStoreUpdate): void {
+        const next = this.applyChain
+            .then(() => this.ensureLoaded())
+            .then(() => this.applyUpdateToCache(payload));
+        // Swallow rejections to keep the chain alive; log so failures aren't
+        // silent. We re-assign with the catch'd promise so subsequent updates
+        // chain onto a settled promise rather than a rejected one.
+        this.applyChain = next.catch((err) => {
+            console.error("[cellIdStore] update failed:", err);
+        });
+    }
+
+    private applyUpdateToCache(payload: CellIdStateStoreUpdate): void {
+        const cache = this.cache as StoreShape;
+        const previous = cache[payload.key];
+
+        if (payload.value === undefined) {
+            delete cache[payload.key];
+        } else {
+            cache[payload.key] = payload.value;
+        }
+
+        const previousJson = previous === undefined ? undefined : JSON.stringify(previous);
+        const nextJson = payload.value === undefined ? undefined : JSON.stringify(payload.value);
+
+        // Always notify listeners, even when the value didn't change, to
+        // preserve the previous external store's behaviour. Skip the disk
+        // flush in that case — it would be a no-op.
+        this.emitter.emit(payload.key, payload.value);
+
+        if (previousJson !== nextJson) {
+            this.dirty = true;
+            this.scheduleFlush();
+        }
+    }
+
+    public listen<K extends CellIdStateStoreKey>(
+        key: K,
+        callback: (value: CellIdStateStoreValue<K> | undefined) => void
+    ): DisposeFunction {
+        const handler = (value: CellIdStateStoreValue<K> | undefined) => {
+            try {
+                callback(value);
+            } catch (e) {
+                console.error("[cellIdStore] listener threw:", e);
+            }
+        };
+        this.emitter.on(key, handler);
+        return () => {
+            this.emitter.off(key, handler);
+        };
+    }
+
+    private scheduleFlush(): void {
+        if (this.flushTimer) return;
+        this.flushTimer = setTimeout(() => {
+            this.flushTimer = null;
+            void this.flush();
+        }, LocalCellIdStore.FLUSH_DEBOUNCE_MS);
+    }
+
+    private async flush(): Promise<void> {
+        if (!this.dirty) return;
+        if (this.flushPromise) {
+            // Coalesce concurrent flushes — wait for the in-flight one and
+            // then re-evaluate (a new update may have arrived during it).
+            await this.flushPromise;
+            return this.flush();
+        }
+        this.flushPromise = this.doFlush();
+        try {
+            await this.flushPromise;
+        } finally {
+            this.flushPromise = null;
+        }
+    }
+
+    private async doFlush(): Promise<void> {
+        if (this.cache === null) return;
+        // Snapshot first so concurrent updates after we serialize don't mark
+        // us clean prematurely.
+        this.dirty = false;
+        const snapshot = JSON.stringify(this.cache, null, 2);
+        try {
+            await vscode.workspace.fs.createDirectory(this.context.globalStorageUri);
+            const bytes = new TextEncoder().encode(`${snapshot}\n`);
+            await vscode.workspace.fs.writeFile(this.tmpUri, bytes);
+            await vscode.workspace.fs.rename(this.tmpUri, this.fileUri, { overwrite: true });
+        } catch (err) {
+            console.error("[cellIdStore] flush failed:", err);
+            // Re-mark dirty so a future call retries.
+            this.dirty = true;
+        }
+    }
+
+    /**
+     * Force any pending writes to disk immediately. Intended for tests and
+     * for clean-shutdown paths where we want to guarantee durability.
+     *
+     * Awaits the in-memory `applyChain` first so any update() calls issued
+     * synchronously before flushNow are guaranteed to be reflected on disk.
+     */
+    public async flushNow(): Promise<void> {
+        await this.applyChain;
+        if (this.flushTimer) {
+            clearTimeout(this.flushTimer);
+            this.flushTimer = null;
+        }
+        if (this.dirty || this.flushPromise) {
+            await this.flush();
+        }
+    }
+
+    /**
+     * Test-only: synchronously drop the in-memory cache so the next read
+     * re-loads from disk. Production code does not need this.
+     */
+    public _resetCacheForTests(): void {
+        this.cache = null;
+        this.loading = null;
+    }
+}

--- a/src/utils/oneTimeMigrations.ts
+++ b/src/utils/oneTimeMigrations.ts
@@ -1,0 +1,92 @@
+import * as vscode from "vscode";
+
+/**
+ * Tiny persistence layer for "I have run this one-shot bookkeeping task" flags.
+ *
+ * The flags live as JSON inside the extension's `globalStorageUri` so they
+ * never contribute to `state.vscdb` and are not subject to the
+ * `mainThreadStorage` size warning.
+ *
+ * The file shape is `{ [migrationId]: { ranAt: ISOString } }`.
+ *
+ * A flag is set only after the migration body resolves successfully. If the
+ * body throws, the flag is left unset so the next activation retries.
+ */
+
+interface MigrationFlag {
+    ranAt: string;
+}
+
+type MigrationFlags = Record<string, MigrationFlag>;
+
+const FLAGS_FILE = "migrations.json";
+const FLAGS_TMP_FILE = "migrations.json.tmp";
+
+function flagsUri(context: vscode.ExtensionContext): vscode.Uri {
+    return vscode.Uri.joinPath(context.globalStorageUri, FLAGS_FILE);
+}
+
+function tmpFlagsUri(context: vscode.ExtensionContext): vscode.Uri {
+    return vscode.Uri.joinPath(context.globalStorageUri, FLAGS_TMP_FILE);
+}
+
+export async function loadFlags(context: vscode.ExtensionContext): Promise<MigrationFlags> {
+    try {
+        const bytes = await vscode.workspace.fs.readFile(flagsUri(context));
+        const text = new TextDecoder("utf-8").decode(bytes);
+        const parsed = JSON.parse(text);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as MigrationFlags;
+        }
+        return {};
+    } catch {
+        // File missing or unreadable — treat as empty.
+        return {};
+    }
+}
+
+async function writeFlags(context: vscode.ExtensionContext, flags: MigrationFlags): Promise<void> {
+    await vscode.workspace.fs.createDirectory(context.globalStorageUri);
+    const finalUri = flagsUri(context);
+    const tmpUri = tmpFlagsUri(context);
+    const bytes = new TextEncoder().encode(`${JSON.stringify(flags, null, 2)}\n`);
+    // Atomic write: write to a temp sibling, then rename onto the final path.
+    // VS Code's `rename({ overwrite: true })` normalizes Windows vs POSIX rename
+    // semantics, so this works identically across platforms.
+    await vscode.workspace.fs.writeFile(tmpUri, bytes);
+    await vscode.workspace.fs.rename(tmpUri, finalUri, { overwrite: true });
+}
+
+export async function setFlag(context: vscode.ExtensionContext, id: string): Promise<void> {
+    const flags = await loadFlags(context);
+    flags[id] = { ranAt: new Date().toISOString() };
+    await writeFlags(context, flags);
+}
+
+export async function isFlagSet(context: vscode.ExtensionContext, id: string): Promise<boolean> {
+    const flags = await loadFlags(context);
+    return Boolean(flags[id]);
+}
+
+/**
+ * Runs `fn` exactly once across all activations of the extension. The
+ * "ran successfully" mark is persisted under
+ * `${globalStorageUri}/migrations.json`.
+ *
+ * If `fn` throws, the flag is NOT set so the next activation retries. The
+ * thrown error is rethrown to the caller so it can decide whether to log,
+ * surface a UI error, or silently continue.
+ */
+export async function runOnce(
+    context: vscode.ExtensionContext,
+    id: string,
+    fn: () => Promise<void>
+): Promise<void> {
+    const flags = await loadFlags(context);
+    if (flags[id]) return;
+
+    await fn();
+
+    flags[id] = { ranAt: new Date().toISOString() };
+    await writeFlags(context, flags);
+}


### PR DESCRIPTION
## Summary

Test Project: 957-json-save-error-fix

This PR delivers three logically related changes to the cell editor save path and extension storage that, taken together, eliminate two persistent pain points: large-document save slowness and a multi-megabyte `mainThreadStorage` warning at activation.

1. **Save-path performance optimization** (`Strategy B`) — caching, skip-merge, coalescing.
2. **Move `cellId` state off `project-accelerate.shared-state-store`** into a local file-backed store under `globalStorageUri`.
3. **One-time cleanup** of orphaned rows (`cellId`, `sourceCellMap`) that the legacy `shared-state-store` had been hauling into memory on every activation.

## Changes

### 1. Cached notebook serializer + cell mutation tracking (`0771e7c0`)

`CodexCellDocument.save()` previously re-stringified every cell on every save. For large notebooks this cost dominated wall-clock save time and, combined with a non-skipping merge step, contributed to truncated writes under load.

- **New `src/providers/codexCellEditorProvider/utils/cachedNotebookSerializer.ts`**: byte-identical replacement for `formatJsonForNotebookFile` that caches per-cell pre-indented JSON. Cache hits are O(1) string lookups.
- **`CodexCellDocument`** (`src/providers/codexCellEditorProvider/codexDocument.ts`):
  - `_serializedCellCache: Map<string, string>` — per-cell serialized form.
  - `_lastWrittenContent: string | null` — enables a **skip-merge fast path**: if disk content is byte-identical to what we last wrote, we bypass `resolveCodexCustomMerge` entirely and write directly.
  - `_saveChainPromise` + `_pendingSaveRequested` — **save coalescing** so concurrent save requests collapse into one in-flight save plus at most one follow-up.
  - `markCellMutated(cellId)` — promoted to `public`. Single source of truth for marking a cell dirty and invalidating its cache entry. All direct mutation sites now go through this helper:
    - `mergeCellWithPrevious` and `cancelMerge` in `codexCellEditorMessagehandling.ts`
    - `unmergeMatchingCellsInTargetFile` in `codexCellEditorProvider.ts`
  - `serializeForDisk()` — new helper used by `save()`, `saveAs()`, and `getText()`.
  - `revert()` clears `_serializedCellCache` and resets `_lastWrittenContent` to disk text.

### 2. Local `cellId` state store (`32995b62`)

`project-accelerate.shared-state-store` persists everything through `globalState` (backed by VS Code's `state.vscdb`). That file is hydrated synchronously on extension activation, so anything stored there directly impacts startup time and triggers the `mainThreadStorage > 5 MB` warning.

`cellId` doesn't need to live there. We replaced the external dependency with a small file-backed store under the extension's own `globalStorageUri`.

- **New `src/utils/oneTimeMigrations.ts`**: `runOnce(context, id, fn)` helper that persists a flag in `globalStorageUri/migrations.json` (atomic write via temp file + rename). Idempotent; flag is only set on success.
- **New `src/utils/cellIdStore.ts`**: `LocalCellIdStore` class.
  - Lazy load from `globalStorageUri/state.json`.
  - In-memory cache + in-process `EventEmitter` for listeners.
  - Debounced atomic writes (temp + rename) — coalesces bursts of `update()` calls.
  - `applyChain` promise serializes in-memory mutations so `flushNow()` can correctly observe pending updates (race-free).
- **`src/stateStore.ts`**: `initializeStateStore(context?)` now constructs/returns a `LocalCellIdStore` singleton. The public API (`storeListener`, `updateStoreState`, `getStoreState`) is unchanged, so call sites in `codexCellEditorProvider.ts` and elsewhere did not need to change.
- **`src/extension.ts`**: `await initializeStateStore(context)` runs early in `activate()`, before any provider that may call `initializeStateStore()` again.

### 3. `sharedStateStoreOrphanCleanupV2` migration (`2d4c16e8`)

Investigation of the `mainThreadStorage` warning revealed that the bloat was not `cellId` (~249 bytes) but a long-orphaned key called `sourceCellMap` (~22.8 MB on the test machine). It was written by `src/activationHelpers/contextAware/miniIndex/indexes/sourceTextIndex.ts` in the `0.0.x` series and the writer was deleted in commit `0c74bb57` (tag `0.6.1`). The data has been sitting in `state.vscdb` ever since.

- **`src/extension.ts`**: replaces `sharedStateStoreCellIdCleanupV1` with `sharedStateStoreOrphanCleanupV2`.
  - The new ID forces machines that already executed V1 to re-run.
  - Wipes both `cellId` and `sourceCellMap` from the `shared-state-store` extension's `globalState` (via its public `updateStoreState({ key, value: undefined })` API — no SQLite reach-in).
  - Per-key try/catch so a single failure does not skip the rest.
- The cleanup runs **once** per machine; the success flag lives in `globalStorageUri/migrations.json`.

## Tests

All three commits ship with focused unit tests; the full suite passes.

- **`src/test/suite/cachedNotebookSerializer.test.ts`** — verifies byte-equivalence between the cached serializer and `formatJsonForNotebookFile` across empty, single-cell, multi-cell, deeply nested, and uncached-cell scenarios.
- **`src/test/suite/cellIdStore.test.ts`** — covers:
  - Read/write round-trips and listener notifications.
  - Coalescing of rapid `update()` calls into a single disk write.
  - Atomic write semantics (temp + rename).
  - Recovery from missing or malformed `state.json`.
  - Race-free interaction between `update()` and `flushNow()`.
- **`src/test/suite/oneTimeMigrations.test.ts`** — covers first-run vs second-run, missing flag file, multiple coexisting migrations, error handling (flag not set if `fn` throws), and `setFlag` idempotence.
- No regressions in existing `codexCellEditorProvider.test.ts`, `notebookSafeSaveUtils.test.ts`, or `resolveCodexCustomMerge.test.ts`.

`npm run compile`, `npx tsc --noEmit`, and `npm run lint` all clean.

## How to test

### Verify the bloat is gone

This is the headline check. The single command below prints **one number**: the byte size of the `project-accelerate.shared-state-store` row inside `state.vscdb`.

Run it **before** installing the new build, then run it again **after** activating the new build once. The number should drop from millions of bytes to `2`.

> Note: the whole `state.vscdb` file size won't shrink — SQLite doesn't reclaim space without `VACUUM`. The **row size** is what matters and what triggers the `mainThreadStorage` warning. Substitute `Codex Beta` for `Codex` in the path if testing the beta build.

**Windows (PowerShell):**

```powershell
python -c "import os,sqlite3;p=os.path.join(os.environ['APPDATA'],r'Codex\User\globalStorage\state.vscdb').replace('\\','/');c=sqlite3.connect('file:'+p+'?mode=ro',uri=True);x=c.execute('select length(value) from ItemTable where key=?',('project-accelerate.shared-state-store',)).fetchone();print(x[0] if x else 'no row')"
```

**macOS (bash/zsh):**

```bash
python3 -c "import os,sqlite3;p=os.path.join(os.environ['HOME'],'Library/Application Support/Codex/User/globalStorage/state.vscdb');c=sqlite3.connect('file:'+p+'?mode=ro',uri=True);x=c.execute('select length(value) from ItemTable where key=?',('project-accelerate.shared-state-store',)).fetchone();print(x[0] if x else 'no row')"
```

**Linux (bash):**

```bash
python3 -c "import os,sqlite3;p=os.path.join(os.environ['HOME'],'.config/Codex/User/globalStorage/state.vscdb');c=sqlite3.connect('file:'+p+'?mode=ro',uri=True);x=c.execute('select length(value) from ItemTable where key=?',('project-accelerate.shared-state-store',)).fetchone();print(x[0] if x else 'no row')"
```

Expected: a large number before, `2` after. On a clean machine without legacy data, `no row` or `2` are both fine.

### Verify the migration ran exactly once

The migration flag and the local cellId store are JSON files under the extension's globalStorageUri. Confirm they exist after activation:

- macOS: `~/Library/Application Support/Codex/User/globalStorage/project-accelerate.codex-editor-extension/migrations.json` and `state.json`
- Linux: `~/.config/Codex/User/globalStorage/project-accelerate.codex-editor-extension/migrations.json` and `state.json`
- Windows: `%APPDATA%\Codex\User\globalStorage\project-accelerate.codex-editor-extension\migrations.json` and `state.json`

`migrations.json` should contain an entry like `"sharedStateStoreOrphanCleanupV2": { "ranAt": "..." }`. Restarting Codex must not change `ranAt` (migration runs exactly once).

## Verification on a real machine

A diagnostic was used to confirm the migration is effective:

- **Before V2**: row was ~22.8 MB (one `sourceCellMap` key dominating).
- **After V2 + activation of the new build**: row shrunk to **2 bytes** (`{}`). The `mainThreadStorage` warning no longer appears in the console at activation.

## Risk / rollback

- **Save path changes** are gated by `markCellMutated` calls at every direct mutation site. The cache is per-document and lives only as long as the document is open, so a stale entry survives at most until the next reload.
- **Local cellId store**: same surface area as before (`storeListener`, `updateStoreState`, `getStoreState`). If `globalStorageUri/state.json` is missing or malformed, the store starts empty — equivalent to a fresh install.
- **V2 cleanup**: only ever calls `updateStoreState({ key, value: undefined })`, which is the public API the `shared-state-store` extension already exposes. No direct SQLite writes. If the extension is not installed, the cleanup is a no-op.

Rollback path: revert these commits. The local `state.json` would become orphaned but harmless. Existing users would not regain the deleted `sourceCellMap` data, which is correct — that data was already unused.

## Test plan
IMPORTANT! Some of the tests should run before opening the pinned project (as that will clear the file).
- [ ] Install the built `.vsix` on a Windows machine that previously triggered the `mainThreadStorage` warning. Confirm the warning is gone.
- [x] Open a large `.codex` file, edit a cell, and save. Confirm save latency on a 6 MB+ notebook is materially better than the prior build.
- [ ] Run the platform-appropriate single-line command above before and after applying the fix. Confirm the number drops from millions to `2`.
- [ ] Confirm `migrations.json` and `state.json` exist under the extension's globalStorageUri.
- [ ] Restart the editor. Re-run the command. Confirm the row size and `migrations.json` `ranAt` are unchanged.
- [ ] On a clean machine without the bloat, confirm everything still activates correctly and the migration completes silently.