### PR TITLE
984 audio countdown option needs to be local instead of project setting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -352,9 +352,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
     initToolPreferences(context);
 
-    // Per-user audio recording preferences (autoRecordOnMicClick,
-    // recordingCountdownSeconds) live in globalState. Initialize before any
-    // provider reads them; the per-workspace migration runs lazily below.
+    // Per-user audio preferences (autoDownloadAudioOnOpen,
+    // autoRecordOnMicClick, recordingCountdownSeconds) live in globalState.
+    // Initialize before any provider reads them; the per-workspace migration
+    // runs lazily below.
     initializeGlobalUserSettings(context);
 
     // Construct the singleton cellId state store (file-backed under

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,10 @@ import { openCodexMigrationTool } from "./codexMigrationTool/codexMigrationTool"
 import { CodexCellEditorProvider } from "./providers/codexCellEditorProvider/codexCellEditorProvider";
 import { checkForUpdatesOnStartup, registerUpdateCommands } from "./utils/updateChecker";
 import { initializeStateStore } from "./stateStore";
+import {
+    initializeGlobalUserSettings,
+    migrateAudioSettingsFromLocalProject,
+} from "./utils/globalUserSettings";
 import { runOnce } from "./utils/oneTimeMigrations";
 import { fileExists } from "./utils/webviewUtils";
 import { checkIfProjectIsInitialized } from "./projectManager/utils/projectUtils";
@@ -348,6 +352,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     initToolPreferences(context);
 
+    // Per-user audio recording preferences (autoRecordOnMicClick,
+    // recordingCountdownSeconds) live in globalState. Initialize before any
+    // provider reads them; the per-workspace migration runs lazily below.
+    initializeGlobalUserSettings(context);
+
     // Construct the singleton cellId state store (file-backed under
     // globalStorageUri). Must run before providers register so that any
     // subsequent initializeStateStore() calls inside providers reuse the
@@ -356,6 +365,21 @@ export async function activate(context: vscode.ExtensionContext) {
         await initializeStateStore(context);
     } catch (e) {
         console.error("[Extension] Failed to initialize cellId state store:", e);
+    }
+
+    // Issue #984: copy legacy per-user audio prefs from the git-synced
+    // localProjectSettings.json into per-user globalState (first project
+    // wins per machine) and strip the keys so they stop syncing.
+    try {
+        const folders = vscode.workspace.workspaceFolders ?? [];
+        for (const folder of folders) {
+            await migrateAudioSettingsFromLocalProject(folder.uri);
+        }
+    } catch (e) {
+        console.warn(
+            "[Extension] Failed to migrate per-user audio settings from local project settings:",
+            e
+        );
     }
 
     // One-shot cleanup of orphaned rows inside the project-accelerate.shared-state-store

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -6182,7 +6182,6 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                             currentMediaFilesStrategy: mediaStrategy,
                             lastMediaFileStrategyRun: mediaStrategy,
                             mediaFileStrategyApplyState: "applied",
