### PR TITLE
Vsix minification

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,8 +18,6 @@
 # Runtime dependencies
 !node_modules/dugite/build/**
 !node_modules/dugite/package.json
-!node_modules/@vscode/codicons/dist/**
-!node_modules/vscode-uri
 
 # Documentation
 !CHANGELOG.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,30 +2,31 @@
 *
 */**
 
-# Allowlist what we need (only extension output, NOT test bundles)
+# Extension output (JS bundles only)
 !out/*.js
-!out/*.js.map
 !out/node_modules/**
+
+# Static assets
 !assets/**
+!src/assets/reset.css
+!src/assets/bible_data_with_vref_keys.json.gz
 
-# Exclude test output and source maps from VSIX
-out/test/**
-out/test-runner/**
-out/**/*.map
-.vscode-test/**
-# !servers/**
-
+# Webview bundles
 !webviews/codex-webviews/dist/**
 !webviews/codex-webviews/src/assets/**
 
-!src/assets/reset.css
-# vscode.css was removed in favor of Tailwind CSS
-!src/assets/bible_data_with_vref_keys.json.gz
-!**/*.svg
+# Runtime dependencies
 !node_modules/dugite/build/**
 !node_modules/dugite/package.json
+!node_modules/@vscode/codicons/dist/**
+!node_modules/vscode-uri
 
+# Documentation
 !CHANGELOG.md
 !LICENSE
-!package*.json
+!package.json
 !README.md
+
+# Global exclusions — override any includes above
+**/*.map
+.vscode-test/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,11 @@
-# Ignore everything
+# VSIX packaging is deny-by-default. Prefer narrow allowlists; broad negations
+# like !out/**, !**/*.svg, !package*.json, or !node_modules/** can pull in
+# source maps, test installs, lockfiles, or large dependency trees.
 *
 */**
 
-# Extension output (JS bundles only)
+# Extension output. Keep this narrow: out/*.js is the extension bundle, while
+# out/node_modules/** is only for runtime files explicitly copied by webpack.
 !out/*.js
 !out/node_modules/**
 
@@ -15,7 +18,8 @@
 !webviews/codex-webviews/dist/**
 !webviews/codex-webviews/src/assets/**
 
-# Runtime dependencies
+# Runtime dependencies not copied into out/. Dugite is externalized, but we
+# ship only its JS wrapper metadata here, not node_modules/dugite/git/**.
 !node_modules/dugite/build/**
 !node_modules/dugite/package.json
 
@@ -25,6 +29,6 @@
 !package.json
 !README.md
 
-# Global exclusions — override any includes above
+# Global exclusions override earlier includes to keep published VSIX files lean.
 **/*.map
 .vscode-test/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,11 +18,6 @@
 !webviews/codex-webviews/dist/**
 !webviews/codex-webviews/src/assets/**
 
-# Runtime dependencies not copied into out/. Dugite is externalized, but we
-# ship only its JS wrapper metadata here, not node_modules/dugite/git/**.
-!node_modules/dugite/build/**
-!node_modules/dugite/package.json
-
 # Documentation
 !CHANGELOG.md
 !LICENSE

--- a/package.json
+++ b/package.json
@@ -1033,10 +1033,10 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "npm run build:webviews && npm run test:webviews && npm run compile && npm run test",
+        "vscode:prepublish": "npm run build:webviews && npm run test:webviews && npm run test && npm run package",
         "compile": "webpack --config webpack.config.js",
         "watch": "webpack --config webpack.config.js --watch",
-        "package": "webpack --config webpack.config.js --mode production --devtool hidden-source-map",
+        "package": "rm -rf out && webpack --config webpack.config.js --config-name extension --mode production",
         "lint": "eslint src --ext ts",
         "pretest": "npm run compile && npm run lint",
         "test": "node ./out/test/runTest.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,11 +27,13 @@ const extensionConfig = {
     },
     externals: {
         vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-        // modules added here also need to be added in the .vscodeignore file
+        // Packaging contract: externals are not bundled into extension.js.
+        // Runtime files must be copied into out/node_modules below or narrowly
+        // allowlisted in .vscodeignore; otherwise installs break or VSIX grows.
         "fts5-sql-bundle": "commonjs fts5-sql-bundle", // WASM-based SQLite fallback — must remain external so locateFile can resolve the .wasm at runtime
         vm: "commonjs vm",
         encoding: "commonjs encoding",
-        dugite: "commonjs dugite", // Must be external so its embedded binary resolution works (needs real __dirname and process.platform)
+        dugite: "commonjs dugite", // Keep external so dugite uses real paths/env when Frontier Auth provides the Git runtime.
         // Note: tar is NOT external - it's bundled so audio import can extract FFmpeg on-demand
     },
     resolve: {
@@ -89,6 +91,7 @@ const extensionConfig = {
             {
                 test: /\.js\.map$/,
                 include: /pdf-parse/,
+                // pdf-parse ships maps next to JS; do not parse them as code.
                 type: "asset/resource",
                 generator: { emit: false },
             },
@@ -105,6 +108,8 @@ const extensionConfig = {
         new webpack.DefinePlugin({
             "process.env.NODE_ENV": JSON.stringify("production"),
         }),
+        // Keep copied runtime assets under out/node_modules so .vscodeignore can
+        // allowlist that output instead of broad root dependency folders.
         new CopyWebpackPlugin({
             patterns: [
                 {
@@ -133,6 +138,8 @@ const extensionConfig = {
                 },
             ],
         }),
+        // pdf-parse dynamically requires pdf.js versions; pin to its default so
+        // webpack does not bundle every pdf.js copy in that package.
         new webpack.ContextReplacementPlugin(
             /pdf-parse[/\\]lib[/\\]pdf\.js/,
             /^\.\/v1\.10\.100/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,12 @@ const extensionConfig = {
                 include: /node_modules/,
                 type: "javascript/auto",
             },
+            {
+                test: /\.js\.map$/,
+                include: /pdf-parse/,
+                type: "asset/resource",
+                generator: { emit: false },
+            },
         ],
     },
     devtool: "nosources-source-map",
@@ -127,10 +133,11 @@ const extensionConfig = {
                 },
             ],
         }),
+        new webpack.ContextReplacementPlugin(
+            /pdf-parse[/\\]lib[/\\]pdf\.js/,
+            /^\.\/v1\.10\.100/
+        ),
     ],
-    optimization: {
-        minimize: false,
-    },
     ignoreWarnings: [
         {
             module: /node_modules\/mocha/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,6 +136,14 @@ const extensionConfig = {
                     from: "node_modules/@vscode/codicons/dist/codicon.ttf",
                     to: "node_modules/@vscode/codicons/dist/codicon.ttf",
                 },
+                {
+                    from: "node_modules/dugite/build",
+                    to: "node_modules/dugite/build",
+                },
+                {
+                    from: "node_modules/dugite/package.json",
+                    to: "node_modules/dugite/package.json",
+                },
             ],
         }),
         // pdf-parse dynamically requires pdf.js versions; pin to its default so


### PR DESCRIPTION
## Summary

This PR reduces the size of the generated VSIX by tightening what we package and making the production extension build smaller.

### What changed

- Uses the production webpack package build for VSIX output so `extension.js` is minified.
- Cleans `out/` before the final package build so stale test or chunk output is not accidentally included.
- Builds only the extension webpack config for the final package output, while still running the full compile/test pipeline before packaging.
- Excludes source maps from the published VSIX.
- Excludes `.vscode-test/` and `package-lock.json` from the VSIX.
- Avoids broad asset/package allowlists like `!**/*.svg` and `!package*.json` that can accidentally pull large unrelated files into the package.
- Keeps `dugite` external while packaging only the small JS wrapper metadata needed at runtime, not dugite’s embedded Git binaries.
- Keeps copied runtime assets, such as `fts5-sql-bundle` and codicons, under `out/node_modules` so `.vscodeignore` can safely include a narrow runtime output path.
- Restricts `pdf-parse` bundling to its default `pdf.js` version instead of pulling in every bundled pdf.js version.
- Adds comments documenting the VSIX packaging contract so future dependency additions do not accidentally bloat or break the package.

## Why

The previous VSIX packaging could include unnecessary production artifacts such as source maps, test installs, lockfiles, and stale build output. This made the VSIX larger than needed and made future dependency additions easy to get wrong.

The new pattern is:

- Bundle what can be bundled.
- Externalize only what needs real runtime paths.
- Copy required external runtime files into `out/node_modules`.
- Allowlist narrow output paths in `.vscodeignore`.
- Keep broad root dependency folders out of the VSIX.

## Test Plan

- Verified the extension builds successfull (vsix)