### PR TITLE
989-audio-dubbing-adjustments-2

### DIFF
--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -250,6 +250,7 @@ export interface ExportOptions {
     removeIds?: boolean;
     includeAudio?: boolean;
     includeTimestamps?: boolean;
+    excludeLabels?: boolean;
 }
 
 // IDML Round-trip export: Uses idmlExporter or biblicaExporter based on filename
@@ -2066,7 +2067,13 @@ export const exportCodexContentAsSubtitlesVtt = async (
                     debug(`File has ${cells.length} active cells`);
 
                     // Generate VTT content
-                    const vttContent = generateVttData(cells, includeStyles, cueSplitting, file.fsPath); // Include styles for VTT
+                    const vttContent = generateVttData(
+                        cells,
+                        includeStyles,
+                        cueSplitting,
+                        file.fsPath,
+                        options?.excludeLabels === true
+                    );
                     debug({ vttContent, cells, includeStyles });
 
                     // Write file

--- a/src/exportHandler/vttUtils.ts
+++ b/src/exportHandler/vttUtils.ts
@@ -72,7 +72,8 @@ export const generateVttData = (
     cells: CodexNotebookAsJSONData["cells"],
     includeStyles: boolean,
     cueSplitting: boolean,
-    filePath: string
+    filePath: string,
+    excludeLabels: boolean = false
 ): string => {
     if (!cells.length) return "";
 
@@ -96,7 +97,7 @@ export const generateVttData = (
             const text = includeStyles ? processVttContent(unit.value) : removeHtmlTags(unit.value);
             const finalText = ensureDialogueLineBreaks(text);
 
-            const rawLabel = unit.metadata?.cellLabel?.trim();
+            const rawLabel = excludeLabels ? undefined : unit.metadata?.cellLabel?.trim();
             const payload = rawLabel
                 ? `<v ${escapeVoiceName(rawLabel)}>${finalText}</v>`
                 : finalText;

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -532,6 +532,21 @@ function getWebviewContent(
                 .format-option-row[data-option].hidden { display: none !important; }
                 .format-option p, .format-option-content p { line-height: 1.45; margin: 4px 0 0 0; }
                 .format-option-content { display: flex; flex-direction: column; gap: 4px; }
+                .format-option-toggle {
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    font-size: 0.9em;
+                    color: var(--vscode-descriptionForeground);
+                    cursor: pointer;
+                    user-select: none;
+                }
+                .format-option-toggle input[type="checkbox"] { margin: 0; cursor: pointer; }
+                .format-section-suboption {
+                    padding: 10px 12px;
+                    background-color: var(--vscode-editor-background);
+                    border-top: 1px solid var(--vscode-input-border);
+                }
                 .format-tag {
                     display: inline-block;
                     padding: 1px 4px;
@@ -722,6 +737,12 @@ function getWebviewContent(
                                             <span class="format-tag">Plain Text Only</span>
                                         </div>
                                     </div>
+                                </div>
+                                <div class="format-section-suboption">
+                                    <label class="format-option-toggle" id="vttExcludeLabelsToggle">
+                                        <input type="checkbox" id="vttExcludeLabelsCb">
+                                        Exclude speaker labels from WebVTT cues
+                                    </label>
                                 </div>
                             </div>
                             <!-- Round-trip: only for supported file types -->
@@ -1518,6 +1539,10 @@ function getWebviewContent(
                     if (selectedAudioMode) {
                         options.includeAudio = true;
                         options.includeTimestamps = selectedAudioMode === 'audio-timestamps';
+                    }
+                    if (selectedFormat && selectedFormat.startsWith('subtitles-vtt-')) {
+                        const cb = document.getElementById('vttExcludeLabelsCb');
+                        if (cb && cb.checked) options.excludeLabels = true;
                     }
                     vscode.postMessage({
                         command: 'export',

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -1483,10 +1483,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 // Read the video file content
                 const fileData = await vscode.workspace.fs.readFile(fileUri);
 
-                // Enforce a reasonable max size (e.g., 600 MB) for video files
-                const MAX_BYTES = 600 * 1024 * 1024;
+                // Enforce a reasonable max size (e.g., 900 MB) for video files
+                const MAX_BYTES = 900 * 1024 * 1024;
                 if (fileData.length > MAX_BYTES) {
-                    throw new Error("Video file exceeds maximum allowed size (500 MB)");
+                    throw new Error("Video file exceeds maximum allowed size 900 MB)");
                 }
 
                 // Determine document segment


### PR DESCRIPTION
## Resolution
This PR makes an option to exclude speaker tags from .vtt export options. You would usually see a <v> tag in the exported file by default. In order to remove it, you now have to click the checkbox in the Subtitle section of the exporter options.

There will also be minor improvements based upon feedback received from the project using it.

## Testing Checklist

- [ ] Open Export view → Step 2. Confirm a single **"Exclude speaker labels from WebVTT cues"** checkbox appears at the bottom of the Subtitle Export Options section (not inside any individual card).
- [ ] Pick a `.codex` file whose cells have non-empty `cellLabel` metadata.
- [ ] Export as **WebVTT with Styling** with the checkbox **unchecked** → output contains `<v Label>…</v>` voice tags.
- [ ] Re-export the same file with the checkbox **checked** → output has no `<v …>` tags; cue text is plain.
- [ ] Repeat the checked-export for **WebVTT Plain** and **WebVTT with Cue Splitting** → both produce label-free cues.
- [ ] Export as **SubRip (SRT)** with the checkbox in either state → output never contains labels (and the checkbox state is ignored).
- [ ] Clicking the checkbox does **not** select/deselect a format card.
- [ ] Switching between VTT cards preserves the checkbox state across the same export session.