-                            autoDownloadAudioOnOpen: false,
                         });
                         debugLog(`Wrote localProjectSettings.json with strategy: ${mediaStrategy} BEFORE cloning`);
                     }

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -383,9 +383,8 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         try {
             const typed = event as any;
             const value = !!typed?.content?.value;
-            const ws = vscode.workspace.getWorkspaceFolder(document.uri);
-            const { setAutoDownloadAudioOnOpen } = await import("../../utils/localProjectSettings");
-            await setAutoDownloadAudioOnOpen(value, ws?.uri);
+            const { setAutoDownloadAudioOnOpen } = await import("../../utils/globalUserSettings");
+            await setAutoDownloadAudioOnOpen(value);
             // Debounce broadcast so rapid toggles coalesce
             pendingAutoDownloadValue = value;
             if (autoDownloadBroadcastTimer) {

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -414,9 +414,8 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         try {
             const typed = event as any;
             const value = !!typed?.content?.value;
-            const ws = vscode.workspace.getWorkspaceFolder(document.uri);
-            const { setAutoRecordOnMicClick } = await import("../../utils/localProjectSettings");
-            await setAutoRecordOnMicClick(value, ws?.uri);
+            const { setAutoRecordOnMicClick } = await import("../../utils/globalUserSettings");
+            await setAutoRecordOnMicClick(value);
             pendingAutoRecordValue = value;
             if (autoRecordBroadcastTimer) {
                 clearTimeout(autoRecordBroadcastTimer);
@@ -449,11 +448,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 Number.isFinite(numeric) && numeric >= 0
                     ? Math.min(Math.round(numeric), 3)
                     : 3;
-            const ws = vscode.workspace.getWorkspaceFolder(document.uri);
             const { setRecordingCountdownSeconds } = await import(
-                "../../utils/localProjectSettings"
+                "../../utils/globalUserSettings"
             );
-            await setRecordingCountdownSeconds(sanitized, ws?.uri);
+            await setRecordingCountdownSeconds(sanitized);
             pendingRecordingCountdownValue = sanitized;
             if (recordingCountdownBroadcastTimer) {
                 clearTimeout(recordingCountdownBroadcastTimer);

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -1133,10 +1133,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
 
             // Also send updated metadata plus project-level flags
             try {
-                const ws = vscode.workspace.getWorkspaceFolder(document.uri);
-                const { getAutoDownloadAudioOnOpen } = await import("../../utils/localProjectSettings");
-                const { getAutoRecordOnMicClick, getRecordingCountdownSeconds } = await import("../../utils/globalUserSettings");
-                const autoFlag = await getAutoDownloadAudioOnOpen(ws?.uri);
+                const { getAutoDownloadAudioOnOpen, getAutoRecordOnMicClick, getRecordingCountdownSeconds } = await import("../../utils/globalUserSettings");
+                const autoFlag = getAutoDownloadAudioOnOpen();
                 const autoRecordFlag = getAutoRecordOnMicClick();
                 const countdownSeconds = getRecordingCountdownSeconds();
                 this.postMessageToWebview(webviewPanel, {

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -1134,10 +1134,11 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
             // Also send updated metadata plus project-level flags
             try {
                 const ws = vscode.workspace.getWorkspaceFolder(document.uri);
-                const { getAutoDownloadAudioOnOpen, getAutoRecordOnMicClick, getRecordingCountdownSeconds } = await import("../../utils/localProjectSettings");
+                const { getAutoDownloadAudioOnOpen } = await import("../../utils/localProjectSettings");
+                const { getAutoRecordOnMicClick, getRecordingCountdownSeconds } = await import("../../utils/globalUserSettings");
                 const autoFlag = await getAutoDownloadAudioOnOpen(ws?.uri);
-                const autoRecordFlag = await getAutoRecordOnMicClick(ws?.uri);
-                const countdownSeconds = await getRecordingCountdownSeconds(ws?.uri);
+                const autoRecordFlag = getAutoRecordOnMicClick();
+                const countdownSeconds = getRecordingCountdownSeconds();
                 this.postMessageToWebview(webviewPanel, {
                     type: "providerUpdatesNotebookMetadataForWebview",
                     content: { ...notebookData.metadata, autoDownloadAudioOnOpen: !!autoFlag, autoRecordOnMicClick: !!autoRecordFlag, recordingCountdownSeconds: countdownSeconds },

--- a/src/providers/codexCellEditorProvider/codexDocument.ts
+++ b/src/providers/codexCellEditorProvider/codexDocument.ts
@@ -1438,8 +1438,8 @@ export class CodexCellDocument implements vscode.CustomDocument {
         const currentTimestamp = Date.now();
 
         // Track which fields are editable (exclude system fields like id, sourceFsPath, etc.)
-        // Note: autoDownloadAudioOnOpen is excluded as it's a project-level setting stored in localProjectSettings.json,
-        // not a file-level metadata field
+        // Note: autoDownloadAudioOnOpen is excluded as it's a per-user setting stored in
+        // globalState (see src/utils/globalUserSettings.ts), not a file-level metadata field
         const editableFields = [
             "videoUrl",
             "textDirection",

--- a/src/utils/globalUserSettings.ts
+++ b/src/utils/globalUserSettings.ts
@@ -1,0 +1,192 @@
+import * as vscode from "vscode";
+
+/**
+ * Per-user, per-machine settings stored in the extension's `globalState`.
+ *
+ * These keys used to live in `.project/localProjectSettings.json` (which is
+ * git-synced and shared across teammates) but they're user preferences, not
+ * project preferences. See issue #984.
+ */
+
+const DEBUG = false;
+const debug = DEBUG
+    ? (...args: unknown[]) => console.log("[globalUserSettings]", ...args)
+    : () => { };
+
+const AUTO_RECORD_ON_MIC_CLICK_KEY = "codex.audio.autoRecordOnMicClick";
+const RECORDING_COUNTDOWN_SECONDS_KEY = "codex.audio.recordingCountdownSeconds";
+
+const DEFAULT_AUTO_RECORD_ON_MIC_CLICK = false;
+const DEFAULT_RECORDING_COUNTDOWN_SECONDS = 3;
+const MAX_RECORDING_COUNTDOWN_SECONDS = 3;
+
+let extensionContext: vscode.ExtensionContext | undefined;
+
+/**
+ * Wires the extension context. Must be called once during activation before
+ * any getter/setter is invoked.
+ */
+export function initializeGlobalUserSettings(context: vscode.ExtensionContext): void {
+    extensionContext = context;
+}
+
+function requireContext(callerName: string): vscode.ExtensionContext {
+    if (!extensionContext) {
+        throw new Error(
+            `[globalUserSettings] ${callerName} called before initializeGlobalUserSettings(context).`
+        );
+    }
+    return extensionContext;
+}
+
+function sanitizeCountdownSeconds(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        return DEFAULT_RECORDING_COUNTDOWN_SECONDS;
+    }
+    return Math.min(Math.round(value), MAX_RECORDING_COUNTDOWN_SECONDS);
+}
+
+export function getAutoRecordOnMicClick(): boolean {
+    if (!extensionContext) {
+        return DEFAULT_AUTO_RECORD_ON_MIC_CLICK;
+    }
+    return !!extensionContext.globalState.get<boolean>(
+        AUTO_RECORD_ON_MIC_CLICK_KEY,
+        DEFAULT_AUTO_RECORD_ON_MIC_CLICK
+    );
+}
+
+export async function setAutoRecordOnMicClick(value: boolean): Promise<void> {
+    const ctx = requireContext("setAutoRecordOnMicClick");
+    await ctx.globalState.update(AUTO_RECORD_ON_MIC_CLICK_KEY, !!value);
+}
+
+export function getRecordingCountdownSeconds(): number {
+    if (!extensionContext) {
+        return DEFAULT_RECORDING_COUNTDOWN_SECONDS;
+    }
+    const raw = extensionContext.globalState.get<number>(
+        RECORDING_COUNTDOWN_SECONDS_KEY,
+        DEFAULT_RECORDING_COUNTDOWN_SECONDS
+    );
+    return sanitizeCountdownSeconds(raw);
+}
+
+export async function setRecordingCountdownSeconds(value: number): Promise<void> {
+    const ctx = requireContext("setRecordingCountdownSeconds");
+    const sanitized = sanitizeCountdownSeconds(value);
+    await ctx.globalState.update(RECORDING_COUNTDOWN_SECONDS_KEY, sanitized);
+}
+
+/**
+ * One-time-per-project migration: if `.project/localProjectSettings.json`
+ * still holds the legacy `autoRecordOnMicClick` or `recordingCountdownSeconds`
+ * keys, copy them into the per-user `globalState` (only when globalState
+ * has no value yet, so the first project opened "wins"), then strip the
+ * keys from the JSON so they stop syncing via git.
+ *
+ * Idempotent: a no-op once the keys have been removed.
+ */
+export async function migrateAudioSettingsFromLocalProject(
+    workspaceFolderUri?: vscode.Uri
+): Promise<void> {
+    if (!extensionContext) {
+        debug("Skipping migration: globalUserSettings not initialized yet.");
+        return;
+    }
+
+    const workspaceFolder =
+        workspaceFolderUri || vscode.workspace.workspaceFolders?.[0]?.uri;
+    if (!workspaceFolder) {
+        return;
+    }
+
+    const settingsPath = vscode.Uri.joinPath(
+        workspaceFolder,
+        ".project",
+        "localProjectSettings.json"
+    );
+
+    let raw: Record<string, unknown>;
+    try {
+        const fileContent = await vscode.workspace.fs.readFile(settingsPath);
+        raw = JSON.parse(Buffer.from(fileContent).toString("utf-8")) ?? {};
+    } catch {
+        return;
+    }
+
+    const hasAutoRecord = Object.prototype.hasOwnProperty.call(
+        raw,
+        "autoRecordOnMicClick"
+    );
+    const hasCountdown = Object.prototype.hasOwnProperty.call(
+        raw,
+        "recordingCountdownSeconds"
+    );
+    if (!hasAutoRecord && !hasCountdown) {
+        return;
+    }
+
+    if (hasAutoRecord) {
+        const existingAutoRecord =
+            extensionContext.globalState.get<boolean | undefined>(
+                AUTO_RECORD_ON_MIC_CLICK_KEY,
+                undefined
+            );
+        if (existingAutoRecord === undefined) {
+            await extensionContext.globalState.update(
+                AUTO_RECORD_ON_MIC_CLICK_KEY,
+                !!raw["autoRecordOnMicClick"]
+            );
+            debug(
+                "Migrated autoRecordOnMicClick from local project settings:",
+                raw["autoRecordOnMicClick"]
+            );
+        }
+        delete raw["autoRecordOnMicClick"];
+    }
+
+    if (hasCountdown) {
+        const existingCountdown =
+            extensionContext.globalState.get<number | undefined>(
+                RECORDING_COUNTDOWN_SECONDS_KEY,
+                undefined
+            );
+        if (existingCountdown === undefined) {
+            const sanitized = sanitizeCountdownSeconds(
+                raw["recordingCountdownSeconds"]
+            );
+            await extensionContext.globalState.update(
+                RECORDING_COUNTDOWN_SECONDS_KEY,
+                sanitized
+            );
+            debug(
+                "Migrated recordingCountdownSeconds from local project settings:",
+                sanitized
+            );
+        }
+        delete raw["recordingCountdownSeconds"];
+    }
+
+    try {
+        const content = JSON.stringify(raw, null, 2);
+        await vscode.workspace.fs.writeFile(
+            settingsPath,
+            Buffer.from(content, "utf-8")
+        );
+        debug("Stripped per-user audio keys from local project settings.");
+    } catch (err) {
+        console.warn(
+            "[globalUserSettings] Failed to strip per-user audio keys from localProjectSettings.json:",
+            err
+        );
+    }
+}
+
+/**
+ * Test-only: clear the cached context so each test can construct its own
+ * fake ExtensionContext. Production code does not call this.
+ */
+export function _resetGlobalUserSettingsForTests(): void {
+    extensionContext = undefined;
+}

--- a/src/utils/globalUserSettings.ts
+++ b/src/utils/globalUserSettings.ts
@@ -13,9 +13,11 @@ const debug = DEBUG
     ? (...args: unknown[]) => console.log("[globalUserSettings]", ...args)
     : () => { };
 
+const AUTO_DOWNLOAD_AUDIO_ON_OPEN_KEY = "codex.audio.autoDownloadAudioOnOpen";
 const AUTO_RECORD_ON_MIC_CLICK_KEY = "codex.audio.autoRecordOnMicClick";
 const RECORDING_COUNTDOWN_SECONDS_KEY = "codex.audio.recordingCountdownSeconds";
 
+const DEFAULT_AUTO_DOWNLOAD_AUDIO_ON_OPEN = false;
 const DEFAULT_AUTO_RECORD_ON_MIC_CLICK = false;
 const DEFAULT_RECORDING_COUNTDOWN_SECONDS = 3;
 const MAX_RECORDING_COUNTDOWN_SECONDS = 3;
@@ -44,6 +46,21 @@ function sanitizeCountdownSeconds(value: unknown): number {
         return DEFAULT_RECORDING_COUNTDOWN_SECONDS;
     }
     return Math.min(Math.round(value), MAX_RECORDING_COUNTDOWN_SECONDS);
+}
+
+export function getAutoDownloadAudioOnOpen(): boolean {
+    if (!extensionContext) {
+        return DEFAULT_AUTO_DOWNLOAD_AUDIO_ON_OPEN;
+    }
+    return !!extensionContext.globalState.get<boolean>(
+        AUTO_DOWNLOAD_AUDIO_ON_OPEN_KEY,
+        DEFAULT_AUTO_DOWNLOAD_AUDIO_ON_OPEN
+    );
+}
+
+export async function setAutoDownloadAudioOnOpen(value: boolean): Promise<void> {
+    const ctx = requireContext("setAutoDownloadAudioOnOpen");
+    await ctx.globalState.update(AUTO_DOWNLOAD_AUDIO_ON_OPEN_KEY, !!value);
 }
 
 export function getAutoRecordOnMicClick(): boolean {
@@ -80,10 +97,11 @@ export async function setRecordingCountdownSeconds(value: number): Promise<void>
 
 /**
  * One-time-per-project migration: if `.project/localProjectSettings.json`
- * still holds the legacy `autoRecordOnMicClick` or `recordingCountdownSeconds`
- * keys, copy them into the per-user `globalState` (only when globalState
- * has no value yet, so the first project opened "wins"), then strip the
- * keys from the JSON so they stop syncing via git.
+ * still holds the legacy `autoDownloadAudioOnOpen`, `autoRecordOnMicClick`,
+ * or `recordingCountdownSeconds` keys, copy them into the per-user
+ * `globalState` (only when globalState has no value yet, so the first
+ * project opened "wins"), then strip the keys from the JSON so they stop
+ * syncing via git.
  *
  * Idempotent: a no-op once the keys have been removed.
  */
@@ -115,6 +133,10 @@ export async function migrateAudioSettingsFromLocalProject(
         return;
     }
 
+    const hasAutoDownload = Object.prototype.hasOwnProperty.call(
+        raw,
+        "autoDownloadAudioOnOpen"
+    );
     const hasAutoRecord = Object.prototype.hasOwnProperty.call(
         raw,
         "autoRecordOnMicClick"
@@ -123,8 +145,27 @@ export async function migrateAudioSettingsFromLocalProject(
         raw,
         "recordingCountdownSeconds"
     );
-    if (!hasAutoRecord && !hasCountdown) {
+    if (!hasAutoDownload && !hasAutoRecord && !hasCountdown) {
         return;
+    }
+
+    if (hasAutoDownload) {
+        const existingAutoDownload =
+            extensionContext.globalState.get<boolean | undefined>(
+                AUTO_DOWNLOAD_AUDIO_ON_OPEN_KEY,
+                undefined
+            );
+        if (existingAutoDownload === undefined) {
+            await extensionContext.globalState.update(
+                AUTO_DOWNLOAD_AUDIO_ON_OPEN_KEY,
+                !!raw["autoDownloadAudioOnOpen"]
+            );
+            debug(
+                "Migrated autoDownloadAudioOnOpen from local project settings:",
+                raw["autoDownloadAudioOnOpen"]
+            );
+        }
+        delete raw["autoDownloadAudioOnOpen"];
     }
 
     if (hasAutoRecord) {

--- a/src/utils/localProjectSettings.ts
+++ b/src/utils/localProjectSettings.ts
@@ -59,15 +59,6 @@ export interface LocalProjectSettings {
     keepFilesOnStreamAndSave?: boolean;
     /** When true, the editor will download/stream audio as soon as a cell opens */
     autoDownloadAudioOnOpen?: boolean;
-    /** When true, clicking the microphone icon in the cell list auto-starts recording */
-    autoRecordOnMicClick?: boolean;
-    /**
-     * Number of seconds to count down before recording begins after the mic
-     * button is clicked. 0 disables the visible countdown but still enforces
-     * a 250ms minimum click-debounce so an accidental double click cannot
-     * immediately start a recording. Default: 3.
-     */
-    recordingCountdownSeconds?: number;
     /** When true, AI Metrics view shows detailed technical metrics instead of simple mode */
     detailedAIMetrics?: boolean;
     /** Track in-progress update for restart-safe cleanup */
@@ -222,8 +213,6 @@ async function writeLocalProjectSettingsInternal(
             keepFilesOnStreamAndSave: settings.keepFilesOnStreamAndSave,
             forceCloseAfterSuccessfulSwap: settings.forceCloseAfterSuccessfulSwap,
             autoDownloadAudioOnOpen: settings.autoDownloadAudioOnOpen ?? false,
-            autoRecordOnMicClick: settings.autoRecordOnMicClick ?? false,
-            recordingCountdownSeconds: settings.recordingCountdownSeconds ?? 3,
             detailedAIMetrics: settings.detailedAIMetrics,
             lfsSourceRemoteUrl: settings.lfsSourceRemoteUrl,
             updateState: settings.updateState,
@@ -372,8 +361,6 @@ export async function ensureLocalProjectSettingsExists(
         changesApplied: true,
         mediaFileStrategyApplyState: "applied",
         autoDownloadAudioOnOpen: false,
-        autoRecordOnMicClick: false,
-        recordingCountdownSeconds: 3,
         mediaFileStrategySwitchStarted: false,
         autoSyncEnabled: true,
         syncDelayMinutes: 5,
@@ -393,48 +380,6 @@ export async function setAutoDownloadAudioOnOpen(
 ): Promise<void> {
     const settings = await readLocalProjectSettings(workspaceFolderUri);
     settings.autoDownloadAudioOnOpen = !!value;
-    await writeLocalProjectSettings(settings, workspaceFolderUri);
-}
-
-export async function getAutoRecordOnMicClick(workspaceFolderUri?: vscode.Uri): Promise<boolean> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    return !!settings.autoRecordOnMicClick;
-}
-
-export async function setAutoRecordOnMicClick(
-    value: boolean,
-    workspaceFolderUri?: vscode.Uri
-): Promise<void> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    settings.autoRecordOnMicClick = !!value;
-    await writeLocalProjectSettings(settings, workspaceFolderUri);
-}
-
-/**
- * Returns the configured countdown duration (in seconds) before a recording
- * begins. Falls back to 3s when unset. Always returns a non-negative number.
- */
-export async function getRecordingCountdownSeconds(
-    workspaceFolderUri?: vscode.Uri
-): Promise<number> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    const raw = settings.recordingCountdownSeconds;
-    if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) {
-        return 3;
-    }
-    return raw;
-}
-
-export async function setRecordingCountdownSeconds(
-    value: number,
-    workspaceFolderUri?: vscode.Uri
-): Promise<void> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    const sanitized =
-        typeof value === "number" && Number.isFinite(value) && value >= 0
-            ? Math.min(Math.round(value), 3)
-            : 3;
-    settings.recordingCountdownSeconds = sanitized;
     await writeLocalProjectSettings(settings, workspaceFolderUri);
 }
 

--- a/src/utils/localProjectSettings.ts
+++ b/src/utils/localProjectSettings.ts
@@ -57,8 +57,6 @@ export interface LocalProjectSettings {
      * Cleared after the switch is applied on project open.
      */
     keepFilesOnStreamAndSave?: boolean;
-    /** When true, the editor will download/stream audio as soon as a cell opens */
-    autoDownloadAudioOnOpen?: boolean;
     /** When true, AI Metrics view shows detailed technical metrics instead of simple mode */
     detailedAIMetrics?: boolean;
     /** Track in-progress update for restart-safe cleanup */
@@ -212,7 +210,6 @@ async function writeLocalProjectSettingsInternal(
             mediaFileStrategySwitchStarted: settings.mediaFileStrategySwitchStarted ?? false,
             keepFilesOnStreamAndSave: settings.keepFilesOnStreamAndSave,
             forceCloseAfterSuccessfulSwap: settings.forceCloseAfterSuccessfulSwap,
-            autoDownloadAudioOnOpen: settings.autoDownloadAudioOnOpen ?? false,
             detailedAIMetrics: settings.detailedAIMetrics,
             lfsSourceRemoteUrl: settings.lfsSourceRemoteUrl,
             updateState: settings.updateState,
@@ -360,27 +357,12 @@ export async function ensureLocalProjectSettingsExists(
         lastMediaFileStrategyRun: "auto-download",
         changesApplied: true,
         mediaFileStrategyApplyState: "applied",
-        autoDownloadAudioOnOpen: false,
         mediaFileStrategySwitchStarted: false,
         autoSyncEnabled: true,
         syncDelayMinutes: 5,
         ...(defaults || {}),
     };
     await writeLocalProjectSettings(def, workspaceFolderUri);
-}
-
-export async function getAutoDownloadAudioOnOpen(workspaceFolderUri?: vscode.Uri): Promise<boolean> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    return !!settings.autoDownloadAudioOnOpen;
-}
-
-export async function setAutoDownloadAudioOnOpen(
-    value: boolean,
-    workspaceFolderUri?: vscode.Uri
-): Promise<void> {
-    const settings = await readLocalProjectSettings(workspaceFolderUri);
-    settings.autoDownloadAudioOnOpen = !!value;
-    await writeLocalProjectSettings(settings, workspaceFolderUri);
 }
 
 /**


### PR DESCRIPTION
Recording Countdown Seconds, Auto Record On Mic Click, and also Auto Download Audio on Open are all per-project-per-user now. 

Matt and I have tested all of these things and found them to be per-project-per-user, across syncs. 