### PR TITLE
fix(audio): replace "unknown" transcription badge with project language

### DIFF
--- a/.cursor/rules/audio-cue-for-questions.mdc
+++ b/.cursor/rules/audio-cue-for-questions.mdc
@@ -1,0 +1,31 @@
+---
+description: Play an audio cue while AskQuestion's orange UI is on screen
+alwaysApply: true
+---
+
+# Audio cue before AskQuestion
+
+The user has a hook-based setup that plays an audio loop while a multiple-choice question is waiting for their input. `AskQuestion` is invisible to Cursor hooks, so the loop must be started **explicitly** by you.
+
+## Rule
+
+**Immediately before every `AskQuestion` tool call**, run this shell command:
+
+```bash
+bash ~/.cursor/hooks/before-question.sh
+```
+
+Place it in the same response as the `AskQuestion` call, with no other tool calls between the two. The script is fast, non-blocking after a brief startup, and self-cleans via a 10-minute safety timeout.
+
+## When to skip
+
+- The script does not exist (e.g., on a different machine). If `~/.cursor/hooks/before-question.sh` is missing, just call `AskQuestion` normally.
+- The user has explicitly said to skip the audio cue in this session.
+
+## What stops it
+
+You do not need to stop the sound — it's killed automatically by:
+
+- The next `preToolUse` (any tool you call afterwards)
+- `beforeSubmitPrompt` when the user types a message
+- A "Stop" button in the macOS dialog that pops alongside the sound

--- a/docs/asr-proxy-endpoint.md
+++ b/docs/asr-proxy-endpoint.md
@@ -44,6 +44,7 @@ Authorization: Bearer <token>  (optional if token in query)
         2. Use the predicted ISO 639-3 code as the ASR adapter.
         3. Return the detected code in the response so the client can surface it to the user.
     - Omitted: the proxy may default to English (current behavior) or run LID — the client treats either as best-effort.
+- `phonetic` (optional): When set to a truthy value (e.g. `1`, `true`), the proxy should also return a phonetic (IPA) transcription **alongside** the orthographic text. Recommended approach: run a phoneme recognition model (e.g. `facebook/wav2vec2-lv-60-espeak-cv-ft`) over the same audio in addition to the regular ASR pass, and populate the `phonetic` field in the response. If the proxy can't honor the request, it should still return the orthographic text and simply omit `phonetic` from the JSON.
 
 ### Request Body
 
@@ -62,6 +63,10 @@ curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT
 # Server-side language identification (LID)
 curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT_TOKEN&lang=auto" \
   -F "file=@audio.wav"
+
+# Orthographic + phonetic (IPA)
+curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT_TOKEN&lang=swh&phonetic=1" \
+  -F "file=@audio.wav"
 ```
 
 ## Response Protocol
@@ -73,11 +78,14 @@ curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT
   "text": "This is the transcribed text",
   "duration_s": 4.94,
   "inference_s": 1.72,
-  "language": "swh"
+  "language": "swh",
+  "phonetic": "ðɪs ɪz ðə trænskraɪbd tɛkst"
 }
 ```
 
 The `language` field is **required when the client sent `lang=auto`** so it can show the detected language to the user. It is optional otherwise.
+
+The `phonetic` field is **populated when the client sent `phonetic=1`** and the proxy was able to produce an IPA transcription. If the proxy doesn't support phoneme recognition, it should omit the field rather than failing the request.
 
 ### Error Response (4xx/5xx)
 

--- a/docs/asr-proxy-endpoint.md
+++ b/docs/asr-proxy-endpoint.md
@@ -37,6 +37,13 @@ Authorization: Bearer <token>  (optional if token in query)
 
 - `source` (required): `"codex"` or `"langquest"`
 - `token` (optional): JWT token if not in Authorization header
+- `lang` (optional): Language hint for the upstream ASR model.
+    - Concrete value: an **ISO 639-3** code (e.g. `eng`, `fra`, `swh`). The proxy should pass this through to the MMS adapter loader (`set_target_lang` / `load_adapter`).
+    - Special value `auto`: requests **server-side language identification (LID)** before transcription. The proxy should:
+        1. Run an MMS LID model (e.g. `facebook/mms-lid-1024` or `mms-lid-4017`) on the audio.
+        2. Use the predicted ISO 639-3 code as the ASR adapter.
+        3. Return the detected code in the response so the client can surface it to the user.
+    - Omitted: the proxy may default to English (current behavior) or run LID — the client treats either as best-effort.
 
 ### Request Body
 
@@ -48,7 +55,12 @@ Authorization: Bearer <token>  (optional if token in query)
 ### Example Request
 
 ```bash
-curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT_TOKEN" \
+# Explicit language (Swahili)
+curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT_TOKEN&lang=swh" \
+  -F "file=@audio.wav"
+
+# Server-side language identification (LID)
+curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT_TOKEN&lang=auto" \
   -F "file=@audio.wav"
 ```
 
