### PR TITLE
fix(audio): restore recording count badge on the History button (#981)

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -256,22 +256,22 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                     <History className="h-3 w-3" />
                     <span className="ml-1">History</span>
                     {typeof historyCount === "number" && historyCount > 0 && (
-                        <span
-                            className="ml-2 inline-flex items-center justify-center rounded-full"
+                        <Badge
+                            variant="secondary"
+                            className="ml-1 justify-center leading-none"
                             style={{
-                                minWidth: "1rem",
-                                height: "1rem",
-                                padding: "0 4px",
+                                minWidth: "1.5em",
+                                height: "1.5em",
+                                padding: "0 0.35em",
+                                fontSize: "0.85em",
+                                fontWeight: 700,
                                 backgroundColor: "var(--vscode-badge-background)",
                                 color: "var(--vscode-badge-foreground)",
-                                fontSize: "0.6rem",
-                                fontWeight: 700,
-                                lineHeight: 1,
                             }}
                             aria-label={`${historyCount} audio recording${historyCount === 1 ? "" : "s"} in history`}
                         >
                             {historyCount}
-                        </span>
+                        </Badge>
                     )}
                 </Button>
                 <Button

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -29,6 +29,8 @@ interface AudioWaveformWithTranscriptionProps {
     targetDurationSeconds?: number | null;
     audioDurationSeconds?: number | null;
     targetDuration?: number | null; // Target duration (in seconds) derived from cell timestamps.
+    /** Total number of audio recordings for the cell (including soft-deleted). When > 0, a count badge is rendered on the History button. */
+    historyCount?: number;
 }
 
 const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionProps> = ({
@@ -49,6 +51,7 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
     audioDurationSeconds,
     targetDuration,
     author,
+    historyCount,
 }) => {
     const [audioSrc, setAudioSrc] = useState<string>("");
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
@@ -252,6 +255,24 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                 >
                     <History className="h-3 w-3" />
                     <span className="ml-1">History</span>
+                    {typeof historyCount === "number" && historyCount > 0 && (
+                        <span
+                            className="ml-2 inline-flex items-center justify-center rounded-full"
+                            style={{
+                                minWidth: "1rem",
+                                height: "1rem",
+                                padding: "0 4px",
+                                backgroundColor: "var(--vscode-badge-background)",
+                                color: "var(--vscode-badge-foreground)",
+                                fontSize: "0.6rem",
+                                fontWeight: 700,
+                                lineHeight: 1,
+                            }}
+                            aria-label={`${historyCount} audio recording${historyCount === 1 ? "" : "s"} in history`}
+                        >
+                            {historyCount}
+                        </span>
+                    )}
                 </Button>
                 <Button
                     variant="outline"

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -481,6 +481,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
     const [isAudioLoading, setIsAudioLoading] = useState(false);
     const [isPlayAudioLoading, setIsPlayAudioLoading] = useState(false);
     const [hasAudioHistory, setHasAudioHistory] = useState<boolean>(false);
+    const [audioHistoryCount, setAudioHistoryCount] = useState<number>(0);
     const [audioWarning, setAudioWarning] = useState<string | null>(null);
     const [currentSelectedAudioId, setCurrentSelectedAudioId] = useState<string | null>(null);
 
@@ -3311,6 +3312,11 @@ const CellEditor: React.FC<CellEditorProps> = ({
     useEffect(() => {
         const cellId = cellMarkers[0];
         setCurrentSelectedAudioId(null);
+        // Reset history flags so a stale count/visibility from the previous
+        // cell doesn't briefly render before the new audioHistoryReceived
+        // response arrives for this cell.
+        setHasAudioHistory(false);
+        setAudioHistoryCount(0);
         window.vscodeApi.postMessage({
             command: "getAudioHistory",
             content: { cellId },
@@ -3866,6 +3872,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
             ) {
                 const history = message.content.audioHistory || [];
                 setHasAudioHistory(history.length > 0);
+                setAudioHistoryCount(history.length);
 
                 // Initialize or correct currentSelectedAudioId from the provider's
                 // authoritative currentAttachmentId.  If it differs from what we
@@ -5449,6 +5456,25 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                 >
                                                     <History className="h-3 w-3 mr-1" />
                                                     History
+                                                    {audioHistoryCount > 0 && (
+                                                        <span
+                                                            className="ml-2 inline-flex items-center justify-center rounded-full"
+                                                            style={{
+                                                                minWidth: "1rem",
+                                                                height: "1rem",
+                                                                padding: "0 4px",
+                                                                backgroundColor:
+                                                                    "var(--vscode-badge-background)",
+                                                                color: "var(--vscode-badge-foreground)",
+                                                                fontSize: "0.6rem",
+                                                                fontWeight: 700,
+                                                                lineHeight: 1,
+                                                            }}
+                                                            aria-label={`${audioHistoryCount} audio recording${audioHistoryCount === 1 ? "" : "s"} in history`}
+                                                        >
+                                                            {audioHistoryCount}
+                                                        </span>
+                                                    )}
                                                 </Button>
                                             )}
 
@@ -5483,6 +5509,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                         scrollEditorBottomIntoView();
                                                     }}
                                                     onShowHistory={() => setShowAudioHistory(true)}
+                                                    historyCount={audioHistoryCount}
                                                     onShowRecorder={() => {
                                                         setShowRecorder(true);
                                                         setCountdown(null);

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -5457,23 +5457,23 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     <History className="h-3 w-3 mr-1" />
                                                     History
                                                     {audioHistoryCount > 0 && (
-                                                        <span
-                                                            className="ml-2 inline-flex items-center justify-center rounded-full"
+                                                        <Badge
+                                                            variant="secondary"
+                                                            className="ml-1 justify-center leading-none"
                                                             style={{
-                                                                minWidth: "1rem",
-                                                                height: "1rem",
-                                                                padding: "0 4px",
+                                                                minWidth: "1.5em",
+                                                                height: "1.5em",
+                                                                padding: "0 0.35em",
+                                                                fontSize: "0.85em",
+                                                                fontWeight: 700,
                                                                 backgroundColor:
                                                                     "var(--vscode-badge-background)",
                                                                 color: "var(--vscode-badge-foreground)",
-                                                                fontSize: "0.6rem",
-                                                                fontWeight: 700,
-                                                                lineHeight: 1,
                                                             }}
                                                             aria-label={`${audioHistoryCount} audio recording${audioHistoryCount === 1 ? "" : "s"} in history`}
                                                         >
                                                             {audioHistoryCount}
-                                                        </span>
+                                                        </Badge>
                                                     )}
                                                 </Button>
                                             )}


### PR DESCRIPTION
The History button used to show a count badge so users could see at a glance how many recordings were stored for the cell — including soft-deleted ones that can still be restored. The badge was removed in 20237e35 along with other count UI; this re-adds only the History button badge, keeping the change minimal.

- Track audioHistoryCount in TextCellEditor from the existing audioHistoryReceived response (history.length already includes soft-deleted entries via getAttachmentHistory).
- Reset hasAudioHistory and audioHistoryCount on cell switch to avoid briefly rendering a stale count from the prior cell.
- Render a theme-aware count badge in both History button render sites: AudioWaveformWithTranscription (waveform view) and the in-recorder History button (the "instead of just showing the record button" scenario from the issue).

No types/index.d.ts or provider changes are needed; the data was already on the wire.