### PR TITLE
956 verse ranges missing after closing issue 848

### DIFF
--- a/.cursor/plans/verse-range-paratext-and-sync_95d659b4.plan.md
+++ b/.cursor/plans/verse-range-paratext-and-sync_95d659b4.plan.md
@@ -25,12 +25,12 @@ isProject: false
 
 ## Goals
 
-- Issue 1: paratext that originally sat between a milestone and the first verse (e.g. the chapter heading "ဖန်ဆင်းခြင်း" with `parentId: 98c7b6a3-…` in your sample) must stay there. Only paratext that was actually disconnected from its parent should move.
+- Issue 1: every parented paratext must be emitted ABOVE its parent verse cell (section-heading paratexts like `\s` in USFM belong above the verse they introduce). Paratext that was already between a milestone and the first verse stays where it was; paratext that originally sat after its parent gets moved to above the parent.
 - Issue 2: the cell ordering produced by `migration_verseRangeLabelsAndPositions` (and the verse-range `cellLabel` it sets) must survive git sync, regardless of which side of the merge the local file is on.
 
 ## Root causes
 
-- Paratext placement: in [`migrateVerseRangeLabelsAndPositionsForFile`](src/projectManager/utils/migrationUtils.ts) lines 3037–3048 every paratext gets bucketed by `parentId` and `emitContentCell` always emits the bucket _after_ the parent ([3212–3217](src/projectManager/utils/migrationUtils.ts)). There is no "before-parent" bucket, so chapter-heading paratexts placed between a milestone and the first verse are forced to after the parent verse.
+- Paratext placement: in [`migrateVerseRangeLabelsAndPositionsForFile`](src/projectManager/utils/migrationUtils.ts) lines 3037–3048 every paratext gets bucketed by `parentId` and `emitContentCell` always emits the bucket _after_ the parent ([3212–3217](src/projectManager/utils/migrationUtils.ts)). There is no "before-parent" bucket, so chapter-heading paratexts placed between a milestone and the first verse are forced to after the parent verse, and paratexts that originally sat after their parent stay where they are even though they should be re-positioned above the parent.
 - Sync overwrite: `resolveCodexCustomMerge` in [src/projectManager/utils/merge/resolvers.ts](src/projectManager/utils/merge/resolvers.ts) walks `ourCells` first and preserves their order (lines 1220–1244), and `applyEditToCell` only knows about `value`, `cellLabel`, `selectedAudioId`, `selectionTimestamp`, `isLocked`, `startTime`, `endTime`, `deleted`, and a generic `data.*` setter ([927–984](src/projectManager/utils/merge/resolvers.ts)). Cell _order_ is not part of edit history, and the migration writes `cellLabel`/`chapterNumber` directly without an `EditHistory` entry, so once any peer's local file is in the unmigrated order during a merge the structural fix is silently dropped.
 
 ## Approach
@@ -39,11 +39,11 @@ isProject: false
 flowchart TD
     raw[Raw cells from disk or merge] --> bail{No milestones AND no range cells?}
     bail -- yes --> noop[Return cells unchanged]
-    bail -- no --> partition[Partition into milestones, contentWithRef, contentWithoutRef, paratextByParentBefore, paratextByParentAfter, styleOrOther]
+    bail -- no --> partition[Partition into milestones, contentWithRef, contentWithoutRef, paratextByParent, orphanParatexts, styleOrOther]
     partition --> emitChap[Emit each milestone then its chapter cells in verse order]
-    emitChap --> emitPara[For each parent: emit BEFORE-paratexts, then parent, then AFTER-paratexts]
+    emitChap --> emitPara[For each parent: emit BEFORE-paratexts, then parent]
     emitChap --> remaining[Emit remaining contentWithRef sorted by book/chapter/verse]