@@ -60,9 +72,12 @@ curl -X POST "http://localhost:8000/api/v1/asr/transcribe?source=codex&token=JWT
 {
   "text": "This is the transcribed text",
   "duration_s": 4.94,
-  "inference_s": 1.72
+  "inference_s": 1.72,
+  "language": "swh"
 }
 ```
+
+The `language` field is **required when the client sent `lang=auto`** so it can show the detected language to the user. It is optional otherwise.
 
 ### Error Response (4xx/5xx)
 

--- a/package.json
+++ b/package.json
@@ -895,6 +895,20 @@
                         "default": "eng",
                         "description": "Language code for transcription. MMS requires ISO-639-3 (e.g., eng, fra, spa). 2-letter codes will be mapped where possible."
                     },
+                    "codex-editor-extension.asrLanguageMode": {
+                        "title": "ASR Language Mode",
+                        "type": "string",
+                        "enum": [
+                            "project",
+                            "auto"
+                        ],
+                        "enumDescriptions": [
+                            "Use the project's source/target language (recommended).",
+                            "Let the ASR service detect the language (sends language=auto, requires server-side LID support)."
+                        ],
+                        "default": "project",
+                        "description": "How the transcription button should hint the language to the ASR service. Toggleable from the Transcribe button in the cell editor."
+                    },
                     "codex-editor-extension.asrPhonetic": {
                         "title": "Return Phonetic (IPA)",
                         "type": "boolean",

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -493,6 +493,9 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             // ASR proxy: "project" → the resolved ISO 639-3 code, "auto" →
             // the literal string "auto" (server-side LID).
             const languageMode = config.get<"project" | "auto">("asrLanguageMode", "project");
+            // When enabled, the webview asks the proxy to also return a
+            // phonetic (IPA) transcription alongside the orthographic text.
+            const phonetic = config.get<boolean>("asrPhonetic", false);
 
             // Try to get authenticated endpoint from FrontierAPI
             try {
@@ -582,10 +585,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 console.debug("[getAsrConfig] Could not resolve project language:", langError);
             }
 
-            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}, language=${language?.name ?? "(none)"}, mode=${languageMode}`);
+            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}, language=${language?.name ?? "(none)"}, mode=${languageMode}, phonetic=${phonetic}`);
             safePostMessageToPanel(webviewPanel, {
                 type: "asrConfig",
-                content: { endpoint, authToken, language, languageMode }
+                content: { endpoint, authToken, language, languageMode, phonetic }
             });
         } catch (error) {
             console.error("Error sending ASR config:", error);
@@ -597,6 +600,7 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                     endpoint: fallbackEndpoint,
                     authToken: undefined,
                     languageMode: "project",
+                    phonetic: false,
                 }
             });
         }
@@ -619,6 +623,26 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             await messageHandlers.getAsrConfig(ctx);
         } catch (err) {
             console.error("[setAsrLanguageMode] Failed to persist mode:", err);
+        }
+    },
+
+    setAsrPhonetic: async (ctx) => {
+        const typedEvent = ctx.event as Extract<
+            EditorPostMessages,
+            { command: "setAsrPhonetic"; }
+        >;
+        const enabled = !!typedEvent.content?.enabled;
+        try {
+            const config = vscode.workspace.getConfiguration("codex-editor-extension");
+            await config.update(
+                "asrPhonetic",
+                enabled,
+                vscode.ConfigurationTarget.Workspace
+            );
+            // Re-send config so the webview reflects the new value.
+            await messageHandlers.getAsrConfig(ctx);
+        } catch (err) {
+            console.error("[setAsrPhonetic] Failed to persist value:", err);
         }
     },
 

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -489,6 +489,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
 
             let authToken: string | undefined;
             let language: { code: string; name: string; } | undefined;
+            // languageMode controls which value the webview will send to the
+            // ASR proxy: "project" → the resolved ISO 639-3 code, "auto" →
+            // the literal string "auto" (server-side LID).
+            const languageMode = config.get<"project" | "auto">("asrLanguageMode", "project");
 
             // Try to get authenticated endpoint from FrontierAPI
             try {
@@ -553,7 +557,18 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                     name?: { [k: string]: string; };
                 }>(isSourceDoc ? "sourceLanguage" : "targetLanguage");
                 if (lang) {
-                    const code = lang.iso1 || lang.tag?.split("-")[0] || lang.iso2t || "";
+                    // Prefer 3-letter ISO 639-3 codes because the ASR proxy
+                    // backend (MMS) is keyed by ISO 639-3 adapters. Fall back
+                    // to the 2-letter form only as a last resort, even though
+                    // it won't directly match an MMS adapter — at least we
+                    // surface *something* and the proxy can decide what to do.
+                    const tagPart = lang.tag?.split("-")[0];
+                    const code =
+                        (tagPart && tagPart.length === 3 ? tagPart : undefined) ||
+                        lang.iso2t ||
+                        (tagPart && tagPart.length === 2 ? tagPart : undefined) ||
+                        lang.iso1 ||
+                        "";
                     const friendlyName =
                         lang.refName ||
                         lang.name?.["en"] ||
@@ -567,10 +582,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 console.debug("[getAsrConfig] Could not resolve project language:", langError);
             }
 
-            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}, language=${language?.name ?? "(none)"}`);
+            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}, language=${language?.name ?? "(none)"}, mode=${languageMode}`);
             safePostMessageToPanel(webviewPanel, {
                 type: "asrConfig",
-                content: { endpoint, authToken, language }
+                content: { endpoint, authToken, language, languageMode }
             });
         } catch (error) {
             console.error("Error sending ASR config:", error);
@@ -581,8 +596,29 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 content: {
                     endpoint: fallbackEndpoint,
                     authToken: undefined,
+                    languageMode: "project",
                 }
             });
+        }
+    },
+
+    setAsrLanguageMode: async (ctx) => {
+        const typedEvent = ctx.event as Extract<
+            EditorPostMessages,
+            { command: "setAsrLanguageMode"; }
+        >;
+        const mode = typedEvent.content?.mode === "auto" ? "auto" : "project";
+        try {
+            const config = vscode.workspace.getConfiguration("codex-editor-extension");
+            await config.update(
+                "asrLanguageMode",
+                mode,
+                vscode.ConfigurationTarget.Workspace
+            );
+            // Re-send config so the webview picks up the new mode immediately.
+            await messageHandlers.getAsrConfig(ctx);
+        } catch (err) {
+            console.error("[setAsrLanguageMode] Failed to persist mode:", err);
         }
     },
 

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -482,12 +482,13 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             console.warn("Failed to set recordingCountdownSeconds", e);
         }
     },
-    getAsrConfig: async ({ webviewPanel }) => {
+    getAsrConfig: async ({ webviewPanel, document }) => {
         try {
             const config = vscode.workspace.getConfiguration("codex-editor-extension");
             let endpoint = config.get<string>("asrEndpoint", "http://localhost:8000/api/v1/asr/transcribe");
 
             let authToken: string | undefined;
+            let language: { code: string; name: string; } | undefined;
 
             // Try to get authenticated endpoint from FrontierAPI
             try {
@@ -539,10 +540,37 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 console.error(`[getAsrConfig] This will cause transcription to fail. Please check authentication status.`);
             }
 
-            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}`);
+            // Resolve language for this editor from project metadata.
+            // Source-file editors transcribe in the project's source language; codex (target) editors in the target language.
+            try {
+                const isSourceDoc = document.uri.fsPath.endsWith(".source");
+                const projectConfig = vscode.workspace.getConfiguration("codex-project-manager");
+                const lang = projectConfig.get<{
+                    tag?: string;
+                    refName?: string;
+                    iso1?: string;
+                    iso2t?: string;
+                    name?: { [k: string]: string; };
+                }>(isSourceDoc ? "sourceLanguage" : "targetLanguage");
+                if (lang) {
+                    const code = lang.iso1 || lang.tag?.split("-")[0] || lang.iso2t || "";
+                    const friendlyName =
+                        lang.refName ||
+                        lang.name?.["en"] ||
+                        (lang.name ? Object.values(lang.name)[0] : undefined) ||
+                        code;
+                    if (code && friendlyName) {
+                        language = { code, name: friendlyName };
+                    }
+                }
+            } catch (langError) {
+                console.debug("[getAsrConfig] Could not resolve project language:", langError);
+            }
+
+            debug(`[getAsrConfig] Sending config: endpoint=${endpoint}, hasToken=${!!authToken}, language=${language?.name ?? "(none)"}`);
             safePostMessageToPanel(webviewPanel, {
                 type: "asrConfig",
-                content: { endpoint, authToken }
+                content: { endpoint, authToken, language }
             });
         } catch (error) {
             console.error("Error sending ASR config:", error);
@@ -552,11 +580,7 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 type: "asrConfig",
                 content: {
                     endpoint: fallbackEndpoint,
-                    provider: "mms",
-                    model: "facebook/mms-1b-all",
-                    language: "eng",
-                    phonetic: false,
-                    authToken: undefined
+                    authToken: undefined,
                 }
             });
         }