-    remaining --> tail[Emit contentWithoutRef and styleOrOther in original positions]
+    remaining --> tail[Emit contentWithoutRef, styleOrOther, and orphan paratexts in original positions]
     tail --> relabel[Auto-fill cellLabel/chapterNumber for range cells unless user-edited]
     relabel --> out[Reordered cells]
 ```
@@ -67,12 +67,9 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult;
 Behavior:
 
 - **Early exit (no-op for non-scripture files):** Walk the input once. If there are no milestones AND no cells with `parsed.kind === "range"`, return `{ cells, mutated: false, orderChanged: false }` immediately. This keeps the helper inert on notes/glossary `.codex` files and on any file the migration is not trying to fix.
-- Partition cells like the current migration does, but build TWO paratext buckets per parent based on each paratext's original index relative to its parent's original index:
-    - `paratextBeforeParent: Map<parentId, cell[]>` for paratexts whose original index is `< parentIndex`.
-    - `paratextAfterParent: Map<parentId, cell[]>` for those `> parentIndex`.
-    - Paratexts whose `parentId` is not present in the cells array are NOT touched here (no soft-delete, no relocation). They flow through as if they were `styleOrOther` and keep their original index. The migration handles orphan soft-delete itself (see §2 below) so this helper has zero mutating side-effects when called from the resolver.
+- Partition cells like the current migration does, but bucket every parented paratext into a single `paratextBeforeParent: Map<parentId, cell[]>`. Multiple paratexts pointing at the same parent retain their original relative order in the bucket. Paratexts whose `parentId` is not present in the cells array are NOT touched here (no soft-delete, no relocation). They flow through as if they were `styleOrOther` and keep their original index. The migration handles orphan soft-delete itself (see §2 below) so this helper has zero mutating side-effects when called from the resolver.
 - Strip `:1` suffixes from `globalReferences` (existing logic). This is metadata-level cleanup of a malformed value, idempotent, and still safe to do on every merge.
-- Emit logic: push `paratextBeforeParent.get(parentId)` BEFORE pushing the parent cell, then push the parent, then push `paratextAfterParent.get(parentId)`.
+- Emit logic: push `paratextBeforeParent.get(parentId)` BEFORE pushing the parent cell. Section-heading style paratexts (e.g. `\s`) belong above the verse they introduce, so the helper normalises every parented paratext to the BEFORE side regardless of where it sat in the input.
 - Auto-fill `cellLabel` and `chapterNumber` on verse-range cells from the parsed ref **only when the user hasn't already set a value**. Concretely: skip the autofill on a cell if `metadata.edits` contains any entry whose `editMap.join(".") === "metadata.cellLabel"` and `type !== EditType.MIGRATION` — i.e. there is a non-migration edit explicitly setting `cellLabel`. Otherwise set it (and add no edit). This preserves intent for human relabels while keeping the auto-derive idempotent across merges.
 - Cells in `contentWithoutRef` and `styleOrOther` keep their original positions in the final output as much as possible (they fall through after the milestone-chapter blocks).
 - The helper does NOT add edit-history entries. It only sets `cellLabel`, `chapterNumber`, and a cleaned `globalReferences[0]`.
@@ -110,7 +107,7 @@ The merge phase (combining child→parent, soft-deleting merged children, tracki
 Add cases to [src/test/suite/migration_verseRangeLabelsAndPositions.test.ts](src/test/suite/migration_verseRangeLabelsAndPositions.test.ts):
 
 - Paratext immediately after a milestone (and before any verse cell) stays between the milestone and the first verse.
-- Paratext immediately after its parent stays after the parent.
+- Paratext that originally appeared after its parent is moved above the parent (section-heading semantics).
 - Multiple paratexts before a parent retain their relative order before the parent.
 - Orphan paratext (parentId not in cells): stays in its original position AND gets `data.deleted = true` with a single MIGRATION edit; running the migration again does not add a second edit.
 - A verse-range cell with a user-edited `cellLabel` (a non-MIGRATION edit on `metadata.cellLabel`) is NOT overwritten by the helper, even on repeated migration runs.

--- a/.cursor/plans/verse-range-paratext-and-sync_95d659b4.plan.md
+++ b/.cursor/plans/verse-range-paratext-and-sync_95d659b4.plan.md
@@ -1,0 +1,156 @@
+---
+name: verse-range-paratext-and-sync
+overview: Stop the verse-range migration from relocating paratext that was already adjacent to a milestone, and make the migration's structural changes (cell order, verse-range cellLabels, orphan paratext soft-deletes) survive a git sync by re-applying them inside the codex merge resolver.
+todos:
+    - id: extract_helper
+      content: Create pure reorderVerseRangeCells helper in src/projectManager/utils/merge/utils/verseRangeReorder.ts (BEFORE/AFTER paratext buckets, idempotent cellLabel/chapterNumber autofill that respects user edits, early-exit when no milestones and no range cells, no edit-history mutations)
+      status: completed
+    - id: wire_migration
+      content: Refactor migrateVerseRangeLabelsAndPositionsForFile to keep the merge phase (mergedChildIds + soft-delete of merged children) and orphan paratext soft-delete, then delegate ordering/relabeling to the helper
+      status: completed
+    - id: wire_resolver
+      content: Call the helper at the end of resolveCodexCustomMerge in src/projectManager/utils/merge/resolvers.ts so cell order and verse-range cellLabel survive sync without mutating data beyond ordering and idempotent relabel
+      status: completed
+    - id: tests_migration
+      content: "Add migration tests: paratext-between-milestone-and-verse stays in place, paratext-after-parent stays after, orphan paratext is soft-deleted in place idempotently, user-edited cellLabel is not overwritten by re-runs, double-run after a sync produces no new mergedChildIds edit"
+      status: completed
+    - id: tests_resolver
+      content: "Add merge resolver tests: cross-side order preservation (ours-unmigrated vs theirs-migrated and vice versa), helper is a no-op for files with no milestones and no range cells, helper does not soft-delete cells in the resolver path"
+      status: completed
+    - id: audit_existing_tests
+      content: Audit src/test/suite/resolveCodexCustomMerge.test.ts and src/test/suite/providerMergeResolve.test.ts for fixtures that contain milestones plus verse-ref cells; update assertions only where new ordering is intentionally desired
+      status: in_progress
+isProject: false
+---
+
+## Goals
+
+- Issue 1: paratext that originally sat between a milestone and the first verse (e.g. the chapter heading "ဖန်ဆင်းခြင်း" with `parentId: 98c7b6a3-…` in your sample) must stay there. Only paratext that was actually disconnected from its parent should move.
+- Issue 2: the cell ordering produced by `migration_verseRangeLabelsAndPositions` (and the verse-range `cellLabel` it sets) must survive git sync, regardless of which side of the merge the local file is on.
+
+## Root causes
+
+- Paratext placement: in [`migrateVerseRangeLabelsAndPositionsForFile`](src/projectManager/utils/migrationUtils.ts) lines 3037–3048 every paratext gets bucketed by `parentId` and `emitContentCell` always emits the bucket _after_ the parent ([3212–3217](src/projectManager/utils/migrationUtils.ts)). There is no "before-parent" bucket, so chapter-heading paratexts placed between a milestone and the first verse are forced to after the parent verse.
+- Sync overwrite: `resolveCodexCustomMerge` in [src/projectManager/utils/merge/resolvers.ts](src/projectManager/utils/merge/resolvers.ts) walks `ourCells` first and preserves their order (lines 1220–1244), and `applyEditToCell` only knows about `value`, `cellLabel`, `selectedAudioId`, `selectionTimestamp`, `isLocked`, `startTime`, `endTime`, `deleted`, and a generic `data.*` setter ([927–984](src/projectManager/utils/merge/resolvers.ts)). Cell _order_ is not part of edit history, and the migration writes `cellLabel`/`chapterNumber` directly without an `EditHistory` entry, so once any peer's local file is in the unmigrated order during a merge the structural fix is silently dropped.
+
+## Approach
+
+```mermaid
+flowchart TD
+    raw[Raw cells from disk or merge] --> bail{No milestones AND no range cells?}
+    bail -- yes --> noop[Return cells unchanged]
+    bail -- no --> partition[Partition into milestones, contentWithRef, contentWithoutRef, paratextByParentBefore, paratextByParentAfter, styleOrOther]
+    partition --> emitChap[Emit each milestone then its chapter cells in verse order]
+    emitChap --> emitPara[For each parent: emit BEFORE-paratexts, then parent, then AFTER-paratexts]
+    emitChap --> remaining[Emit remaining contentWithRef sorted by book/chapter/verse]
+    remaining --> tail[Emit contentWithoutRef and styleOrOther in original positions]
+    tail --> relabel[Auto-fill cellLabel/chapterNumber for range cells unless user-edited]
+    relabel --> out[Reordered cells]
+```
+
+### 1. Extract a pure reorder/relabel function
+
+Create `reorderVerseRangeCells(cells)` (in a new helper file co-located with the migration, e.g. `src/projectManager/utils/merge/utils/verseRangeReorder.ts` so both the migration and the merge resolver can import it without a circular dep on `migrationUtils.ts`). Signature roughly:
+
+```typescript
+export interface VerseRangeReorderResult {
+    cells: any[];
+    /** True if any metadata field was changed (cellLabel/chapterNumber autofill, suffix-stripped refs). */
+    mutated: boolean;
+    /** True if cell order changed. */
+    orderChanged: boolean;
+}
+
+export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult;
+```
+
+Behavior:
+
+- **Early exit (no-op for non-scripture files):** Walk the input once. If there are no milestones AND no cells with `parsed.kind === "range"`, return `{ cells, mutated: false, orderChanged: false }` immediately. This keeps the helper inert on notes/glossary `.codex` files and on any file the migration is not trying to fix.
+- Partition cells like the current migration does, but build TWO paratext buckets per parent based on each paratext's original index relative to its parent's original index:
+    - `paratextBeforeParent: Map<parentId, cell[]>` for paratexts whose original index is `< parentIndex`.
+    - `paratextAfterParent: Map<parentId, cell[]>` for those `> parentIndex`.
+    - Paratexts whose `parentId` is not present in the cells array are NOT touched here (no soft-delete, no relocation). They flow through as if they were `styleOrOther` and keep their original index. The migration handles orphan soft-delete itself (see §2 below) so this helper has zero mutating side-effects when called from the resolver.
+- Strip `:1` suffixes from `globalReferences` (existing logic). This is metadata-level cleanup of a malformed value, idempotent, and still safe to do on every merge.
+- Emit logic: push `paratextBeforeParent.get(parentId)` BEFORE pushing the parent cell, then push the parent, then push `paratextAfterParent.get(parentId)`.
+- Auto-fill `cellLabel` and `chapterNumber` on verse-range cells from the parsed ref **only when the user hasn't already set a value**. Concretely: skip the autofill on a cell if `metadata.edits` contains any entry whose `editMap.join(".") === "metadata.cellLabel"` and `type !== EditType.MIGRATION` — i.e. there is a non-migration edit explicitly setting `cellLabel`. Otherwise set it (and add no edit). This preserves intent for human relabels while keeping the auto-derive idempotent across merges.
+- Cells in `contentWithoutRef` and `styleOrOther` keep their original positions in the final output as much as possible (they fall through after the milestone-chapter blocks).
+- The helper does NOT add edit-history entries. It only sets `cellLabel`, `chapterNumber`, and a cleaned `globalReferences[0]`.
+
+### 2. Use the helper from the migration
+
+In [`migrateVerseRangeLabelsAndPositionsForFile`](src/projectManager/utils/migrationUtils.ts) (lines 2999–3275):
+
+- Keep the existing merge phase that combines split children into the parent, soft-deletes children, and tracks `mergedChildIds`. These add edits and need to keep doing so.
+- **Orphan paratext soft-delete stays in the migration** (not in the helper). After the merge phase but before calling the helper, walk the cells once: for any paratext whose `parentId` does not match an existing cell id, if `data.deleted !== true` set it and append a single MIGRATION `EditHistory` entry with `editMap: EditMapUtils.dataDeleted()`. Idempotent: never adds an edit if already deleted. Soft-delete edits propagate to peers through the existing edit-history replay in `resolveMetadataConflictsUsingEditHistory`.
+- After the merge phase and orphan soft-delete, replace the manual partition+emit code with a call to `reorderVerseRangeCells(cells)` and use its `cells`/`mutated`/`orderChanged` plus the merge/orphan flags to decide whether to write the file.
+- Drop the existing single-bucket `paratextByParentId` since the helper handles ordering.
+
+### 3. Apply the helper inside the merge resolver
+
+In `resolveCodexCustomMerge` ([src/projectManager/utils/merge/resolvers.ts](src/projectManager/utils/merge/resolvers.ts)), right before the final `formatJsonForNotebookFile` ([1287–1293](src/projectManager/utils/merge/resolvers.ts)):
+
+```typescript
+const reordered = reorderVerseRangeCells(resultCells);
+resultCells.length = 0;
+resultCells.push(...reordered.cells);
+```
+
+This guarantees that whether the merge ran on user A's machine or user B's machine, the final file is always in correct verse-range order with correct `cellLabel`/`chapterNumber`. The helper:
+
+- Bails out as a no-op on files with no milestones and no range cells, so non-scripture notebooks are untouched.
+- Adds no edit-history entries, so repeated merges do not bloat edit history.
+- Does not soft-delete any cells in the resolver path (orphan handling stays in the migration).
+- Does not overwrite a `cellLabel` that has been hand-edited by a user.
+
+The merge phase (combining child→parent, soft-deleting merged children, tracking `mergedChildIds`) and the orphan paratext soft-delete stay in the migration only — those edits already propagate through the resolver's existing edit-history replay.
+
+### 4. Tests
+
+Add cases to [src/test/suite/migration_verseRangeLabelsAndPositions.test.ts](src/test/suite/migration_verseRangeLabelsAndPositions.test.ts):
+
+- Paratext immediately after a milestone (and before any verse cell) stays between the milestone and the first verse.
+- Paratext immediately after its parent stays after the parent.
+- Multiple paratexts before a parent retain their relative order before the parent.
+- Orphan paratext (parentId not in cells): stays in its original position AND gets `data.deleted = true` with a single MIGRATION edit; running the migration again does not add a second edit.
+- A verse-range cell with a user-edited `cellLabel` (a non-MIGRATION edit on `metadata.cellLabel`) is NOT overwritten by the helper, even on repeated migration runs.
+- Regression test for `mergedChildIds` accumulation: run the migration, simulate a merge against an unmigrated peer (round-trip through `resolveCodexCustomMerge`), then run the migration again — assert no new `mergedChildIds` edit is appended on the second run and the parent's value/cellLabel/order are stable.
+
+Add focused tests for the merge resolver in [src/test/suite/resolveCodexCustomMerge.test.ts](src/test/suite/resolveCodexCustomMerge.test.ts) (or a new file) that:
+
+- Build `ourContent` with cells in the unmigrated order and `theirContent` with the same cells in migrated order. Assert the merged output is in migrated order (verse-sorted under the milestone) with correct verse-range `cellLabel`, regardless of which side is "ours".
+- Build both sides already migrated and assert the merge is stable (no change in order, no extra edits added by the resolver).
+- Provide a notebook with no milestones and no range cells; assert the resolver output is byte-stable (the helper's early-exit no-op path).
+- Provide a notebook containing an orphan paratext; assert the resolver does NOT mutate `data.deleted` for that paratext (orphan handling is migration-only).
+
+### 5. Audit existing tests
+
+Review fixtures in:
+
+- [src/test/suite/resolveCodexCustomMerge.test.ts](src/test/suite/resolveCodexCustomMerge.test.ts)
+- [src/test/suite/providerMergeResolve.test.ts](src/test/suite/providerMergeResolve.test.ts)
+- [src/test/suite/codexCellEditorProvider.test.ts](src/test/suite/codexCellEditorProvider.test.ts) (uses `resolveCodexCustomMerge`)
+
+For each test that asserts a specific cell order, check whether its fixture contains both a milestone AND any cell with `parsed.kind === "range"`. If neither, the helper's early-exit keeps behavior identical and the test should pass unchanged. If both, decide per-test whether the new ordering is the intended outcome (update the assertion) or an unintended side-effect (adjust the fixture).
+
+## Files touched
+
+- New: `src/projectManager/utils/merge/utils/verseRangeReorder.ts` (the pure helper).
+- Edit: [src/projectManager/utils/migrationUtils.ts](src/projectManager/utils/migrationUtils.ts) — `migrateVerseRangeLabelsAndPositionsForFile` retains the merge phase, adds an orphan paratext soft-delete pass, and delegates ordering/relabel to the helper. `migrateGlobalReferencesForFile` is untouched.
+- Edit: [src/projectManager/utils/merge/resolvers.ts](src/projectManager/utils/merge/resolvers.ts) — call the helper at the end of `resolveCodexCustomMerge`.
+- Edit: [src/test/suite/migration_verseRangeLabelsAndPositions.test.ts](src/test/suite/migration_verseRangeLabelsAndPositions.test.ts) — paratext + orphan + user-edit + double-run tests.
+- New/edit: merge resolver tests for cross-side order preservation, no-op early exit, and no-orphan-mutation.
+
+## Out of scope
+
+- No change to the merge phase logic (mergedChildIds, soft-delete of merged children) — it is already correct.
+- No auto-running the migration on activation or post-sync; the merge resolver fix makes that unnecessary.
+- No change to `migration_addGlobalReferences`, `migration_reorderMisplacedParatextCells`, or any unrelated migration.
+
+## Regression risks (mitigated)
+
+- **Resolver mutating data on every merge.** The helper now only changes `cellLabel`/`chapterNumber` (when not user-edited) and strips `:1` suffixes from `globalReferences`. It adds no edit-history entries and never soft-deletes from the resolver path.
+- **Non-scripture files getting reordered.** The early-exit returns the input untouched when there are no milestones and no range cells.
+- **Orphan paratexts mass-deleted across the team.** Orphan soft-delete is migration-only, so it only happens on the explicit manual `runVerseRangeLabelsAndPositionsMigration` command and propagates via edit history to peers — never re-triggered inside the resolver.
+- **Human-edited `cellLabel` clobbered.** The helper skips autofill on any cell that already carries a non-MIGRATION `metadata.cellLabel` edit.
+- **`mergedChildIds` accumulating across syncs (as seen in the Genesis 1:1 example).** Once order survives merges, the migration won't keep re-merging the same children on each peer, so the list stops growing. Verified by the new double-run regression test.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "codex-editor-extension",
-    "version": "0.26.0",
+    "version": "0.27.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "codex-editor-extension",
-            "version": "0.26.0",
+            "version": "0.27.0",
             "license": "MIT",
             "dependencies": {
                 "@types/csv-parse": "^1.2.5",

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -22,6 +22,7 @@ import {
     buildCellPositionContextMap,
     insertUniqueCellsPreservingRelativePositions,
 } from "./utils/positionPreservationUtils";
+import { reorderVerseRangeCells } from "./utils/verseRangeReorder";
 
 const DEBUG_MODE = false;
 function debugLog(...args: any[]): void {
@@ -1282,12 +1283,22 @@ export async function resolveCodexCustomMerge(
         }
     }
 
+    // Re-apply verse-range reordering (and idempotent cellLabel/chapterNumber autofill) so
+    // that the migrated cell ordering survives git syncs regardless of which side is "ours".
+    // The helper:
+    //   - bails out as a no-op on files with no milestones and no verse-range cells;
+    //   - never adds edit-history entries;
+    //   - never soft-deletes cells (orphan paratext handling stays in the migration);
+    //   - skips cellLabel autofill on cells the user has hand-labeled.
+    const reordered = reorderVerseRangeCells(resultCells);
+    const finalCells = reordered.cells;
+
     // Return the full notebook structure with merged cells and metadata
     // (formatted consistently for `.codex`/`.source` file writes)
     return formatJsonForNotebookFile(
         {
             ...ourNotebook,
-            cells: resultCells,
+            cells: finalCells,
             metadata: mergedMetadata,
         }
     );

--- a/src/projectManager/utils/merge/utils/verseRangeReorder.ts
+++ b/src/projectManager/utils/merge/utils/verseRangeReorder.ts
@@ -48,10 +48,11 @@ function hasUserCellLabelEdit(cell: any): boolean {
  * Behavior:
  *   - Early-exits when the file has no milestones AND no verse-range cells (`parsed.kind === "range"`).
  *     Non-scripture notebooks (notes, glossaries, etc.) are returned untouched.
- *   - Builds two paratext buckets per parent — BEFORE and AFTER — based on each paratext's original
- *     index relative to its parent's original index, and emits each bucket on the correct side of
- *     the parent. Paratext that was originally adjacent to its parent (e.g. a chapter-heading
- *     paratext between a milestone and the first verse) stays where it was.
+ *   - Always emits paratext cells immediately BEFORE their parent verse cell. Section-heading
+ *     style paratexts in scripture (e.g. \\s) belong above the verse they introduce, so the
+ *     helper places every parented paratext on the BEFORE side regardless of its original
+ *     index. Multiple paratexts pointing at the same parent retain their original relative
+ *     order in the BEFORE block.
  *   - Strips legacy `:1`-style cell-id suffixes from `globalReferences[0]` (idempotent).
  *   - Auto-fills `cellLabel` and `chapterNumber` on verse-range cells from the parsed ref, but
  *     skips the autofill when the cell already has a non-MIGRATION `metadata.cellLabel` edit so
@@ -91,9 +92,8 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
         return { cells, mutated: false, orderChanged: false };
     }
 
-    // Second pass: full partition. We track each cell's original index so we can place paratexts
-    // on the correct side of their parent (BEFORE vs AFTER) and decide where orphan paratexts
-    // belong in the final output.
+    // Second pass: full partition. We track each cell's original index so we can re-insert
+    // orphan paratexts at their original index in the tail.
     const milestones: Array<{ cell: any; chapter: number | null; originalIndex: number; }> = [];
     const contentWithRef: Array<{
         cell: any;
@@ -164,22 +164,19 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
         }
     }
 
-    // Bucket paratexts by parent + side (BEFORE/AFTER), and collect orphans separately.
+    // Bucket every parented paratext into a single BEFORE-parent block. Section-heading
+    // paratexts belong above the verse they introduce, so we drop the original index and emit
+    // them above their parent regardless of where they sat in the input. Orphans (parentId
+    // not present) are kept aside and re-inserted at their original index further down.
     const paratextBeforeParent = new Map<string, any[]>();
-    const paratextAfterParent = new Map<string, any[]>();
     const orphanParatexts: Array<{ cell: any; originalIndex: number; }> = [];
     for (const pt of paratextOriginal) {
         const parentId = pt.parentId;
         const parentIndex =
             typeof parentId === "string" ? originalIndexById.get(parentId) : undefined;
         if (parentId && parentIndex !== undefined) {
-            if (pt.originalIndex < parentIndex) {
-                if (!paratextBeforeParent.has(parentId)) paratextBeforeParent.set(parentId, []);
-                paratextBeforeParent.get(parentId)!.push(pt.cell);
-            } else {
-                if (!paratextAfterParent.has(parentId)) paratextAfterParent.set(parentId, []);
-                paratextAfterParent.get(parentId)!.push(pt.cell);
-            }
+            if (!paratextBeforeParent.has(parentId)) paratextBeforeParent.set(parentId, []);
+            paratextBeforeParent.get(parentId)!.push(pt.cell);
         } else {
             orphanParatexts.push({ cell: pt.cell, originalIndex: pt.originalIndex });
         }
@@ -224,13 +221,6 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
             }
         }
         newCells.push(cell);
-        if (typeof parentId === "string") {
-            const after = paratextAfterParent.get(parentId);
-            if (after) {
-                for (const pt of after) newCells.push(pt);
-                consumedParentIds.add(parentId);
-            }
-        }
     };
 
     for (const { cell, chapter } of milestones) {
@@ -270,13 +260,6 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
             }
         }
         newCells.push(cell);
-        if (typeof parentId === "string") {
-            const after = paratextAfterParent.get(parentId);
-            if (after) {
-                for (const pt of after) newCells.push(pt);
-                consumedParentIds.add(parentId);
-            }
-        }
     }
 
     // Any paratext buckets we didn't consume (parent existed but was filtered out, e.g. as a
@@ -284,18 +267,6 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
     // aren't lost.
     const leftoverBuckets: Array<{ cell: any; originalIndex: number; }> = [];
     for (const [parentId, bucket] of paratextBeforeParent) {
-        if (consumedParentIds.has(parentId)) continue;
-        for (const pt of bucket) {
-            const originalIndex = (() => {
-                const id = pt.metadata?.id;
-                return typeof id === "string"
-                    ? originalIndexById.get(id) ?? Number.MAX_SAFE_INTEGER
-                    : Number.MAX_SAFE_INTEGER;
-            })();
-            leftoverBuckets.push({ cell: pt, originalIndex });
-        }
-    }
-    for (const [parentId, bucket] of paratextAfterParent) {
         if (consumedParentIds.has(parentId)) continue;
         for (const pt of bucket) {
             const originalIndex = (() => {

--- a/src/projectManager/utils/merge/utils/verseRangeReorder.ts
+++ b/src/projectManager/utils/merge/utils/verseRangeReorder.ts
@@ -1,0 +1,340 @@
+import { CodexCellTypes, EditType } from "../../../../../types/enums";
+import { extractParentCellIdFromParatext } from "../../../../providers/codexCellEditorProvider/utils/cellUtils";
+import {
+    parseVerseRef,
+    getSortKeyFromParsedRef,
+    stripCellIdSuffix,
+    type ParsedVerseRef,
+} from "../../../../utils/verseRefUtils";
+
+/**
+ * Result of running {@link reorderVerseRangeCells}.
+ *
+ * - `cells` — the (possibly) reordered cell array. The same cell instances are reused; only the
+ *   array order and a few metadata fields are touched.
+ * - `mutated` — `true` when this function mutated metadata on at least one cell (cellLabel /
+ *   chapterNumber autofill, or `:1`-style cell id suffix stripped from `globalReferences[0]`).
+ * - `orderChanged` — `true` when the output cell order differs from the input order.
+ *
+ * The helper does NOT add edit-history entries, soft-delete cells, merge values, or modify any
+ * field other than the ones listed above. It is safe to call from the codex merge resolver on
+ * every merge — orphan paratext soft-delete and child→parent merging stay in the migration.
+ */
+export interface VerseRangeReorderResult {
+    cells: any[];
+    mutated: boolean;
+    orderChanged: boolean;
+}
+
+/** Decide whether a cell already carries a non-MIGRATION edit on `metadata.cellLabel`. */
+function hasUserCellLabelEdit(cell: any): boolean {
+    const edits = cell?.metadata?.edits;
+    if (!Array.isArray(edits)) return false;
+    for (const edit of edits) {
+        if (!edit || edit.type === EditType.MIGRATION) continue;
+        const editMap = edit.editMap;
+        if (!Array.isArray(editMap)) continue;
+        if (editMap.length === 2 && editMap[0] === "metadata" && editMap[1] === "cellLabel") {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Pure reorder/relabel pass for a notebook's cells. Used by both the verse-range migration and
+ * the codex merge resolver so that the migrated cell ordering survives git syncs.
+ *
+ * Behavior:
+ *   - Early-exits when the file has no milestones AND no verse-range cells (`parsed.kind === "range"`).
+ *     Non-scripture notebooks (notes, glossaries, etc.) are returned untouched.
+ *   - Builds two paratext buckets per parent — BEFORE and AFTER — based on each paratext's original
+ *     index relative to its parent's original index, and emits each bucket on the correct side of
+ *     the parent. Paratext that was originally adjacent to its parent (e.g. a chapter-heading
+ *     paratext between a milestone and the first verse) stays where it was.
+ *   - Strips legacy `:1`-style cell-id suffixes from `globalReferences[0]` (idempotent).
+ *   - Auto-fills `cellLabel` and `chapterNumber` on verse-range cells from the parsed ref, but
+ *     skips the autofill when the cell already has a non-MIGRATION `metadata.cellLabel` edit so
+ *     that human relabels are not clobbered.
+ *   - Orphan paratexts (parentId not present in the file) are NOT touched: they keep their
+ *     original index and are never soft-deleted by this helper. The migration handles orphan
+ *     soft-delete itself so that resolver-time calls have zero mutating side-effects beyond
+ *     ordering and the safe relabel/cleanup listed above.
+ */
+export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
+    if (!Array.isArray(cells) || cells.length === 0) {
+        return { cells: cells ?? [], mutated: false, orderChanged: false };
+    }
+
+    // First pass: cheap detection so we can no-op on non-scripture notebooks.
+    let hasMilestone = false;
+    let hasRangeCell = false;
+    for (const cell of cells) {
+        const md = cell?.metadata;
+        if (!md) continue;
+        if (md.type === CodexCellTypes.MILESTONE) {
+            hasMilestone = true;
+        } else if (
+            md.type !== CodexCellTypes.PARATEXT &&
+            md.type !== CodexCellTypes.STYLE
+        ) {
+            const ref = md.data?.globalReferences?.[0];
+            if (typeof ref === "string") {
+                const parsed = parseVerseRef(ref);
+                if (parsed?.kind === "range") hasRangeCell = true;
+            }
+        }
+        if (hasMilestone && hasRangeCell) break;
+    }
+
+    if (!hasMilestone && !hasRangeCell) {
+        return { cells, mutated: false, orderChanged: false };
+    }
+
+    // Second pass: full partition. We track each cell's original index so we can place paratexts
+    // on the correct side of their parent (BEFORE vs AFTER) and decide where orphan paratexts
+    // belong in the final output.
+    const milestones: Array<{ cell: any; chapter: number | null; originalIndex: number; }> = [];
+    const contentWithRef: Array<{
+        cell: any;
+        parsed: ParsedVerseRef;
+        sortKey: { book: string; chapter: number; verse: number; };
+        originalIndex: number;
+    }> = [];
+    const contentWithoutRef: Array<{ cell: any; originalIndex: number; }> = [];
+    const styleOrOther: Array<{ cell: any; originalIndex: number; }> = [];
+    const paratextOriginal: Array<{ cell: any; originalIndex: number; parentId: string | null; }> = [];
+
+    let mutated = false;
+
+    // First pass: classify every cell and remember the original index of each id.
+    const originalIndexById = new Map<string, number>();
+    for (let i = 0; i < cells.length; i++) {
+        const cell = cells[i];
+        const id = cell?.metadata?.id;
+        if (typeof id === "string" && id.length > 0) {
+            originalIndexById.set(id, i);
+        }
+    }
+
+    for (let i = 0; i < cells.length; i++) {
+        const cell = cells[i];
+        const md = cell?.metadata || {};
+        const cellType = md.type;
+        const cellId = md.id;
+
+        if (cellType === CodexCellTypes.MILESTONE) {
+            const milestoneValue = typeof cell?.value === "string" ? cell.value : "";
+            const chapter = extractChapterNumberFromMilestoneValue(milestoneValue);
+            milestones.push({ cell, chapter, originalIndex: i });
+            continue;
+        }
+
+        if (cellType === CodexCellTypes.PARATEXT && cellId) {
+            const parentId = extractParentCellIdFromParatext(
+                typeof cellId === "string" ? cellId : String(cellId),
+                md
+            );
+            paratextOriginal.push({ cell, originalIndex: i, parentId });
+            continue;
+        }
+
+        if (cellType === CodexCellTypes.STYLE) {
+            styleOrOther.push({ cell, originalIndex: i });
+            continue;
+        }
+
+        const rawRef = md.data?.globalReferences?.[0];
+        if (typeof rawRef === "string") {
+            const cleanedRef = stripCellIdSuffix(rawRef);
+            if (cleanedRef !== rawRef) {
+                if (!md.data) md.data = {};
+                md.data.globalReferences = [cleanedRef];
+                cell.metadata = md;
+                mutated = true;
+            }
+        }
+        const ref = md.data?.globalReferences?.[0];
+        const parsed = typeof ref === "string" ? parseVerseRef(ref) : null;
+        if (parsed) {
+            const sortKey = getSortKeyFromParsedRef(parsed);
+            contentWithRef.push({ cell, parsed, sortKey, originalIndex: i });
+        } else {
+            contentWithoutRef.push({ cell, originalIndex: i });
+        }
+    }
+
+    // Bucket paratexts by parent + side (BEFORE/AFTER), and collect orphans separately.
+    const paratextBeforeParent = new Map<string, any[]>();
+    const paratextAfterParent = new Map<string, any[]>();
+    const orphanParatexts: Array<{ cell: any; originalIndex: number; }> = [];
+    for (const pt of paratextOriginal) {
+        const parentId = pt.parentId;
+        const parentIndex =
+            typeof parentId === "string" ? originalIndexById.get(parentId) : undefined;
+        if (parentId && parentIndex !== undefined) {
+            if (pt.originalIndex < parentIndex) {
+                if (!paratextBeforeParent.has(parentId)) paratextBeforeParent.set(parentId, []);
+                paratextBeforeParent.get(parentId)!.push(pt.cell);
+            } else {
+                if (!paratextAfterParent.has(parentId)) paratextAfterParent.set(parentId, []);
+                paratextAfterParent.get(parentId)!.push(pt.cell);
+            }
+        } else {
+            orphanParatexts.push({ cell: pt.cell, originalIndex: pt.originalIndex });
+        }
+    }
+
+    // Partition content-with-ref by (book, chapter), sort each by verse start.
+    const contentByChapter = new Map<string, typeof contentWithRef>();
+    for (const item of contentWithRef) {
+        const key = `${item.sortKey.book}\t${item.sortKey.chapter}`;
+        if (!contentByChapter.has(key)) contentByChapter.set(key, []);
+        contentByChapter.get(key)!.push(item);
+    }
+    for (const arr of contentByChapter.values()) {
+        arr.sort((a, b) => a.sortKey.verse - b.sortKey.verse);
+    }
+
+    const newCells: any[] = [];
+    const consumedParentIds = new Set<string>();
+
+    const emitContentCell = (item: (typeof contentWithRef)[0]) => {
+        const { cell, parsed } = item;
+        const md = cell.metadata || {};
+        const parentId = md.id;
+
+        if (parsed.kind === "range" && !hasUserCellLabelEdit(cell)) {
+            if (md.cellLabel !== parsed.cellLabel) {
+                md.cellLabel = parsed.cellLabel;
+                mutated = true;
+            }
+            if (md.chapterNumber === undefined || md.chapterNumber === null) {
+                md.chapterNumber = String(parsed.chapter);
+                mutated = true;
+            }
+            cell.metadata = md;
+        }
+
+        if (typeof parentId === "string") {
+            const before = paratextBeforeParent.get(parentId);
+            if (before) {
+                for (const pt of before) newCells.push(pt);
+                consumedParentIds.add(parentId);
+            }
+        }
+        newCells.push(cell);
+        if (typeof parentId === "string") {
+            const after = paratextAfterParent.get(parentId);
+            if (after) {
+                for (const pt of after) newCells.push(pt);
+                consumedParentIds.add(parentId);
+            }
+        }
+    };
+
+    for (const { cell, chapter } of milestones) {
+        newCells.push(cell);
+        if (chapter != null) {
+            const keysToDelete: string[] = [];
+            for (const [key, items] of contentByChapter.entries()) {
+                const [, chapStr] = key.split("\t");
+                if (parseInt(chapStr, 10) === chapter) {
+                    for (const item of items) emitContentCell(item);
+                    keysToDelete.push(key);
+                }
+            }
+            for (const k of keysToDelete) contentByChapter.delete(k);
+        }
+    }
+
+    // Emit remaining content-with-ref (chapter not matched to any milestone) in deterministic order.
+    const remaining: typeof contentWithRef = [];
+    for (const items of contentByChapter.values()) remaining.push(...items);
+    remaining.sort(
+        (a, b) =>
+            a.sortKey.book.localeCompare(b.sortKey.book) ||
+            a.sortKey.chapter - b.sortKey.chapter ||
+            a.sortKey.verse - b.sortKey.verse
+    );
+    for (const item of remaining) emitContentCell(item);
+
+    // Emit content-without-ref cells, attaching any paratexts whose parent matches.
+    for (const { cell } of contentWithoutRef) {
+        const parentId = cell.metadata?.id;
+        if (typeof parentId === "string") {
+            const before = paratextBeforeParent.get(parentId);
+            if (before) {
+                for (const pt of before) newCells.push(pt);
+                consumedParentIds.add(parentId);
+            }
+        }
+        newCells.push(cell);
+        if (typeof parentId === "string") {
+            const after = paratextAfterParent.get(parentId);
+            if (after) {
+                for (const pt of after) newCells.push(pt);
+                consumedParentIds.add(parentId);
+            }
+        }
+    }
+
+    // Any paratext buckets we didn't consume (parent existed but was filtered out, e.g. as a
+    // style cell) get appended in the same relative order they appeared originally so they
+    // aren't lost.
+    const leftoverBuckets: Array<{ cell: any; originalIndex: number; }> = [];
+    for (const [parentId, bucket] of paratextBeforeParent) {
+        if (consumedParentIds.has(parentId)) continue;
+        for (const pt of bucket) {
+            const originalIndex = (() => {
+                const id = pt.metadata?.id;
+                return typeof id === "string"
+                    ? originalIndexById.get(id) ?? Number.MAX_SAFE_INTEGER
+                    : Number.MAX_SAFE_INTEGER;
+            })();
+            leftoverBuckets.push({ cell: pt, originalIndex });
+        }
+    }
+    for (const [parentId, bucket] of paratextAfterParent) {
+        if (consumedParentIds.has(parentId)) continue;
+        for (const pt of bucket) {
+            const originalIndex = (() => {
+                const id = pt.metadata?.id;
+                return typeof id === "string"
+                    ? originalIndexById.get(id) ?? Number.MAX_SAFE_INTEGER
+                    : Number.MAX_SAFE_INTEGER;
+            })();
+            leftoverBuckets.push({ cell: pt, originalIndex });
+        }
+    }
+
+    // Style/other and orphan paratexts retain their relative ordering by original index.
+    const tail: Array<{ cell: any; originalIndex: number; }> = [
+        ...styleOrOther,
+        ...orphanParatexts,
+        ...leftoverBuckets,
+    ];
+    tail.sort((a, b) => a.originalIndex - b.originalIndex);
+    for (const { cell } of tail) newCells.push(cell);
+
+    const oldIds = cells.map((c) => c?.metadata?.id ?? "").join(",");
+    const newIds = newCells.map((c) => c?.metadata?.id ?? "").join(",");
+    const orderChanged = oldIds !== newIds;
+
+    return { cells: newCells, mutated, orderChanged };
+}
+
+/**
+ * Extracts a chapter number from a milestone cell's value (e.g. "John 4", "4", "GEN 2").
+ * Mirrors the local helper in migrationUtils so the helper file has no circular import.
+ */
+function extractChapterNumberFromMilestoneValue(value: string | undefined): number | null {
+    if (value == null || typeof value !== "string") return null;
+    const matches = value.match(/(\d+)(?!.*\d)/);
+    if (matches?.[1]) {
+        const n = parseInt(matches[1], 10);
+        return !isNaN(n) && n > 0 ? n : null;
+    }
+    const parsed = parseInt(value, 10);
+    return !isNaN(parsed) && parsed > 0 ? parsed : null;
+}

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -13,12 +13,11 @@ import { generateCellIdFromHash, isUuidFormat } from "../../utils/uuidUtils";
 import { getCorrespondingSourceUri, getCorrespondingCodexUri } from "../../utils/codexNotebookUtils";
 import {
     parseVerseRef,
-    getSortKeyFromParsedRef,
-    stripCellIdSuffix,
     type ParsedVerseRef,
 } from "../../utils/verseRefUtils";
 import bibleData from "../../../webviews/codex-webviews/src/assets/bible-books-lookup.json";
 import { resolveCodexCustomMerge, mergeDuplicateCellsUsingResolverLogic } from "./merge/resolvers";
+import { reorderVerseRangeCells } from "./merge/utils/verseRangeReorder";
 import { atomicWriteUriText } from "../../utils/notebookSafeSaveUtils";
 import { normalizeNotebookFileText, formatJsonForNotebookFile } from "../../utils/notebookFileFormattingUtils";
 
@@ -3010,89 +3009,44 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
         const cells: any[] = notebookData.cells || [];
         if (cells.length === 0) return false;
 
-        const milestones: Array<{ cell: any; chapter: number | null; }> = [];
-        const contentWithRef: Array<{
-            cell: any;
-            parsed: ParsedVerseRef;
-            sortKey: { book: string; chapter: number; verse: number; };
-        }> = [];
-        const contentWithoutRef: any[] = [];
-        const paratextByParentId = new Map<string, any[]>();
-        const styleOrOther: any[] = [];
-        let hadSuffixedRefs = false;
+        let hasChanges = false;
 
-        for (let i = 0; i < cells.length; i++) {
-            const cell = cells[i];
-            const md = cell.metadata || {};
+        // ---- Merge phase ---------------------------------------------------------------------
+        // Recombine split verse-range cells (child has parentId -> parent). Soft-deletes merged
+        // children (sets data.deleted=true with an edit-history entry) and tracks merged child
+        // ids in parent.metadata.data.mergedChildIds so the merge survives git sync (where
+        // deleted-only-on-our-side cells would otherwise be re-added by the codex merge
+        // resolver, causing the next migration run to double the parent's content).
+        const contentForMerge: Array<{ cell: any; parsed: ParsedVerseRef; }> = [];
+        for (const cell of cells) {
+            const md = cell?.metadata || {};
             const cellType = md.type;
-            const cellId = md.id;
-
-            if (cellType === CodexCellTypes.MILESTONE) {
-                const milestoneValue = typeof cell?.value === "string" ? cell.value : "";
-                const chapter = extractChapterNumberFromMilestoneValue(milestoneValue);
-                milestones.push({ cell, chapter });
+            if (
+                cellType === CodexCellTypes.MILESTONE ||
+                cellType === CodexCellTypes.PARATEXT ||
+                cellType === CodexCellTypes.STYLE
+            ) {
                 continue;
-            }
-
-            if (cellType === CodexCellTypes.PARATEXT && cellId) {
-                const parentId = extractParentCellIdFromParatext(
-                    typeof cellId === "string" ? cellId : String(cellId),
-                    md
-                );
-                if (parentId) {
-                    if (!paratextByParentId.has(parentId)) paratextByParentId.set(parentId, []);
-                    paratextByParentId.get(parentId)!.push(cell);
-                } else {
-                    styleOrOther.push(cell);
-                }
-                continue;
-            }
-
-            if (cellType === CodexCellTypes.STYLE) {
-                styleOrOther.push(cell);
-                continue;
-            }
-
-            const rawRef = md.data?.globalReferences?.[0];
-            if (typeof rawRef === "string") {
-                const cleanedRef = stripCellIdSuffix(rawRef);
-                if (cleanedRef !== rawRef) {
-                    md.data.globalReferences = [cleanedRef];
-                    cell.metadata = md;
-                    hadSuffixedRefs = true;
-                }
             }
             const ref = md.data?.globalReferences?.[0];
             const parsed = typeof ref === "string" ? parseVerseRef(ref) : null;
-            if (parsed) {
-                const sortKey = getSortKeyFromParsedRef(parsed);
-                contentWithRef.push({ cell, parsed, sortKey });
-            } else {
-                contentWithoutRef.push(cell);
-            }
+            if (parsed) contentForMerge.push({ cell, parsed });
         }
 
-        let hasChanges = hadSuffixedRefs;
-
-        // Merge phase: recombine split verse-range cells (child has parentId -> parent).
-        // Soft-deletes merged children (sets data.deleted=true with an edit-history entry) and
-        // tracks merged child ids in parent.metadata.data.mergedChildIds so the merge survives
-        // git sync (where deleted-only-on-our-side cells would otherwise be re-added by the
-        // codex merge resolver, causing the next migration run to double the parent's content).
         const idToContentIndex = new Map<string, number>();
-        for (let i = 0; i < contentWithRef.length; i++) {
-            const id = contentWithRef[i].cell.metadata?.id;
+        for (let i = 0; i < contentForMerge.length; i++) {
+            const id = contentForMerge[i].cell.metadata?.id;
             if (id) idToContentIndex.set(id, i);
         }
-        for (let i = 0; i < contentWithRef.length; i++) {
-            const childMd = contentWithRef[i].cell.metadata || {};
+        for (let i = 0; i < contentForMerge.length; i++) {
+            const childMd = contentForMerge[i].cell.metadata || {};
             const parentId = childMd.parentId;
             if (!parentId) continue;
             const parentIdx = idToContentIndex.get(parentId);
             if (parentIdx === undefined) continue;
 
-            const parent = contentWithRef[parentIdx];
-            const child = contentWithRef[i];
+            const parent = contentForMerge[parentIdx];
+            const child = contentForMerge[i];
             const pRef = parent.parsed;
             const cRef = child.parsed;
             const sameRange =
@@ -3110,7 +3064,6 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
             const childValue = child.cell.value || "";
             const childAlreadyDeleted = child.cell.metadata?.data?.deleted === true;
 
-            // Ensure parent has metadata.data with a mergedChildIds list available for tracking.
             const parentMd: any = parent.cell.metadata || (parent.cell.metadata = {});
             const parentData: any = parentMd.data || (parentMd.data = {});
             const existingMergedIds: string[] = Array.isArray(parentData.mergedChildIds)
@@ -3143,7 +3096,6 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
                 hasChanges = true;
             }
 
-            // Track the merged child id on the parent (defensive, survives sync via edit history).
             if (typeof childId === "string" && !existingMergedIds.includes(childId)) {
                 existingMergedIds.push(childId);
                 parentData.mergedChildIds = existingMergedIds;
@@ -3159,9 +3111,6 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
                 hasChanges = true;
             }
 
-            // Soft-delete the child instead of hard-removing it. Keeps the deletion in edit
-            // history so it propagates across syncs (resolveMetadataConflictsUsingEditHistory
-            // applies the most recent metadata.data.deleted edit).
             if (!childAlreadyDeleted) {
                 const cMd: any = child.cell.metadata || (child.cell.metadata = {});
                 const cData: any = cMd.data || (cMd.data = {});
@@ -3179,85 +3128,49 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
             }
         }
 
-        // Partition content-with-ref by (book, chapter), sort each by verse
-        const contentByChapter = new Map<string, typeof contentWithRef>();
-        for (const item of contentWithRef) {
-            const key = `${item.sortKey.book}\t${item.sortKey.chapter}`;
-            if (!contentByChapter.has(key)) contentByChapter.set(key, []);
-            contentByChapter.get(key)!.push(item);
+        // ---- Orphan paratext soft-delete -----------------------------------------------------
+        // Paratext cells whose parent verse cell is not present in this file are no longer
+        // meaningful content. Mark them deleted (idempotent) so they propagate to peers via
+        // edit-history replay. The reorder helper below leaves them in their original index;
+        // it never soft-deletes from the resolver path.
+        const idsInFile = new Set<string>();
+        for (const cell of cells) {
+            const id = cell?.metadata?.id;
+            if (typeof id === "string" && id.length > 0) idsInFile.add(id);
         }
-        for (const arr of contentByChapter.values()) {
-            arr.sort((a, b) => a.sortKey.verse - b.sortKey.verse);
-        }
+        for (const cell of cells) {
+            const md = cell?.metadata;
+            if (md?.type !== CodexCellTypes.PARATEXT) continue;
+            const cellId = md?.id;
+            if (typeof cellId !== "string" || cellId.length === 0) continue;
+            const parentId = extractParentCellIdFromParatext(cellId, md);
+            const parentExists = typeof parentId === "string" && idsInFile.has(parentId);
+            if (parentExists) continue;
+            if (md.data?.deleted === true) continue;
 
-        const newCells: any[] = [];
-
-        const emitContentCell = (item: (typeof contentWithRef)[0]) => {
-            const { cell, parsed } = item;
-            const md = cell.metadata || {};
-            const parentId = md.id;
-
-            if (parsed.kind === "range") {
-                if (md.cellLabel !== parsed.cellLabel) {
-                    md.cellLabel = parsed.cellLabel;
-                    hasChanges = true;
-                }
-                if (md.chapterNumber === undefined || md.chapterNumber === null) {
-                    md.chapterNumber = String(parsed.chapter);
-                    hasChanges = true;
-                }
-                cell.metadata = md;
-            }
-            newCells.push(cell);
-            if (parentId) {
-                const paratextCells = paratextByParentId.get(parentId);
-                if (paratextCells) {
-                    for (const pt of paratextCells) newCells.push(pt);
-                }
-            }
-        };
-
-        for (const { cell, chapter } of milestones) {
-            newCells.push(cell);
-            if (chapter != null) {
-                const keysToDelete: string[] = [];
-                for (const [key, items] of contentByChapter.entries()) {
-                    const [, chapStr] = key.split("\t");
-                    if (parseInt(chapStr, 10) === chapter) {
-                        for (const item of items) emitContentCell(item);
-                        keysToDelete.push(key);
-                    }
-                }
-                for (const k of keysToDelete) contentByChapter.delete(k);
-            }
+            const data: any = md.data || (md.data = {});
+            data.deleted = true;
+            const edits: any[] = md.edits || (md.edits = []);
+            edits.push({
+                editMap: EditMapUtils.dataDeleted(),
+                value: true,
+                timestamp: Date.now(),
+                type: EditType.MIGRATION,
+                author: "system",
+                validatedBy: [],
+            });
+            cell.metadata = md;
+            hasChanges = true;
         }
 
-        // Emit remaining content-with-ref (chapter not matched to any milestone) in deterministic order
-        const remaining: typeof contentWithRef = [];
-        for (const items of contentByChapter.values()) remaining.push(...items);
-        remaining.sort(
-            (a, b) =>
-                a.sortKey.book.localeCompare(b.sortKey.book) ||
-                a.sortKey.chapter - b.sortKey.chapter ||
-                a.sortKey.verse - b.sortKey.verse
-        );
-        for (const item of remaining) emitContentCell(item);
+        // ---- Reorder + relabel pass ----------------------------------------------------------
+        // Delegated to the shared helper so the codex merge resolver can run the same logic and
+        // keep the migrated ordering / cellLabel after every git sync.
+        const reordered = reorderVerseRangeCells(cells);
+        const newCells = reordered.cells;
+        const orderChanged = reordered.orderChanged;
+        if (reordered.mutated) hasChanges = true;
 
-        for (const cell of contentWithoutRef) {
-            newCells.push(cell);
-            const parentId = cell.metadata?.id;
-            if (parentId) {
-                const paratextCells = paratextByParentId.get(parentId);
-                if (paratextCells) {
-                    for (const pt of paratextCells) newCells.push(pt);
-                }
-            }
-        }
-        for (const cell of styleOrOther) newCells.push(cell);
-
-        const oldIds = cells.map((c) => c.metadata?.id ?? "").join(",");
-        const newIds = newCells.map((c) => c.metadata?.id ?? "").join(",");
-        const orderChanged = oldIds !== newIds;
         if (orderChanged || hasChanges) {
             notebookData.cells = newCells;
             const updatedContent = await serializer.serializeNotebook(

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -3074,13 +3074,16 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
 
         let hasChanges = hadSuffixedRefs;
 
-        // Merge phase: recombine split verse-range cells (child has parentId -> parent)
+        // Merge phase: recombine split verse-range cells (child has parentId -> parent).
+        // Soft-deletes merged children (sets data.deleted=true with an edit-history entry) and
+        // tracks merged child ids in parent.metadata.data.mergedChildIds so the merge survives
+        // git sync (where deleted-only-on-our-side cells would otherwise be re-added by the
+        // codex merge resolver, causing the next migration run to double the parent's content).
         const idToContentIndex = new Map<string, number>();
         for (let i = 0; i < contentWithRef.length; i++) {
             const id = contentWithRef[i].cell.metadata?.id;
             if (id) idToContentIndex.set(id, i);
         }
-        const mergedChildIndices = new Set<number>();
         for (let i = 0; i < contentWithRef.length; i++) {
             const childMd = contentWithRef[i].cell.metadata || {};
             const parentId = childMd.parentId;
@@ -3103,24 +3106,77 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
                         : false);
             if (!sameRange) continue;
 
-            parent.cell.value = (parent.cell.value || "") + (child.cell.value || "");
-            const parentEdits: any[] = parent.cell.metadata?.edits || [];
-            parentEdits.push({
-                editMap: ["value"],
-                value: parent.cell.value,
-                timestamp: Date.now(),
-                type: EditType.MIGRATION,
-                author: "system",
-                validatedBy: [],
-            });
-            parent.cell.metadata.edits = parentEdits;
-            mergedChildIndices.add(i);
-            hasChanges = true;
-        }
-        if (mergedChildIndices.size > 0) {
-            const filtered = contentWithRef.filter((_, idx) => !mergedChildIndices.has(idx));
-            contentWithRef.length = 0;
-            contentWithRef.push(...filtered);
+            const childId = child.cell.metadata?.id;
+            const childValue = child.cell.value || "";
+            const childAlreadyDeleted = child.cell.metadata?.data?.deleted === true;
+
+            // Ensure parent has metadata.data with a mergedChildIds list available for tracking.
+            const parentMd: any = parent.cell.metadata || (parent.cell.metadata = {});
+            const parentData: any = parentMd.data || (parentMd.data = {});
+            const existingMergedIds: string[] = Array.isArray(parentData.mergedChildIds)
+                ? parentData.mergedChildIds.slice()
+                : [];
+            const alreadyTrackedById =
+                typeof childId === "string" && existingMergedIds.includes(childId);
+
+            // Idempotency guards (in priority order):
+            //  1. Child already soft-deleted -> previous run handled this; nothing to do.
+            //  2. Parent already lists this child id in mergedChildIds -> ensure soft-delete only.
+            //  3. Parent.value already endsWith child.value -> previous run merged but tracking
+            //     was lost (e.g. via sync); skip append, ensure soft-delete + tracking.
+            const skipAppend =
+                childAlreadyDeleted ||
+                alreadyTrackedById ||
+                (childValue.length > 0 && (parent.cell.value || "").endsWith(childValue));
+
+            if (!skipAppend) {
+                parent.cell.value = (parent.cell.value || "") + childValue;
+                const parentEdits: any[] = parentMd.edits || (parentMd.edits = []);
+                parentEdits.push({
+                    editMap: EditMapUtils.value(),
+                    value: parent.cell.value,
+                    timestamp: Date.now(),
+                    type: EditType.MIGRATION,
+                    author: "system",
+                    validatedBy: [],
+                });
+                hasChanges = true;
+            }
+
+            // Track the merged child id on the parent (defensive, survives sync via edit history).
+            if (typeof childId === "string" && !existingMergedIds.includes(childId)) {
+                existingMergedIds.push(childId);
+                parentData.mergedChildIds = existingMergedIds;
+                const parentEdits: any[] = parentMd.edits || (parentMd.edits = []);
+                parentEdits.push({
+                    editMap: ["metadata", "data", "mergedChildIds"],
+                    value: existingMergedIds.slice(),
+                    timestamp: Date.now(),
+                    type: EditType.MIGRATION,
+                    author: "system",
+                    validatedBy: [],
+                });
+                hasChanges = true;
+            }
+
+            // Soft-delete the child instead of hard-removing it. Keeps the deletion in edit
+            // history so it propagates across syncs (resolveMetadataConflictsUsingEditHistory
+            // applies the most recent metadata.data.deleted edit).
+            if (!childAlreadyDeleted) {
+                const cMd: any = child.cell.metadata || (child.cell.metadata = {});
+                const cData: any = cMd.data || (cMd.data = {});
+                cData.deleted = true;
+                const childEdits: any[] = cMd.edits || (cMd.edits = []);
+                childEdits.push({
+                    editMap: EditMapUtils.dataDeleted(),
+                    value: true,
+                    timestamp: Date.now(),
+                    type: EditType.MIGRATION,
+                    author: "system",
+                    validatedBy: [],
+                });
+                hasChanges = true;
+            }
         }
 
         // Partition content-with-ref by (book, chapter), sort each by verse

--- a/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
+++ b/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
@@ -633,12 +633,15 @@ suite("migrateVerseRangeLabelsAndPositionsForFile", () => {
         );
     });
 
-    test("paratext that originally appeared after its parent stays after", async () => {
+    test("paratext that originally appeared after its parent is moved above the parent", async () => {
         const milestoneId = randomUUID();
         const verseId = randomUUID();
         const noteId = randomUUID();
         const verse2Id = randomUUID();
 
+        // Section-heading style paratexts in scripture (\\s) belong above the verse they
+        // introduce, so the migration normalises every parented paratext to BEFORE its parent
+        // regardless of its original index.
         const uri = await createTempNotebookFile(".codex", [
             {
                 value: "Genesis 1",
@@ -656,7 +659,7 @@ suite("migrateVerseRangeLabelsAndPositionsForFile", () => {
                 },
             },
             {
-                value: "<span><em>Translator note</em></span>",
+                value: "<span><em>Section heading</em></span>",
                 languageId: "html",
                 metadata: {
                     id: noteId,
@@ -684,8 +687,8 @@ suite("migrateVerseRangeLabelsAndPositionsForFile", () => {
         const ids = data.cells.map((c: any) => c.metadata?.id);
         assert.deepStrictEqual(
             ids,
-            [milestoneId, verseId, noteId, verse2Id],
-            "AFTER-parent paratext should remain right after its parent"
+            [milestoneId, noteId, verseId, verse2Id],
+            "Paratext should be moved above its parent verse, even when originally below"
         );
     });
 

--- a/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
+++ b/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
@@ -284,4 +284,295 @@ suite("migrateVerseRangeLabelsAndPositionsForFile", () => {
         assert.strictEqual(data.cells[1].metadata?.id, id1);
         assert.strictEqual(data.cells[2].metadata?.data?.globalReferences?.[0], "JHN 4:4");
     });
+
+    test("should soft-delete child and track mergedChildIds when merging split verse-range cells", async () => {
+        const milestoneId = randomUUID();
+        const parentId = randomUUID();
+        const childId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 50",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Parent first sentence.</span>",
+                metadata: {
+                    id: parentId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Child second sentence.</span>",
+                metadata: {
+                    id: childId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    parentId,
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        const wasMigrated = await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        assert.strictEqual(wasMigrated, true);
+
+        const data = await readNotebookFile(uri);
+
+        // Child should still be present in the file (soft-deleted, not hard-removed)
+        const parent = data.cells.find((c: any) => c.metadata?.id === parentId);
+        const child = data.cells.find((c: any) => c.metadata?.id === childId);
+        assert.ok(parent, "Parent cell should be in the file");
+        assert.ok(child, "Child cell should be soft-deleted but still present in the file");
+
+        // Parent should have the merged value
+        assert.strictEqual(
+            parent.value,
+            "<span>Parent first sentence.</span><span>Child second sentence.</span>"
+        );
+        assert.strictEqual(parent.metadata?.cellLabel, "12-13");
+
+        // Parent should track merged child id
+        assert.deepStrictEqual(parent.metadata?.data?.mergedChildIds, [childId]);
+
+        // Parent should have a value-edit and a mergedChildIds-edit recorded
+        const parentEdits: any[] = parent.metadata?.edits || [];
+        const valueEdits = parentEdits.filter((e) => e.editMap?.join(".") === "value");
+        const trackingEdits = parentEdits.filter(
+            (e) => e.editMap?.join(".") === "metadata.data.mergedChildIds"
+        );
+        assert.strictEqual(valueEdits.length, 1, "Should have exactly one value migration edit");
+        assert.strictEqual(valueEdits[0].type, "migration");
+        assert.strictEqual(trackingEdits.length, 1, "Should have one mergedChildIds edit");
+        assert.deepStrictEqual(trackingEdits[0].value, [childId]);
+
+        // Child should be marked deleted with a deletion edit
+        assert.strictEqual(child.metadata?.data?.deleted, true);
+        const childEdits: any[] = child.metadata?.edits || [];
+        const deleteEdits = childEdits.filter(
+            (e) => e.editMap?.join(".") === "metadata.data.deleted"
+        );
+        assert.strictEqual(deleteEdits.length, 1, "Child should have one deletion edit");
+        assert.strictEqual(deleteEdits[0].value, true);
+        assert.strictEqual(deleteEdits[0].type, "migration");
+    });
+
+    test("should not duplicate parent value when re-running migration after a sync re-introduces the child", async () => {
+        const milestoneId = randomUUID();
+        const parentId = randomUUID();
+        const childId = randomUUID();
+
+        // Initial state: parent + un-merged child (as-imported)
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 50",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Parent first.</span>",
+                metadata: {
+                    id: parentId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Child second.</span>",
+                metadata: {
+                    id: childId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    parentId,
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        // First migration: merges child into parent and soft-deletes child
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const after1 = await readNotebookFile(uri);
+        const parent1 = after1.cells.find((c: any) => c.metadata?.id === parentId);
+        const expectedMergedValue =
+            "<span>Parent first.</span><span>Child second.</span>";
+        assert.strictEqual(parent1.value, expectedMergedValue);
+
+        // Simulate sync: re-introduce child cell WITHOUT data.deleted (as if pulled in from
+        // another user's branch where the deletion didn't propagate). The codex merge resolver
+        // would normally do this, but mergedChildIds on the parent should still gate the merge.
+        const fileBytes = await vscode.workspace.fs.readFile(uri);
+        const serializer = new CodexContentSerializer();
+        const notebookData: any = await serializer.deserializeNotebook(
+            fileBytes,
+            new vscode.CancellationTokenSource().token
+        );
+        const childIdx = notebookData.cells.findIndex(
+            (c: any) => c.metadata?.id === childId
+        );
+        if (childIdx >= 0) {
+            const ch = notebookData.cells[childIdx];
+            // Strip the deletion (sim a sync that lost the deletion edit)
+            if (ch.metadata?.data) {
+                delete ch.metadata.data.deleted;
+            }
+            ch.metadata.edits = (ch.metadata.edits || []).filter(
+                (e: any) => e.editMap?.join(".") !== "metadata.data.deleted"
+            );
+        }
+        const reSerialized = await serializer.serializeNotebook(
+            notebookData,
+            new vscode.CancellationTokenSource().token
+        );
+        await vscode.workspace.fs.writeFile(uri, reSerialized);
+
+        // Second migration: should NOT re-append the child's value because mergedChildIds
+        // already tracks it (even though child no longer has data.deleted).
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const after2 = await readNotebookFile(uri);
+        const parent2 = after2.cells.find((c: any) => c.metadata?.id === parentId);
+        const child2 = after2.cells.find((c: any) => c.metadata?.id === childId);
+
+        assert.strictEqual(
+            parent2.value,
+            expectedMergedValue,
+            "Parent value must NOT be doubled by the second run"
+        );
+
+        // Child should be re-soft-deleted by the second run
+        assert.strictEqual(child2.metadata?.data?.deleted, true);
+
+        // Parent should still have only ONE value migration edit
+        const parentEdits: any[] = parent2.metadata?.edits || [];
+        const valueEdits = parentEdits.filter((e) => e.editMap?.join(".") === "value");
+        assert.strictEqual(
+            valueEdits.length,
+            1,
+            "There should be exactly one value migration edit (no second append)"
+        );
+    });
+
+    test("should not duplicate when sync also drops mergedChildIds tracking (endsWith safeguard)", async () => {
+        const milestoneId = randomUUID();
+        const parentId = randomUUID();
+        const childId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 50",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Parent A.</span>",
+                metadata: {
+                    id: parentId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Child B.</span>",
+                metadata: {
+                    id: childId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    parentId,
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        // Strip BOTH the parent's mergedChildIds tracking AND the child's data.deleted
+        // to simulate the worst-case sync where both signals were lost. The endsWith
+        // safeguard should still prevent a duplicate append.
+        const serializer = new CodexContentSerializer();
+        const fileBytes = await vscode.workspace.fs.readFile(uri);
+        const notebookData: any = await serializer.deserializeNotebook(
+            fileBytes,
+            new vscode.CancellationTokenSource().token
+        );
+        for (const cell of notebookData.cells) {
+            if (cell.metadata?.id === parentId && cell.metadata?.data?.mergedChildIds) {
+                delete cell.metadata.data.mergedChildIds;
+                cell.metadata.edits = (cell.metadata.edits || []).filter(
+                    (e: any) => e.editMap?.join(".") !== "metadata.data.mergedChildIds"
+                );
+            }
+            if (cell.metadata?.id === childId) {
+                if (cell.metadata?.data) delete cell.metadata.data.deleted;
+                cell.metadata.edits = (cell.metadata.edits || []).filter(
+                    (e: any) => e.editMap?.join(".") !== "metadata.data.deleted"
+                );
+            }
+        }
+        const reSerialized = await serializer.serializeNotebook(
+            notebookData,
+            new vscode.CancellationTokenSource().token
+        );
+        await vscode.workspace.fs.writeFile(uri, reSerialized);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const data = await readNotebookFile(uri);
+        const parent = data.cells.find((c: any) => c.metadata?.id === parentId);
+        assert.strictEqual(
+            parent.value,
+            "<span>Parent A.</span><span>Child B.</span>",
+            "endsWith guard should prevent doubling even when tracking signals are lost"
+        );
+    });
+
+    test("should be idempotent across multiple consecutive runs when child has parentId", async () => {
+        const milestoneId = randomUUID();
+        const parentId = randomUUID();
+        const childId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 50",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Parent X.</span>",
+                metadata: {
+                    id: parentId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Child Y.</span>",
+                metadata: {
+                    id: childId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    parentId,
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const second = await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const third = await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        assert.strictEqual(second, false, "Second run should report no changes");
+        assert.strictEqual(third, false, "Third run should report no changes");
+
+        const data = await readNotebookFile(uri);
+        const parent = data.cells.find((c: any) => c.metadata?.id === parentId);
+        assert.strictEqual(parent.value, "<span>Parent X.</span><span>Child Y.</span>");
+    });
 });

--- a/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
+++ b/src/test/suite/migration_verseRangeLabelsAndPositions.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import { randomUUID } from "crypto";
 import { CodexContentSerializer } from "../../serializer";
 import { migrateVerseRangeLabelsAndPositionsForFile } from "../../projectManager/utils/migrationUtils";
+import { resolveCodexCustomMerge } from "../../projectManager/utils/merge/resolvers";
 import { CodexCellTypes } from "../../../types/enums";
 
 async function createTempNotebookFile(
@@ -574,5 +575,383 @@ suite("migrateVerseRangeLabelsAndPositionsForFile", () => {
         const data = await readNotebookFile(uri);
         const parent = data.cells.find((c: any) => c.metadata?.id === parentId);
         assert.strictEqual(parent.value, "<span>Parent X.</span><span>Child Y.</span>");
+    });
+
+    test("paratext between a milestone and the first verse stays in place", async () => {
+        const milestoneId = randomUUID();
+        const headingId = randomUUID();
+        const verse1Id = randomUUID();
+        const verse2Id = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 1",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span><strong>Heading</strong></span>",
+                languageId: "html",
+                metadata: {
+                    id: headingId,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: verse1Id,
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>In the beginning...</span>",
+                metadata: {
+                    id: verse1Id,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:1"),
+                    cellLabel: "1",
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>...and the earth was formless.</span>",
+                metadata: {
+                    id: verse2Id,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:2"),
+                    cellLabel: "2",
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        const data = await readNotebookFile(uri);
+        const ids = data.cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            [milestoneId, headingId, verse1Id, verse2Id],
+            "Heading paratext should stay between the milestone and verse 1"
+        );
+    });
+
+    test("paratext that originally appeared after its parent stays after", async () => {
+        const milestoneId = randomUUID();
+        const verseId = randomUUID();
+        const noteId = randomUUID();
+        const verse2Id = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 1",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>In the beginning...</span>",
+                metadata: {
+                    id: verseId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:1"),
+                    cellLabel: "1",
+                    edits: [],
+                },
+            },
+            {
+                value: "<span><em>Translator note</em></span>",
+                languageId: "html",
+                metadata: {
+                    id: noteId,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: verseId,
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>...and the earth was formless.</span>",
+                metadata: {
+                    id: verse2Id,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:2"),
+                    cellLabel: "2",
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        const data = await readNotebookFile(uri);
+        const ids = data.cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            [milestoneId, verseId, noteId, verse2Id],
+            "AFTER-parent paratext should remain right after its parent"
+        );
+    });
+
+    test("multiple paratexts before a parent retain their relative order", async () => {
+        const milestoneId = randomUUID();
+        const heading1 = randomUUID();
+        const heading2 = randomUUID();
+        const heading3 = randomUUID();
+        const verseId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 1",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>A</span>",
+                languageId: "html",
+                metadata: {
+                    id: heading1,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: verseId,
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>B</span>",
+                languageId: "html",
+                metadata: {
+                    id: heading2,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: verseId,
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>C</span>",
+                languageId: "html",
+                metadata: {
+                    id: heading3,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: verseId,
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Verse text.</span>",
+                metadata: {
+                    id: verseId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:1"),
+                    cellLabel: "1",
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        const data = await readNotebookFile(uri);
+        const ids = data.cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            [milestoneId, heading1, heading2, heading3, verseId],
+            "BEFORE-parent paratexts must keep their relative order"
+        );
+    });
+
+    test("orphan paratext is soft-deleted in place idempotently", async () => {
+        const milestoneId = randomUUID();
+        const verseId = randomUUID();
+        const orphanId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 1",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Verse 1</span>",
+                metadata: {
+                    id: verseId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:1"),
+                    cellLabel: "1",
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Stale heading</span>",
+                languageId: "html",
+                metadata: {
+                    id: orphanId,
+                    type: CodexCellTypes.PARATEXT,
+                    parentId: "missing-parent-id",
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const data1 = await readNotebookFile(uri);
+        const orphan1 = data1.cells.find((c: any) => c.metadata?.id === orphanId);
+        assert.ok(orphan1, "Orphan paratext should still be present");
+        assert.strictEqual(orphan1.metadata?.data?.deleted, true, "Orphan should be soft-deleted");
+        const orphanIndex1 = data1.cells.findIndex(
+            (c: any) => c.metadata?.id === orphanId
+        );
+        assert.strictEqual(
+            orphanIndex1,
+            data1.cells.length - 1,
+            "Orphan paratext should keep its trailing position"
+        );
+
+        const orphanDeleteEdits1 = (orphan1.metadata?.edits || []).filter(
+            (e: any) => e.editMap?.join(".") === "metadata.data.deleted"
+        );
+        assert.strictEqual(orphanDeleteEdits1.length, 1, "First run should add exactly one deletion edit");
+
+        const second = await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        assert.strictEqual(second, false, "Second migration run should be a no-op");
+        const data2 = await readNotebookFile(uri);
+        const orphan2 = data2.cells.find((c: any) => c.metadata?.id === orphanId);
+        const orphanDeleteEdits2 = (orphan2.metadata?.edits || []).filter(
+            (e: any) => e.editMap?.join(".") === "metadata.data.deleted"
+        );
+        assert.strictEqual(
+            orphanDeleteEdits2.length,
+            1,
+            "Second run must NOT add another deletion edit"
+        );
+    });
+
+    test("user-edited cellLabel on a verse-range cell is not overwritten by the helper", async () => {
+        const milestoneId = randomUUID();
+        const rangeId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 1",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Verses 1-3</span>",
+                metadata: {
+                    id: rangeId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 1:1-3"),
+                    // User has explicitly relabelled this cell
+                    cellLabel: "1a",
+                    edits: [
+                        {
+                            editMap: ["metadata", "cellLabel"],
+                            value: "1a",
+                            timestamp: 1,
+                            type: "user-edit",
+                            author: "translator",
+                            validatedBy: [],
+                        },
+                    ],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        const data = await readNotebookFile(uri);
+        const range = data.cells.find((c: any) => c.metadata?.id === rangeId);
+        assert.strictEqual(
+            range.metadata?.cellLabel,
+            "1a",
+            "User-edited cellLabel must be preserved across migration runs"
+        );
+    });
+
+    test("double-run after a sync round-trip does not append a new mergedChildIds edit", async () => {
+        const milestoneId = randomUUID();
+        const parentId = randomUUID();
+        const childId = randomUUID();
+
+        const uri = await createTempNotebookFile(".codex", [
+            {
+                value: "Genesis 50",
+                languageId: "html",
+                metadata: { id: milestoneId, type: CodexCellTypes.MILESTONE, edits: [] },
+            },
+            {
+                value: "<span>Parent first.</span>",
+                metadata: {
+                    id: parentId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    edits: [],
+                },
+            },
+            {
+                value: "<span>Child second.</span>",
+                metadata: {
+                    id: childId,
+                    type: CodexCellTypes.TEXT,
+                    ...ref("GEN 50:12-13"),
+                    parentId,
+                    edits: [],
+                },
+            },
+        ]);
+        testFiles.push(uri);
+
+        // First migration: merges child -> parent
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+        const after1Bytes = await vscode.workspace.fs.readFile(uri);
+        const after1Text = Buffer.from(after1Bytes).toString("utf8");
+
+        // Build a "peer" branch where the child still looks like an unmerged sibling
+        // (no data.deleted, no mergedChildIds tracked on the parent).
+        const peer: any = JSON.parse(after1Text);
+        for (const c of peer.cells) {
+            if (c.metadata?.id === childId && c.metadata?.data) {
+                delete c.metadata.data.deleted;
+                c.metadata.edits = (c.metadata.edits || []).filter(
+                    (e: any) => e.editMap?.join(".") !== "metadata.data.deleted"
+                );
+            }
+            if (c.metadata?.id === parentId && c.metadata?.data) {
+                delete c.metadata.data.mergedChildIds;
+                c.metadata.edits = (c.metadata.edits || []).filter(
+                    (e: any) =>
+                        e.editMap?.join(".") !== "metadata.data.mergedChildIds" &&
+                        e.editMap?.join(".") !== "value"
+                );
+                c.value = "<span>Parent first.</span>";
+            }
+        }
+        const peerText = JSON.stringify(peer);
+
+        // Sync round-trip: merge ours-migrated against peer-unmigrated. Ours order should win,
+        // and the helper running inside the resolver guarantees the merged file is in the
+        // migrated cell order with the merge phase's edits intact.
+        const merged = await resolveCodexCustomMerge(after1Text, peerText);
+        await vscode.workspace.fs.writeFile(uri, Buffer.from(merged, "utf8"));
+
+        // Run the migration again. Because mergedChildIds is still tracked in the merged
+        // edit history, the merge phase must NOT append a new mergedChildIds edit.
+        await migrateVerseRangeLabelsAndPositionsForFile(uri);
+
+        const final = await readNotebookFile(uri);
+        const parentFinal = final.cells.find((c: any) => c.metadata?.id === parentId);
+        const trackingEdits = (parentFinal.metadata?.edits || []).filter(
+            (e: any) => e.editMap?.join(".") === "metadata.data.mergedChildIds"
+        );
+        assert.strictEqual(
+            trackingEdits.length,
+            1,
+            "After sync + re-migration there should still be exactly one mergedChildIds edit"
+        );
+        assert.strictEqual(
+            parentFinal.value,
+            "<span>Parent first.</span><span>Child second.</span>",
+            "Parent value must not be doubled across sync + re-migration"
+        );
     });
 });

--- a/src/test/suite/resolveCodexCustomMerge.test.ts
+++ b/src/test/suite/resolveCodexCustomMerge.test.ts
@@ -258,3 +258,228 @@ suite("Codex Custom Merge - Paratextual Cell Position Preservation", () => {
         );
     });
 });
+
+suite("Codex Custom Merge - Verse Range Order Preservation Across Sync", () => {
+    /**
+     * Build a notebook with a chapter milestone and three single-verse cells.
+     * `cellOrder` lets us reorder them to simulate the unmigrated/migrated sides of a sync.
+     */
+    function buildScriptureNotebook(cellOrder: Array<"M" | "V1" | "V2" | "V3R">): string {
+        const byKey: Record<string, any> = {
+            M: {
+                kind: 2,
+                languageId: "html",
+                value: "John 4",
+                metadata: { id: "M1", type: "milestone", edits: [] },
+            },
+            V1: {
+                kind: 2,
+                languageId: "scripture",
+                value: "<span>v1</span>",
+                metadata: {
+                    id: "V1",
+                    type: "text",
+                    cellLabel: "1",
+                    data: { globalReferences: ["JHN 4:1"] },
+                    edits: [],
+                },
+            },
+            V2: {
+                kind: 2,
+                languageId: "scripture",
+                value: "<span>v2</span>",
+                metadata: {
+                    id: "V2",
+                    type: "text",
+                    cellLabel: "2",
+                    data: { globalReferences: ["JHN 4:2"] },
+                    edits: [],
+                },
+            },
+            // Verse-range cell at "JHN 4:3-5" — the migrated side should place this in verse order
+            V3R: {
+                kind: 2,
+                languageId: "scripture",
+                value: "<span>v3-5</span>",
+                metadata: {
+                    id: "V3R",
+                    type: "text",
+                    data: { globalReferences: ["JHN 4:3-5"] },
+                    edits: [],
+                },
+            },
+        };
+        return JSON.stringify({
+            cells: cellOrder.map((k) => byKey[k]),
+            metadata: { id: "TEST", originalName: "TEST" },
+        });
+    }
+
+    test("ours-unmigrated vs theirs-migrated yields migrated order", async () => {
+        // Ours: range cell appears AFTER all single verses (unmigrated layout)
+        const oursUnmigrated = buildScriptureNotebook(["M", "V1", "V2", "V3R"]);
+        // Theirs: range cell already placed between V2 and (would-be) verse 6 — but here it's
+        // simply right after V2 in correct verse-start order.
+        const theirsMigrated = buildScriptureNotebook(["M", "V1", "V2", "V3R"]);
+
+        const merged = await resolveCodexCustomMerge(oursUnmigrated, theirsMigrated);
+        const notebook = JSON.parse(merged);
+        const ids = notebook.cells.map((c: any) => c.metadata?.id);
+        // Expected order: milestone, then verses in start-verse order under that chapter.
+        assert.deepStrictEqual(ids, ["M1", "V1", "V2", "V3R"]);
+        const range = notebook.cells.find((c: any) => c.metadata?.id === "V3R");
+        assert.strictEqual(range.metadata.cellLabel, "3-5", "Verse-range cellLabel should be auto-derived");
+        assert.strictEqual(range.metadata.chapterNumber, "4", "Chapter number should be auto-derived");
+    });
+
+    test("theirs-unmigrated vs ours-migrated still yields migrated order regardless of which side is ours", async () => {
+        // Cross-side scenario A: ours has range at the wrong end
+        const oursWrong = buildScriptureNotebook(["V3R", "M", "V1", "V2"]);
+        const theirsCorrect = buildScriptureNotebook(["M", "V1", "V2", "V3R"]);
+
+        const mergedA = await resolveCodexCustomMerge(oursWrong, theirsCorrect);
+        const idsA = JSON.parse(mergedA).cells.map((c: any) => c.metadata?.id);
+        // Even though "ours" had the range cell first, the helper places it under the milestone.
+        assert.deepStrictEqual(idsA, ["M1", "V1", "V2", "V3R"]);
+
+        // Cross-side scenario B: swapped — ours is correct, theirs is wrong
+        const mergedB = await resolveCodexCustomMerge(theirsCorrect, oursWrong);
+        const idsB = JSON.parse(mergedB).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(idsB, ["M1", "V1", "V2", "V3R"]);
+    });
+
+    test("merge of two already-migrated sides is stable (no order or label changes)", async () => {
+        const a = buildScriptureNotebook(["M", "V1", "V2", "V3R"]);
+        const b = buildScriptureNotebook(["M", "V1", "V2", "V3R"]);
+        const merged1 = await resolveCodexCustomMerge(a, b);
+        const merged2 = await resolveCodexCustomMerge(merged1, merged1);
+
+        const ids1 = JSON.parse(merged1).cells.map((c: any) => c.metadata?.id);
+        const ids2 = JSON.parse(merged2).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(ids1, ["M1", "V1", "V2", "V3R"]);
+        assert.deepStrictEqual(ids2, ids1);
+
+        // No new edits should be added by the resolver pass
+        const cells2 = JSON.parse(merged2).cells;
+        for (const c of cells2) {
+            const labelEdits = (c.metadata?.edits || []).filter(
+                (e: any) => e.editMap?.join(".") === "metadata.cellLabel"
+            );
+            assert.strictEqual(
+                labelEdits.length,
+                0,
+                `Resolver must not add cellLabel edits (cell ${c.metadata?.id})`
+            );
+        }
+    });
+
+    test("merge of a notebook with no milestones and no range cells is byte-stable", async () => {
+        // No milestone and no range cell -> helper early-exits, output mirrors merge result only
+        const ourContent = createNotebook([
+            createCell("CELL-1", "First"),
+            createCell("CELL-2", "Second"),
+            createCell("CELL-3", "Third"),
+        ]);
+        const merged1 = await resolveCodexCustomMerge(ourContent, ourContent);
+        const merged2 = await resolveCodexCustomMerge(merged1, merged1);
+        assert.strictEqual(merged1, merged2, "Repeated merges of a non-scripture notebook must be byte-stable");
+        const ids = JSON.parse(merged1).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(ids, ["CELL-1", "CELL-2", "CELL-3"]);
+    });
+
+    test("orphan paratext is NOT soft-deleted by the resolver path", async () => {
+        // Notebook contains a milestone (so the helper does NOT early-exit) AND an orphan
+        // paratext whose parent verse is missing. The helper must keep the orphan intact —
+        // soft-delete is the migration's job, not the resolver's.
+        const orphanedContent = JSON.stringify({
+            cells: [
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "Genesis 1",
+                    metadata: { id: "M1", type: "milestone", edits: [] },
+                },
+                {
+                    kind: 2,
+                    languageId: "scripture",
+                    value: "<span>verse</span>",
+                    metadata: {
+                        id: "V1",
+                        type: "text",
+                        cellLabel: "1",
+                        data: { globalReferences: ["GEN 1:1"] },
+                        edits: [],
+                    },
+                },
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "<span>orphan note</span>",
+                    metadata: {
+                        id: "ORPH",
+                        type: "paratext",
+                        parentId: "missing-id",
+                        data: {},
+                        edits: [],
+                    },
+                },
+            ],
+            metadata: { id: "TEST", originalName: "TEST" },
+        });
+        const merged = await resolveCodexCustomMerge(orphanedContent, orphanedContent);
+        const orphan = JSON.parse(merged).cells.find((c: any) => c.metadata?.id === "ORPH");
+        assert.ok(orphan, "Orphan paratext must still be present");
+        assert.notStrictEqual(
+            orphan.metadata?.data?.deleted,
+            true,
+            "Resolver must NOT soft-delete orphan paratext"
+        );
+        const orphanDeleteEdits = (orphan.metadata?.edits || []).filter(
+            (e: any) => e.editMap?.join(".") === "metadata.data.deleted"
+        );
+        assert.strictEqual(
+            orphanDeleteEdits.length,
+            0,
+            "Resolver must NOT add a soft-delete edit for orphan paratext"
+        );
+    });
+
+    test("user-edited cellLabel on a verse-range cell is preserved across a merge", async () => {
+        const customLabel = "1a";
+        const a = JSON.stringify({
+            cells: [
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "Genesis 1",
+                    metadata: { id: "M1", type: "milestone", edits: [] },
+                },
+                {
+                    kind: 2,
+                    languageId: "scripture",
+                    value: "<span>1-3</span>",
+                    metadata: {
+                        id: "RANGE",
+                        type: "text",
+                        cellLabel: customLabel,
+                        data: { globalReferences: ["GEN 1:1-3"] },
+                        edits: [
+                            {
+                                editMap: ["metadata", "cellLabel"],
+                                value: customLabel,
+                                timestamp: 1,
+                                type: "user-edit",
+                                author: "translator",
+                                validatedBy: [],
+                            },
+                        ],
+                    },
+                },
+            ],
+            metadata: { id: "TEST", originalName: "TEST" },
+        });
+        const merged = await resolveCodexCustomMerge(a, a);
+        const range = JSON.parse(merged).cells.find((c: any) => c.metadata?.id === "RANGE");
+        assert.strictEqual(range.metadata.cellLabel, customLabel, "Resolver must not overwrite a user-edited cellLabel");
+    });
+});


### PR DESCRIPTION
Closes #956 

PROJECT TO TEST WITH CODEX BETA: recover-verses-burmese-bible

The verse-range cell merge phase in migrateVerseRangeLabelsAndPositionsForFile hard-removed merged child cells and unconditionally appended their value to the parent. Under git sync this caused parent content to be doubled: the codex merge resolver re-introduces cells unique to "their" version (because the deletion was never recorded in edit history), so a re-run of the migration would append the child's value a second time.
- Soft-delete merged children (data.deleted = true with a MIGRATION edit on ["metadata","data","deleted"]) instead of hard-removing them, so the deletion propagates through edit history and other peers honor it on next pull.
- Track merged child ids in parent.metadata.data.mergedChildIds (with a matching edit) so the merge state survives sync and gates re-runs.
- Add three idempotency guards in the merge loop: skip if the child is already soft-deleted, if the parent already lists the child id, or if parent.value already endsWith the child value.
- Add tests covering the soft-delete + tracking output, double-run protection when a sync re-introduces the child, and the endsWith fallback when both tracking signals are stripped.

## Testing Checklist
- [ ] Run Fix Verse Range and Label migration through the command palette
- [ ] Check json of Genesis after verse 26 of Chapter 50 to make sure there are no extra cells
- [ ] Make sure ranged verses are combined in the target window like how they are in the source window (eg. Gen 1:17-18 should now be in both views)