@@ -577,7 +601,8 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 ...(attachment || {}),
                 transcription: {
                     content: transcribedText,
-                    language: language || "unknown",
+                    // Friendly language name (e.g. "English"); empty string when unknown.
+                    language: language || "",
                     timestamp: Date.now(),
                 },
                 updatedAt: Date.now(),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -581,6 +581,10 @@ export type EditorPostMessages =
     }
     | { command: "getAsrConfig"; }
     | {
+        command: "setAsrLanguageMode";
+        content: { mode: "project" | "auto"; };
+    }
+    | {
         command: "mergeCellWithPrevious";
         content: {
             currentCellId: string;
@@ -2150,7 +2154,20 @@ type EditorReceiveMessages =
         milestoneIndex?: number;
         subsectionIndex?: number;
     }
-    | { type: "asrConfig"; content: { endpoint: string; authToken?: string; language?: { code: string; name: string; }; }; }
+    | {
+        type: "asrConfig";
+        content: {
+            endpoint: string;
+            authToken?: string;
+            language?: { code: string; name: string; };
+            /**
+             * How the webview should hint the language to the ASR proxy:
+             *  - "project" → send the resolved ISO 639-3 code (or omit if unresolved)
+             *  - "auto"    → send `lang=auto` so the proxy can run LID first
+             */
+            languageMode?: "project" | "auto";
+        };
+    }
     | { type: "startBatchTranscription"; content: { count: number; }; }
     | {
         type: "providerConfirmsBacktranslationSet";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -585,6 +585,10 @@ export type EditorPostMessages =
         content: { mode: "project" | "auto"; };
     }
     | {
+        command: "setAsrPhonetic";
+        content: { enabled: boolean; };
+    }
+    | {
         command: "mergeCellWithPrevious";
         content: {
             currentCellId: string;
@@ -2166,6 +2170,12 @@ type EditorReceiveMessages =
              *  - "auto"    → send `lang=auto` so the proxy can run LID first
              */
             languageMode?: "project" | "auto";
+            /**
+             * When true, the webview should ask the ASR proxy to also return a
+             * phonetic (IPA) transcription alongside the orthographic text.
+             * Surfaced via `?phonetic=1` and persists as a workspace setting.
+             */
+            phonetic?: boolean;
         };
     }
     | { type: "startBatchTranscription"; content: { count: number; }; }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2150,7 +2150,7 @@ type EditorReceiveMessages =
         milestoneIndex?: number;
         subsectionIndex?: number;
     }
-    | { type: "asrConfig"; content: { endpoint: string; authToken?: string; }; }
+    | { type: "asrConfig"; content: { endpoint: string; authToken?: string; language?: { code: string; name: string; }; }; }
     | { type: "startBatchTranscription"; content: { count: number; }; }
     | {
         type: "providerConfirmsBacktranslationSet";

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -139,11 +139,22 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                             >
                                 {transcription.content}
                             </p>
-                            {transcription.language && (
-                                <Badge variant="secondary" className="text-xs">
-                                    {transcription.language}
-                                </Badge>
-                            )}
+                            {(() => {
+                                // `language` is the friendly display name (e.g. "English") resolved from
+                                // the project's source/target language at transcription time. Treat empty/
+                                // missing values and the legacy "unknown" sentinel as no-known-language so
+                                // the user can tell the transcription happened without a language hint.
+                                const lang = transcription.language?.trim();
+                                const hasKnownLanguage = !!lang && lang.toLowerCase() !== "unknown";
+                                return (
+                                    <Badge
+                                        variant="secondary"
+                                        className={hasKnownLanguage ? "text-xs" : "text-[10px]"}
+                                    >
+                                        {hasKnownLanguage ? lang : "Transcription Language Unknown"}
+                                    </Badge>
+                                );
+                            })()}
                         </div>
                         <Button
                             onClick={onInsertTranscription}

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -2,7 +2,16 @@ import React, { useEffect, useState } from "react";
 import { CustomWaveformCanvas } from "./CustomWaveformCanvas.tsx";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
-import { MessageCircle, Copy, Loader2, Trash2, History, Mic } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "../components/ui/dropdown-menu";
+import { MessageCircle, Copy, Loader2, Trash2, History, Mic, ChevronDown } from "lucide-react";
 import type { ValidationStatusIconProps } from "./AudioValidationStatusIcon.tsx";
 import { AudioValidationBadge } from "./AudioValidationBadge.tsx";
 import type { AudioValidationPopoverProps } from "./AudioValidationBadge.tsx";
@@ -29,6 +38,11 @@ interface AudioWaveformWithTranscriptionProps {
     targetDurationSeconds?: number | null;
     audioDurationSeconds?: number | null;
     targetDuration?: number | null; // Target duration (in seconds) derived from cell timestamps.
+    // ASR language hint shown next to the Transcribe button and toggleable
+    // between the project language and server-side auto-detect (LID).
+    asrLanguageName?: string; // friendly name of the project's language (e.g. "Swahili"). Falls back to "Auto Detect".
+    asrLanguageMode?: "project" | "auto";
+    onChangeAsrLanguageMode?: (mode: "project" | "auto") => void;
 }
 
 const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionProps> = ({
@@ -49,6 +63,9 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
     audioDurationSeconds,
     targetDuration,
     author,
+    asrLanguageName,
+    asrLanguageMode = "project",
+    onChangeAsrLanguageMode,
 }) => {
     const [audioSrc, setAudioSrc] = useState<string>("");
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
@@ -232,18 +249,75 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
 
             {/* Action buttons at bottom */}
             <div className="flex flex-wrap items-center justify-center gap-2 px-2">
-                {!transcription && !isTranscribing && (
-                    <Button
-                        onClick={onTranscribe}
-                        disabled={disabled || (!audioUrl && !audioBlob)}
-                        variant="outline"
-                        className="h-8 px-2 text-xs text-[var(--vscode-button-background)] border-[var(--vscode-button-background)]/20 hover:bg-[var(--vscode-button-background)]/10"
-                        title="Transcribe Audio"
-                    >
-                        <MessageCircle className="h-3 w-3" />
-                        <span className="ml-1">Transcribe</span>
-                    </Button>
-                )}
+                {!transcription && !isTranscribing && (() => {
+                    const transcribeDisabled = disabled || (!audioUrl && !audioBlob);
+                    const isAuto = asrLanguageMode === "auto";
+                    // The label shows what will actually happen on click — the
+                    // resolved project language name, or "Auto Detect" when
+                    // either the user opted into auto-detect or we couldn't
+                    // resolve a project language to send.
+                    const effectiveLabel =
+                        !isAuto && asrLanguageName ? asrLanguageName : "Auto Detect";
+                    const sharedBtnClass =
+                        "h-8 px-2 text-xs text-[var(--vscode-button-background)] border-[var(--vscode-button-background)]/20 hover:bg-[var(--vscode-button-background)]/10";
+                    return (
+                        <div className="inline-flex items-stretch">
+                            <Button
+                                onClick={onTranscribe}
+                                disabled={transcribeDisabled}
+                                variant="outline"
+                                className={`${sharedBtnClass} rounded-r-none border-r-0`}
+                                title={`Transcribe Audio (${effectiveLabel})`}
+                            >
+                                <MessageCircle className="h-3 w-3" />
+                                <span className="ml-1">Transcribe</span>
+                            </Button>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={transcribeDisabled}
+                                        className={`${sharedBtnClass} rounded-l-none gap-1 pl-2 pr-1.5`}
+                                        title={`Language: ${effectiveLabel}. Click to change.`}
+                                        aria-label={`Change transcription language. Current: ${effectiveLabel}`}
+                                    >
+                                        <span className="max-w-[10ch] truncate">
+                                            {effectiveLabel}
+                                        </span>
+                                        <ChevronDown className="h-3 w-3 opacity-70" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end" className="min-w-[12rem]">
+                                    <DropdownMenuLabel>Transcription language</DropdownMenuLabel>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuRadioGroup
+                                        value={
+                                            !asrLanguageName
+                                                ? "auto"
+                                                : asrLanguageMode
+                                        }
+                                        onValueChange={(v) =>
+                                            onChangeAsrLanguageMode?.(
+                                                v === "auto" ? "auto" : "project"
+                                            )
+                                        }
+                                    >
+                                        <DropdownMenuRadioItem
+                                            value="project"
+                                            disabled={!asrLanguageName}
+                                        >
+                                            {asrLanguageName || "Project language (unset)"}
+                                        </DropdownMenuRadioItem>
+                                        <DropdownMenuRadioItem value="auto">
+                                            Auto Detect
+                                        </DropdownMenuRadioItem>
+                                    </DropdownMenuRadioGroup>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
+                    );
+                })()}
                 <Button
                     variant="outline"
                     size="sm"

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -11,7 +11,19 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu";
-import { MessageCircle, Copy, Loader2, Trash2, History, Mic, ChevronDown } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover";
+import { Switch } from "../components/ui/switch";
+import { Label } from "../components/ui/label";
+import {
+    MessageCircle,
+    Copy,
+    Loader2,
+    Trash2,
+    History,
+    Mic,
+    ChevronDown,
+    Settings,
+} from "lucide-react";
 import type { ValidationStatusIconProps } from "./AudioValidationStatusIcon.tsx";
 import { AudioValidationBadge } from "./AudioValidationBadge.tsx";
 import type { AudioValidationPopoverProps } from "./AudioValidationBadge.tsx";
@@ -43,6 +55,9 @@ interface AudioWaveformWithTranscriptionProps {
     asrLanguageName?: string; // friendly name of the project's language (e.g. "Swahili"). Falls back to "Auto Detect".
     asrLanguageMode?: "project" | "auto";
     onChangeAsrLanguageMode?: (mode: "project" | "auto") => void;
+    // Persistent ASR preferences exposed via the Transcribe-row gear popover.
+    asrPhonetic?: boolean;
+    onChangeAsrPhonetic?: (enabled: boolean) => void;
 }
 
 const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionProps> = ({
@@ -66,6 +81,8 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
     asrLanguageName,
     asrLanguageMode = "project",
     onChangeAsrLanguageMode,
+    asrPhonetic = false,
+    onChangeAsrPhonetic,
 }) => {
     const [audioSrc, setAudioSrc] = useState<string>("");
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
@@ -315,6 +332,53 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                                     </DropdownMenuRadioGroup>
                                 </DropdownMenuContent>
                             </DropdownMenu>
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={transcribeDisabled}
+                                        className={`${sharedBtnClass} rounded-l-none border-l-0 px-1.5 -ml-px`}
+                                        title="Transcription preferences"
+                                        aria-label="Transcription preferences"
+                                    >
+                                        <Settings className="h-3 w-3" />
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent align="end" className="w-72 p-3">
+                                    <div className="space-y-3">
+                                        <div className="space-y-1">
+                                            <p className="text-sm font-medium leading-none">
+                                                Transcription preferences
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                Applies to all cells in this project.
+                                            </p>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-3">
+                                            <div className="flex flex-col">
+                                                <Label
+                                                    htmlFor="asr-phonetic-switch"
+                                                    className="text-sm"
+                                                >
+                                                    Include phonetic (IPA)
+                                                </Label>
+                                                <span className="text-xs text-muted-foreground mt-0.5">
+                                                    Also return an IPA rendering of the
+                                                    audio when supported by the server.
+                                                </span>
+                                            </div>
+                                            <Switch
+                                                id="asr-phonetic-switch"
+                                                checked={!!asrPhonetic}
+                                                onCheckedChange={(checked) =>
+                                                    onChangeAsrPhonetic?.(!!checked)
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                </PopoverContent>
+                            </Popover>
                         </div>
                     );
                 })()}

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -4,6 +4,7 @@ import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import {
     DropdownMenu,
+    DropdownMenuCheckboxItem,
     DropdownMenuContent,
     DropdownMenuLabel,
     DropdownMenuRadioGroup,
@@ -11,9 +12,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu";
-import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover";
-import { Switch } from "../components/ui/switch";
-import { Label } from "../components/ui/label";
 import {
     MessageCircle,
     Copy,
@@ -22,7 +20,6 @@ import {
     History,
     Mic,
     ChevronDown,
-    Settings,
 } from "lucide-react";
 import type { ValidationStatusIconProps } from "./AudioValidationStatusIcon.tsx";
 import { AudioValidationBadge } from "./AudioValidationBadge.tsx";
@@ -327,55 +324,20 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                                             Auto Detect
                                         </DropdownMenuRadioItem>
                                     </DropdownMenuRadioGroup>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuCheckboxItem
+                                        checked={!!asrPhonetic}
+                                        onCheckedChange={(checked) =>
+                                            onChangeAsrPhonetic?.(!!checked)
+                                        }
+                                        // Keep the menu open so users can flip multiple
+                                        // settings before dismissing.
+                                        onSelect={(e) => e.preventDefault()}
+                                    >
+                                        Include phonetic (IPA)
+                                    </DropdownMenuCheckboxItem>
                                 </DropdownMenuContent>
                             </DropdownMenu>
-                            <Popover>
-                                <PopoverTrigger asChild>
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        disabled={transcribeDisabled}
-                                        className={`${sharedBtnClass} rounded-l-none border-l-0 px-1.5 -ml-px`}
-                                        title="Transcription preferences"
-                                        aria-label="Transcription preferences"
-                                    >
-                                        <Settings className="h-3 w-3" />
-                                    </Button>
-                                </PopoverTrigger>
-                                <PopoverContent align="end" className="w-72 p-3">
-                                    <div className="space-y-3">
-                                        <div className="space-y-1">
-                                            <p className="text-sm font-medium leading-none">
-                                                Transcription preferences
-                                            </p>
-                                            <p className="text-xs text-muted-foreground">
-                                                Applies to all cells in this project.
-                                            </p>
-                                        </div>
-                                        <div className="flex items-start justify-between gap-3">
-                                            <div className="flex flex-col">
-                                                <Label
-                                                    htmlFor="asr-phonetic-switch"
-                                                    className="text-sm"
-                                                >
-                                                    Include phonetic (IPA)
-                                                </Label>
-                                                <span className="text-xs text-muted-foreground mt-0.5">
-                                                    Also return an IPA rendering of the
-                                                    audio when supported by the server.
-                                                </span>
-                                            </div>
-                                            <Switch
-                                                id="asr-phonetic-switch"
-                                                checked={!!asrPhonetic}
-                                                onCheckedChange={(checked) =>
-                                                    onChangeAsrPhonetic?.(!!checked)
-                                                }
-                                            />
-                                        </div>
-                                    </div>
-                                </PopoverContent>
-                            </Popover>
                         </div>
                     );
                 })()}

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -263,7 +263,7 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
 
             {/* Action buttons at bottom */}
             <div className="flex flex-wrap items-center justify-center gap-2 px-2">
-                {!transcription && !isTranscribing && (() => {
+                {!isTranscribing && (() => {
                     const transcribeDisabled = disabled || (!audioUrl && !audioBlob);
                     const isAuto = asrLanguageMode === "auto";
                     // The label shows what will actually happen on click — the
@@ -272,6 +272,16 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                     // resolve a project language to send.
                     const effectiveLabel =
                         !isAuto && asrLanguageName ? asrLanguageName : "Auto Detect";
+                    // Once a transcription exists, the same control becomes a
+                    // "Re-transcribe" affordance — same flow, just relabeled so
+                    // users know they're about to overwrite the saved result.
+                    const hasExistingTranscription = !!transcription;
+                    const transcribeButtonLabel = hasExistingTranscription
+                        ? "Re-transcribe"
+                        : "Transcribe";
+                    const transcribeTitle = hasExistingTranscription
+                        ? `Re-transcribe Audio (${effectiveLabel})`
+                        : `Transcribe Audio (${effectiveLabel})`;
                     const sharedBtnClass =
                         "h-8 px-2 text-xs text-[var(--vscode-button-background)] border-[var(--vscode-button-background)]/20 hover:bg-[var(--vscode-button-background)]/10";
                     return (
@@ -281,10 +291,10 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                                 disabled={transcribeDisabled}
                                 variant="outline"
                                 className={`${sharedBtnClass} rounded-r-none border-r-0`}
-                                title={`Transcribe Audio (${effectiveLabel})`}
+                                title={transcribeTitle}
                             >
                                 <MessageCircle className="h-3 w-3" />
-                                <span className="ml-1">Transcribe</span>
+                                <span className="ml-1">{transcribeButtonLabel}</span>
                             </Button>
                             <DropdownMenu>
                                 <DropdownMenuTrigger asChild>

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -295,13 +295,10 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                                         type="button"
                                         variant="outline"
                                         disabled={transcribeDisabled}
-                                        className={`${sharedBtnClass} rounded-l-none gap-1 pl-2 pr-1.5`}
+                                        className={`${sharedBtnClass} rounded-l-none px-1.5`}
                                         title={`Language: ${effectiveLabel}. Click to change.`}
                                         aria-label={`Change transcription language. Current: ${effectiveLabel}`}
                                     >
-                                        <span className="max-w-[10ch] truncate">
-                                            {effectiveLabel}
-                                        </span>
                                         <ChevronDown className="h-3 w-3 opacity-70" />
                                     </Button>
                                 </DropdownMenuTrigger>

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -458,11 +458,8 @@ const CodexCellEditor: React.FC = () => {
                     // Fetch ASR config
                     const asrConfig = await new Promise<{
                         endpoint: string;
-                        provider: string;
-                        model: string;
-                        language: string;
-                        phonetic: boolean;
                         authToken?: string;
+                        language?: { code: string; name: string; };
                     }>((resolve, reject) => {
                         let resolved = false;
                         const onMsg = (ev: MessageEvent) => {
@@ -493,25 +490,6 @@ const CodexCellEditor: React.FC = () => {
                             }
                         }, 5000);
                     });
-
-                    const toIso3 = (code?: string) => {
-                        const ISO2_TO_ISO3: Record<string, string> = {
-                            en: "eng",
-                            fr: "fra",
-                            es: "spa",
-                            de: "deu",
-                            pt: "por",
-                            it: "ita",
-                            nl: "nld",
-                            ru: "rus",
-                            zh: "zho",
-                            ja: "jpn",
-                            ko: "kor",
-                        };
-                        if (!code) return "eng";
-                        const norm = code.toLowerCase();
-                        return norm.length === 2 ? ISO2_TO_ISO3[norm] ?? "eng" : norm;
-                    };
 
                     const wsEndpoint =
                         asrConfig.endpoint ||
@@ -584,7 +562,11 @@ const CodexCellEditor: React.FC = () => {
                                 next.add(cellId);
                                 return next;
                             });
-                            const result = await client.transcribe(blob);
+                            const result = await client.transcribe(
+                                blob,
+                                60000,
+                                asrConfig.language?.code
+                            );
                             const text = (result.text || "").trim();
                             if (text) {
                                 vscode.postMessage({
@@ -592,7 +574,7 @@ const CodexCellEditor: React.FC = () => {
                                     content: {
                                         cellId,
                                         transcribedText: text,
-                                        language: "unknown",
+                                        language: asrConfig.language?.name || "",
                                     },
                                 } as unknown as EditorPostMessages);
 

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -577,12 +577,18 @@ const CodexCellEditor: React.FC = () => {
                             );
                             const text = (result.text || "").trim();
                             if (text) {
+                                // Reflect what was actually sent on the wire so
+                                // the post-transcription badge can distinguish
+                                // project-language runs from auto-detect runs.
+                                const languageLabel = isAutoMode
+                                    ? "Auto Detect"
+                                    : asrConfig.language?.name || "";
                                 vscode.postMessage({
                                     command: "updateCellAfterTranscription",
                                     content: {
                                         cellId,
                                         transcribedText: text,
-                                        language: asrConfig.language?.name || "",
+                                        language: languageLabel,
                                     },
                                 } as unknown as EditorPostMessages);
 

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -461,6 +461,7 @@ const CodexCellEditor: React.FC = () => {
                         authToken?: string;
                         language?: { code: string; name: string; };
                         languageMode?: "project" | "auto";
+                        phonetic?: boolean;
                     }>((resolve, reject) => {
                         let resolved = false;
                         const onMsg = (ev: MessageEvent) => {
@@ -567,10 +568,12 @@ const CodexCellEditor: React.FC = () => {
                             const languageHint = isAutoMode
                                 ? "auto"
                                 : asrConfig.language?.code || undefined;
+                            const includePhonetic = !!asrConfig.phonetic;
                             const result = await client.transcribe(
                                 blob,
                                 60000,
-                                languageHint
+                                languageHint,
+                                includePhonetic
                             );
                             const text = (result.text || "").trim();
                             if (text) {

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -460,6 +460,7 @@ const CodexCellEditor: React.FC = () => {
                         endpoint: string;
                         authToken?: string;
                         language?: { code: string; name: string; };
+                        languageMode?: "project" | "auto";
                     }>((resolve, reject) => {
                         let resolved = false;
                         const onMsg = (ev: MessageEvent) => {
@@ -562,10 +563,14 @@ const CodexCellEditor: React.FC = () => {
                                 next.add(cellId);
                                 return next;
                             });
+                            const isAutoMode = asrConfig.languageMode === "auto";
+                            const languageHint = isAutoMode
+                                ? "auto"
+                                : asrConfig.language?.code || undefined;
                             const result = await client.transcribe(
                                 blob,
                                 60000,
-                                asrConfig.language?.code
+                                languageHint
                             );
                             const text = (result.text || "").trim();
                             if (text) {

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -3099,11 +3099,16 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 // Save transcription to cell metadata
                 const audioId = sessionStorage.getItem(`audio-id-${cellMarkers[0]}`);
                 if (audioId) {
-                    const languageName = asrConfig?.language?.name || "";
+                    // Reflect what we actually sent on the wire, not the project
+                    // language. In auto mode the badge should say "Auto Detect"
+                    // so the user can tell which mode produced this output.
+                    const languageLabel = isAutoMode
+                        ? "Auto Detect"
+                        : asrConfig?.language?.name || "";
                     const transcriptionData = {
                         content: transcribedText,
                         timestamp: Date.now(),
-                        language: languageName,
+                        language: languageLabel,
                     };
 
                     // Save to cell metadata via provider
@@ -3112,7 +3117,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         content: {
                             cellId: cellMarkers[0],
                             transcribedText: transcribedText,
-                            language: languageName,
+                            language: languageLabel,
                         },
                     };
                     window.vscodeApi.postMessage(messageContent);

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -496,11 +496,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
     const transcriptionClientRef = useRef<WhisperTranscriptionClient | null>(null);
     const [asrConfig, setAsrConfig] = useState<{
         endpoint: string;
-        provider: string;
-        model: string;
-        language: string; // ISO-639-3 expected by MMS; may be ISO-639-1 and mapped
-        phonetic: boolean;
         authToken?: string;
+        // Language resolved from project metadata for this editor (target language for codex, source for source files).
+        // `code` is an ISO code passed as the ?lang= hint; `name` is the friendly display name used by the UI.
+        language?: { code: string; name: string; };
     } | null>(null);
 
     // Helper to smoothly center the editor. Coalesces multiple calls and
@@ -3073,8 +3072,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 setTranscriptionStatus(`Error: ${error}`);
             };
 
-            // Perform transcription
-            const result = await client.transcribe(audioBlob);
+            // Perform transcription, hinting the ASR with the project's language when known.
+            const result = await client.transcribe(audioBlob, 60000, asrConfig?.language?.code);
 
             // Success - save transcription but don't automatically insert
             const transcribedText = result.text.trim();
@@ -3082,9 +3081,11 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 // Save transcription to cell metadata
                 const audioId = sessionStorage.getItem(`audio-id-${cellMarkers[0]}`);
                 if (audioId) {
+                    const languageName = asrConfig?.language?.name || "";
                     const transcriptionData = {
                         content: transcribedText,
                         timestamp: Date.now(),
+                        language: languageName,
                     };
 
                     // Save to cell metadata via provider
@@ -3093,7 +3094,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         content: {
                             cellId: cellMarkers[0],
                             transcribedText: transcribedText,
-                            language: "unknown",
+                            language: languageName,
                         },
                     };
                     window.vscodeApi.postMessage(messageContent);

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -502,6 +502,9 @@ const CellEditor: React.FC<CellEditorProps> = ({
         language?: { code: string; name: string; };
         // Whether the user wants to send the project language or let the server detect it.
         languageMode?: "project" | "auto";
+        // Whether the user has opted in to receiving a phonetic (IPA) transcription
+        // alongside the orthographic one.
+        phonetic?: boolean;
     } | null>(null);
 
     // Helper to smoothly center the editor. Coalesces multiple calls and
@@ -3082,7 +3085,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
             const languageHint = isAutoMode
                 ? "auto"
                 : asrConfig?.language?.code || undefined;
-            const result = await client.transcribe(audioBlob, 60000, languageHint);
+            const includePhonetic = !!asrConfig?.phonetic;
+            const result = await client.transcribe(
+                audioBlob,
+                60000,
+                languageHint,
+                includePhonetic
+            );
 
             // Success - save transcription but don't automatically insert
             const transcribedText = result.text.trim();
@@ -5496,6 +5505,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                         window.vscodeApi.postMessage({
                                                             command: "setAsrLanguageMode",
                                                             content: { mode },
+                                                        } as EditorPostMessages);
+                                                    }}
+                                                    asrPhonetic={!!asrConfig?.phonetic}
+                                                    onChangeAsrPhonetic={(enabled) => {
+                                                        window.vscodeApi.postMessage({
+                                                            command: "setAsrPhonetic",
+                                                            content: { enabled },
                                                         } as EditorPostMessages);
                                                     }}
                                                     onRequestRemove={() => {

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -500,6 +500,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
         // Language resolved from project metadata for this editor (target language for codex, source for source files).
         // `code` is an ISO code passed as the ?lang= hint; `name` is the friendly display name used by the UI.
         language?: { code: string; name: string; };
+        // Whether the user wants to send the project language or let the server detect it.
+        languageMode?: "project" | "auto";
     } | null>(null);
 
     // Helper to smoothly center the editor. Coalesces multiple calls and
@@ -3072,8 +3074,15 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 setTranscriptionStatus(`Error: ${error}`);
             };
 
-            // Perform transcription, hinting the ASR with the project's language when known.
-            const result = await client.transcribe(audioBlob, 60000, asrConfig?.language?.code);
+            // Perform transcription. When the user picks "Auto Detect" we send
+            // `lang=auto` so the proxy can run server-side LID. Otherwise we
+            // send the project's language code (if resolved). Omitting it
+            // entirely also works but matches today's English-default behavior.
+            const isAutoMode = asrConfig?.languageMode === "auto";
+            const languageHint = isAutoMode
+                ? "auto"
+                : asrConfig?.language?.code || undefined;
+            const result = await client.transcribe(audioBlob, 60000, languageHint);
 
             // Success - save transcription but don't automatically insert
             const transcribedText = result.text.trim();
@@ -5479,6 +5488,16 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     onInsertTranscription={
                                                         handleInsertTranscription
                                                     }
+                                                    asrLanguageName={asrConfig?.language?.name}
+                                                    asrLanguageMode={
+                                                        asrConfig?.languageMode ?? "project"
+                                                    }
+                                                    onChangeAsrLanguageMode={(mode) => {
+                                                        window.vscodeApi.postMessage({
+                                                            command: "setAsrLanguageMode",
+                                                            content: { mode },
+                                                        } as EditorPostMessages);
+                                                    }}
                                                     onRequestRemove={() => {
                                                         setConfirmingDiscard(true);
                                                         scrollEditorBottomIntoView();

--- a/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
@@ -11,7 +11,8 @@ export class WhisperTranscriptionClient {
 
     async transcribe(
         audioBlob: Blob,
-        timeoutMs: number = 60000
+        timeoutMs: number = 60000,
+        language?: string
     ): Promise<{ text: string; }> {
         try {
             // Create FormData with audio file
@@ -24,6 +25,9 @@ export class WhisperTranscriptionClient {
             url.searchParams.set("source", "codex");
             if (this.authToken) {
                 url.searchParams.set("token", this.authToken);
+            }
+            if (language) {
+                url.searchParams.set("lang", language);
             }
 
             // Prepare headers

--- a/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
@@ -26,6 +26,12 @@ export class WhisperTranscriptionClient {
             if (this.authToken) {
                 url.searchParams.set("token", this.authToken);
             }
+            // Language hint for the ASR proxy. Concrete values are ISO 639-3
+            // codes (e.g. "eng", "swh", "fra") which the proxy uses to pick
+            // the MMS adapter. The special value "auto" requests language
+            // identification (LID) on the proxy side before transcription.
+            // Omitting the param entirely is equivalent to today's behavior
+            // (server picks a default, typically English).
             if (language) {
                 url.searchParams.set("lang", language);
             }

--- a/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/WhisperTranscriptionClient.ts
@@ -12,8 +12,9 @@ export class WhisperTranscriptionClient {
     async transcribe(
         audioBlob: Blob,
         timeoutMs: number = 60000,
-        language?: string
-    ): Promise<{ text: string; }> {
+        language?: string,
+        phonetic?: boolean
+    ): Promise<{ text: string; phonetic?: string; }> {
         try {
             // Create FormData with audio file
             const formData = new FormData();
@@ -34,6 +35,12 @@ export class WhisperTranscriptionClient {
             // (server picks a default, typically English).
             if (language) {
                 url.searchParams.set("lang", language);
+            }
+            // When set, ask the proxy to also return a phonetic (IPA)
+            // transcription alongside the orthographic text. The proxy is
+            // expected to populate `phonetic` in the JSON response.
+            if (phonetic) {
+                url.searchParams.set("phonetic", "1");
             }
 
             // Prepare headers
@@ -93,7 +100,11 @@ export class WhisperTranscriptionClient {
 
                 // Parse response
                 const result = await response.json();
-                return { text: result.text || "" };
+                const phoneticText =
+                    typeof result.phonetic === "string" && result.phonetic.trim()
+                        ? result.phonetic
+                        : undefined;
+                return { text: result.text || "", phonetic: phoneticText };
             } catch (error) {
                 clearTimeout(timeoutId);
 


### PR DESCRIPTION
Resolve the project's source or target language (depending on editor type) in getAsrConfig and pass it to the ASR endpoint as a ?lang= hint, then store the friendly language name on the cell and display it on the transcription badge. When no project language is configured, the badge falls back to "Transcription Language Unknown" instead of the bare "unknown" string. Legacy stored "unknown" values render the new fallback text so existing data isn't misleading.

Closes #979.