### PR TITLE
feat(audio): warn and disable recording when no input device detected…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2305,6 +2305,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
             "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -2358,6 +2359,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
             "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -4982,7 +4984,6 @@
             "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -5025,7 +5026,6 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -5066,7 +5066,6 @@
             "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -5084,7 +5083,6 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -5151,7 +5149,6 @@
             "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -5166,7 +5163,6 @@
             "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -5260,7 +5256,6 @@
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -5271,7 +5266,6 @@
             "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -6017,6 +6011,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -6053,6 +6048,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6065,6 +6061,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
             "integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6089,6 +6086,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -6132,6 +6130,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6255,6 +6254,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6267,6 +6267,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6282,6 +6283,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -6418,7 +6420,6 @@
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -8275,6 +8276,7 @@
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -8472,6 +8474,7 @@
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -9976,6 +9979,7 @@
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -10502,6 +10506,7 @@
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
             "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "peerDependencies": {
                 "bare-abort-controller": "*"
             },
@@ -10934,6 +10939,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -11821,8 +11827,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -12508,7 +12513,8 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1400418.tgz",
             "integrity": "sha512-U8j75zDOXF8IP3o0Cgb7K4tFA9uUHEOru2Wx64+EUqL4LNOh9dRe1i8WKR1k3mSpjcCe3aIkTDvEwq0YkI4hfw==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/diff": {
             "version": "7.0.0",
@@ -12820,6 +12826,7 @@
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
             }
@@ -13050,6 +13057,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -14421,7 +14429,6 @@
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -16386,7 +16393,6 @@
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -16829,7 +16835,6 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -16866,7 +16871,6 @@
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -19645,6 +19649,7 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -21575,7 +21580,6 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -21586,8 +21590,7 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -22691,6 +22694,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -24213,7 +24217,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/turndown": {
             "version": "7.2.4",
@@ -24284,6 +24289,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -27232,6 +27238,7 @@
             "integrity": "sha512-SyrSVpygEdPzvgpapVZRQCy8XIOecadp56bPQewpfSfo9ypB6wdOUkx13NBu2ANDlUAtJX7KaLJpTtywVHNlVw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^22.2.0",
                 "@wdio/config": "8.46.0",
@@ -27312,6 +27319,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -27361,6 +27369,7 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",
@@ -27437,6 +27446,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -27681,6 +27691,7 @@
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -27791,8 +27802,7 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -3025,6 +3025,18 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     return;
                 }
 
+                // Mark deletion as in progress so the webview can disable the
+                // project's actions immediately — this covers the confirmation
+                // dialog window, preventing repeated Delete clicks from stacking
+                // multiple delete requests/dialogs. "verifying" reflects the
+                // pre-confirmation work (existence + sync-status checks + dialog).
+                this.safeSendMessage({
+                    command: "project.deletingInProgress",
+                    projectPath,
+                    deleting: true,
+                    stage: "verifying",
+                });
+
                 // Ensure the path exists
                 try {
                     const projectUri = vscode.Uri.file(projectPath);
@@ -3075,10 +3087,23 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     );
 
                     if (confirmResult === actionButtonText) {
+                        // Confirmed — transition the webview label from
+                        // "Verifying..." to "Deleting..." for the actual removal.
+                        this.safeSendMessage({
+                            command: "project.deletingInProgress",
+                            projectPath,
+                            deleting: true,
+                            stage: "deleting",
+                        });
                         // Perform deletion
                         await this.performProjectDeletion(projectPath, projectName);
                     } else {
                         // User cancelled deletion
+                        this.safeSendMessage({
+                            command: "project.deletingInProgress",
+                            projectPath,
+                            deleting: false,
+                        });
                         this.safeSendMessage({
                             command: "project.deleteResponse",
                             success: false,
@@ -3088,6 +3113,12 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                 } catch (error) {
                     console.error("Project not found:", error);
                     vscode.window.showErrorMessage("The specified project could not be found.");
+
+                    this.safeSendMessage({
+                        command: "project.deletingInProgress",
+                        projectPath,
+                        deleting: false,
+                    });
 
                     // Send error response to webview
                     this.safeSendMessage({
@@ -4636,6 +4667,13 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                 error: error instanceof Error ? error.message : String(error),
             });
         } finally {
+            // Clear the deleting flag for any card still mounted (e.g. on failure;
+            // on success the card unmounts when the refreshed list arrives).
+            this.safeSendMessage({
+                command: "project.deletingInProgress",
+                projectPath,
+                deleting: false,
+            });
             // Always refresh the projects list
             await this.sendList(this.webviewPanel!);
         }

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -1388,6 +1388,21 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         const listeners: vscode.Disposable[] = [];
         listeners.push(viewStateDisposable);
 
+        // Relay OS-level window focus changes to the webview. Webview iframes
+        // don't reliably get `window.focus` / `visibilitychange` when the whole
+        // VS Code app gains/loses OS focus, so the audio recorder can't refresh
+        // mic availability on its own. `onDidChangeWindowState` is the reliable
+        // host-side signal; forward it so the recorder re-checks permissions
+        // after the user returns from OS settings.
+        listeners.push(
+            vscode.window.onDidChangeWindowState((state) => {
+                this.postMessageToWebview(webviewPanel, {
+                    type: "windowFocusChanged",
+                    focused: state.focused,
+                });
+            })
+        );
+
         listeners.push(
             document.onDidChangeForVsCodeAndWebview((e) => {
                 debug("Document changed for VS Code and webview");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1950,6 +1950,17 @@ type EditorReceiveMessages =
         };
     }
     | {
+        /**
+         * Forwarded from the extension host's `vscode.window.onDidChangeWindowState`.
+         * Webview iframes don't reliably receive OS-level focus / visibilitychange
+         * events, so the host relays them. The audio recorder uses `focused: true`
+         * to refresh microphone availability (a permission can only change while
+         * the user is away in OS settings).
+         */
+        type: "windowFocusChanged";
+        focused: boolean;
+    }
+    | {
         type: "providerSendsInitialContent";
         content: QuillCellContent[];
         isSourceText: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -288,6 +288,7 @@ export type MessagesFromStartupFlowProvider =
     | { command: "project.renamingInProgress"; projectPath: string; renaming: boolean; }
     | { command: "project.zippingInProgress"; projectPath: string; zipType: "full" | "mini"; zipping: boolean; }
     | { command: "project.cleaningInProgress"; projectPath: string; cleaning: boolean; }
+    | { command: "project.deletingInProgress"; projectPath: string; deleting: boolean; stage?: "verifying" | "deleting"; }
     | {
         command: "project.swapCloneWarning";
         repoUrl: string;

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { CustomWaveformCanvas } from "./CustomWaveformCanvas.tsx";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
-import { MessageCircle, Copy, Loader2, Trash2, History, Mic } from "lucide-react";
+import { MessageCircle, Copy, Loader2, Trash2, History, Mic, MicOff } from "lucide-react";
 import type { ValidationStatusIconProps } from "./AudioValidationStatusIcon.tsx";
 import { AudioValidationBadge } from "./AudioValidationBadge.tsx";
 import type { AudioValidationPopoverProps } from "./AudioValidationBadge.tsx";
@@ -31,6 +31,12 @@ interface AudioWaveformWithTranscriptionProps {
     targetDuration?: number | null; // Target duration (in seconds) derived from cell timestamps.
     /** Total number of audio recordings for the cell (including soft-deleted). When > 0, a count badge is rendered on the History button. */
     historyCount?: number;
+    /** Mic unavailable (no device OR permission denied). When true, the Re-record button warns about it. */
+    micUnavailable?: boolean;
+    /** No input device detected. */
+    noMicDetected?: boolean;
+    /** Mic permission denied by the OS/browser. */
+    micPermissionDenied?: boolean;
 }
 
 const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionProps> = ({
@@ -52,6 +58,9 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
     targetDuration,
     author,
     historyCount,
+    micUnavailable = false,
+    noMicDetected = false,
+    micPermissionDenied = false,
 }) => {
     const [audioSrc, setAudioSrc] = useState<string>("");
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
@@ -111,6 +120,15 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
             cancelled = true;
         };
     }, [audioBlob, targetDuration]);
+
+    // The Re-record button stays clickable even when the mic is unavailable so
+    // the user can still upload an audio file from the recorder view; we only
+    // change its copy/affordance to surface the problem up front.
+    const micRecordLabel = micPermissionDenied
+        ? "Microphone access denied"
+        : noMicDetected
+          ? "No microphone detected"
+          : "Re-record";
 
     return (
         <div className="bg-[var(--vscode-editor-background)] flex flex-col gap-y-3 p-3 sm:p-4 rounded-md shadow w-full relative">
@@ -277,12 +295,24 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                 <Button
                     variant="outline"
                     size="sm"
-                    className="h-8 px-2 text-xs"
+                    className={
+                        micUnavailable
+                            ? "h-8 px-2 text-xs border-red-500 text-red-600 hover:text-red-600 dark:text-red-400"
+                            : "h-8 px-2 text-xs"
+                    }
                     onClick={() => onShowRecorder?.()}
-                    title="Re-record / Upload New"
+                    title={
+                        micUnavailable
+                            ? `${micRecordLabel} — click to upload an audio file instead`
+                            : "Re-record / Upload New"
+                    }
                 >
-                    <Mic className="h-3 w-3" />
-                    <span className="ml-1">Re-record</span>
+                    {micUnavailable ? (
+                        <MicOff className="h-3 w-3" />
+                    ) : (
+                        <Mic className="h-3 w-3" />
+                    )}
+                    <span className="ml-1">{micRecordLabel}</span>
                 </Button>
             </div>
         </div>

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -534,17 +534,20 @@ const CellEditor: React.FC<CellEditorProps> = ({
             undefined,
     };
 
-    // Microphone detection — drives the disabled state and warning under the
-    // recorder. Updates live via `devicechange`, so unplugging or plugging in
-    // a mic flips the UI immediately. See `hooks/useAudioInputDevices.ts` for
-    // the debug flag used to simulate "no microphone" on dev machines.
-    const {
-        hasAudioInput,
-        isChecking: isCheckingAudioDevices,
-        isSupported: isAudioDeviceApiSupported,
-    } = useAudioInputDevices();
-    const noMicDetected =
-        isAudioDeviceApiSupported && !isCheckingAudioDevices && !hasAudioInput;
+    // Microphone availability — drives the disabled state and warning under
+    // the recorder. Reacts live to both `devicechange` and permission changes
+    // so the UI stays in sync without a reload. See
+    // `hooks/useAudioInputDevices.ts` (top of file) for the in-code constant
+    // reviewers can flip to simulate "no microphone" / "permission denied"
+    // on machines with a working mic.
+    const { noMicDetected, micPermissionDenied, micUnavailable } = useAudioInputDevices();
+    // Mirror `micUnavailable` into a ref so guards inside callbacks (and
+    // setTimeout-deferred work like the auto-start path) can read the
+    // latest value without becoming stale closures.
+    const micUnavailableRef = useRef<boolean>(micUnavailable);
+    useEffect(() => {
+        micUnavailableRef.current = micUnavailable;
+    }, [micUnavailable]);
 
     const centerEditor = useCallback(() => {
         const el = cellEditorRef.current;
@@ -2762,6 +2765,19 @@ const CellEditor: React.FC<CellEditorProps> = ({
         // Prevent recording if cell is locked
         if (isCellLocked) {
             setRecordingStatus("Cannot record: cell is locked");
+            return;
+        }
+
+        // Prevent recording — and importantly, the visible pre-record
+        // countdown — when no mic is available or permission is denied.
+        // Read from the ref so the auto-start path (deferred via setTimeout)
+        // sees the latest value rather than its captured render-time copy.
+        if (micUnavailableRef.current) {
+            setRecordingStatus(
+                micPermissionDenied
+                    ? "Microphone access denied"
+                    : "No microphone detected"
+            );
             return;
         }
 
@@ -5720,6 +5736,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                             : "idle";
                                     const recorderTitle = isCellLocked
                                         ? "Cannot record: cell is locked"
+                                        : micPermissionDenied
+                                        ? "Microphone access denied"
                                         : noMicDetected
                                         ? "No microphone detected"
                                         : isRecording
@@ -5742,7 +5760,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                     : startRecording
                                                             }
                                                             disabled={isCellLocked}
-                                                            unavailable={noMicDetected}
+                                                            unavailable={micUnavailable}
                                                             title={recorderTitle}
                                                         />
 
@@ -5813,12 +5831,20 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                 </span>
                                                             </div>
                                                         )}
-                                                        {noMicDetected && (
-                                                            <Alert className="w-fit border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
-                                                                <AlertCircle className="h-4 w-4 !text-yellow-600 dark:!text-yellow-400" />
+                                                        {micUnavailable && (
+                                                            // Override the Alert's default absolute-icon layout so the
+                                                            // AlertCircle and text share a single flex row with proper
+                                                            // vertical centering. The `!` (important) prefixes are needed
+                                                            // because the base Alert variant pins the SVG with
+                                                            // `[&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4`.
+                                                            <Alert
+                                                                className="w-fit flex items-center gap-2 border-yellow-500 bg-yellow-50 dark:bg-yellow-950 [&>svg]:!static [&>svg+div]:!translate-y-0 [&>svg~*]:!pl-0"
+                                                            >
+                                                                <AlertCircle className="h-4 w-4 shrink-0 !text-yellow-600 dark:!text-yellow-400" />
                                                                 <AlertDescription className="text-yellow-800 dark:text-yellow-200">
-                                                                    No microphone detected. Connect
-                                                                    an input device to record.
+                                                                    {micPermissionDenied
+                                                                        ? "Microphone access denied. Enable microphone permissions in your system settings to record."
+                                                                        : "No microphone detected. Connect an input device to record."}
                                                                 </AlertDescription>
                                                             </Alert>
                                                         )}

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -540,7 +540,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
     // `hooks/useAudioInputDevices.ts` (top of file) for the in-code constant
     // reviewers can flip to simulate "no microphone" / "permission denied"
     // on machines with a working mic.
-    const { noMicDetected, micPermissionDenied, micUnavailable } = useAudioInputDevices();
+    const { noMicDetected, micPermissionDenied, micUnavailable, reportRecorderError } =
+        useAudioInputDevices();
     // Mirror `micUnavailable` into a ref so guards inside callbacks (and
     // setTimeout-deferred work like the auto-start path) can read the
     // latest value without becoming stale closures.
@@ -548,6 +549,14 @@ const CellEditor: React.FC<CellEditorProps> = ({
     useEffect(() => {
         micUnavailableRef.current = micUnavailable;
     }, [micUnavailable]);
+    // Ref for the runtime classifier so `startActualRecording`'s deps stay
+    // stable. `startActualRecording` is wrapped in `useCallback([audioUrl])`
+    // and changing its deps to include a new function on every render would
+    // ripple through several effects.
+    const reportRecorderErrorRef = useRef(reportRecorderError);
+    useEffect(() => {
+        reportRecorderErrorRef.current = reportRecorderError;
+    }, [reportRecorderError]);
 
     const centerEditor = useCallback(() => {
         const el = cellEditorRef.current;
@@ -789,6 +798,12 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 },
             });
 
+            // Successful stream acquisition is the ground-truth signal that
+            // mic access works. Clear any previous runtime-reported denial so
+            // the UI recovers without waiting for a (potentially unreliable)
+            // OS-level permission event.
+            reportRecorderErrorRef.current?.(null);
+
             const mediaRecorderOptions: MediaRecorderOptions = {};
             try {
                 if (typeof MediaRecorder !== "undefined") {
@@ -862,7 +877,18 @@ const CellEditor: React.FC<CellEditorProps> = ({
             recorder.start();
             setMediaRecorder(recorder);
         } catch (err) {
-            setRecordingStatus("Microphone access denied");
+            // Promote the raw error to a typed availability state so the UI
+            // flips to the right warning (grey slashed mic + "Access denied"
+            // alert for `NotAllowedError`, "No microphone detected" for
+            // `NotFoundError`). The hook ignores unrecognized error names so
+            // transient failures don't accidentally disable recording.
+            reportRecorderErrorRef.current?.(err);
+            const errName = (err as { name?: string } | null)?.name;
+            const statusMessage =
+                errName === "NotFoundError" || errName === "DevicesNotFoundError"
+                    ? "No microphone detected"
+                    : "Microphone access denied";
+            setRecordingStatus(statusMessage);
             console.error("Error accessing microphone:", err);
             setCountdown(null);
             setIsStartingRecording(false);

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -22,6 +22,7 @@ import { WhisperTranscriptionClient } from "./WhisperTranscriptionClient";
 import AudioWaveformWithTranscription from "./AudioWaveformWithTranscription";
 import { AudioValidationBadge } from "./AudioValidationBadge";
 import { useAudioValidationStatus } from "./hooks/useAudioValidationStatus";
+import { useAudioInputDevices } from "./hooks/useAudioInputDevices";
 import SourceTextDisplay from "./SourceTextDisplay";
 import { AudioHistoryViewer } from "./AudioHistoryViewer";
 import { useMessageHandler } from "./hooks/useCentralizedMessageDispatcher";
@@ -531,6 +532,18 @@ const CellEditor: React.FC<CellEditorProps> = ({
             (window as any)?.initialData?.validationCountAudio ??
             undefined,
     };
+
+    // Microphone detection — drives the disabled state and warning under the
+    // recorder. Updates live via `devicechange`, so unplugging or plugging in
+    // a mic flips the UI immediately. See `hooks/useAudioInputDevices.ts` for
+    // the debug flag used to simulate "no microphone" on dev machines.
+    const {
+        hasAudioInput,
+        isChecking: isCheckingAudioDevices,
+        isSupported: isAudioDeviceApiSupported,
+    } = useAudioInputDevices();
+    const noMicDetected =
+        isAudioDeviceApiSupported && !isCheckingAudioDevices && !hasAudioInput;
 
     const centerEditor = useCallback(() => {
         const el = cellEditorRef.current;
@@ -5680,6 +5693,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                             : "idle";
                                     const recorderTitle = isCellLocked
                                         ? "Cannot record: cell is locked"
+                                        : noMicDetected
+                                        ? "No microphone detected"
                                         : isRecording
                                         ? "Stop Recording"
                                         : countdown !== null
@@ -5699,7 +5714,9 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                     ? stopRecording
                                                                     : startRecording
                                                             }
-                                                            disabled={isCellLocked}
+                                                            disabled={
+                                                                isCellLocked || noMicDetected
+                                                            }
                                                             title={recorderTitle}
                                                         />
 
@@ -5769,6 +5786,21 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                     auto-trimmed
                                                                 </span>
                                                             </div>
+                                                        )}
+                                                        {noMicDetected && (
+                                                            <span
+                                                                role="alert"
+                                                                className="text-xs text-muted-foreground inline-flex items-center gap-1"
+                                                            >
+                                                                <AlertTriangle
+                                                                    className="h-3 w-3"
+                                                                    style={{
+                                                                        color: "var(--vscode-errorForeground)",
+                                                                    }}
+                                                                />
+                                                                No microphone detected. Connect an
+                                                                input device to record.
+                                                            </span>
                                                         )}
                                                         {hint && (
                                                             <span className="text-xs text-muted-foreground inline-flex items-center gap-1">

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -541,8 +541,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
     // `hooks/useAudioInputDevices.ts` (top of file) for the in-code constant
     // reviewers can flip to simulate "no microphone" / "permission denied"
     // on machines with a working mic.
-    const { noMicDetected, micPermissionDenied, micUnavailable, reportRecorderError } =
-        useAudioInputDevices();
+    const {
+        noMicDetected,
+        micPermissionDenied,
+        micUnavailable,
+        reportRecorderError,
+        probeMicAccess,
+    } = useAudioInputDevices();
     // Mirror `micUnavailable` into a ref so guards inside callbacks (and
     // setTimeout-deferred work like the auto-start path) can read the
     // latest value without becoming stale closures.
@@ -558,6 +563,20 @@ const CellEditor: React.FC<CellEditorProps> = ({
     useEffect(() => {
         reportRecorderErrorRef.current = reportRecorderError;
     }, [reportRecorderError]);
+
+    // Probe real mic access (via a silent `getUserMedia` + immediate stop)
+    // whenever the user opens the audio tab. Chromium's Permissions API
+    // misreports the OS-level state on macOS and Windows, so this is the
+    // only way to disable the record button before the user clicks. The
+    // hook caches the result at module scope, so repeated tab opens and
+    // cell switches don't re-prompt or re-flash the OS recording indicator.
+    // Skipped for locked cells (the button is already disabled for other
+    // reasons; no point asking the OS for permission we won't use).
+    useEffect(() => {
+        if (activeTab !== "audio") return;
+        if (isCellLocked) return;
+        probeMicAccess();
+    }, [activeTab, isCellLocked, probeMicAccess]);
 
     const centerEditor = useCallback(() => {
         const el = cellEditorRef.current;

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -5936,7 +5936,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                 <AlertCircle className="h-4 w-4 shrink-0 !text-yellow-600 dark:!text-yellow-400" />
                                                                 <AlertDescription className="text-yellow-800 dark:text-yellow-200">
                                                                     {micPermissionDenied
-                                                                        ? "Microphone access denied. Enable microphone permissions in your system settings to record."
+                                                                        ? "Microphone access denied. Enable microphone permissions in your system settings to record — you may need to fully quit and reopen the app for the change to take effect."
                                                                         : "No microphone detected. Connect an input device to record."}
                                                                 </AlertDescription>
                                                             </Alert>

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -556,7 +556,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
         micUnavailable,
         reportRecorderError,
         probeMicAccess,
-    } = useAudioInputDevices();
+    } = useAudioInputDevices({ active: activeTab === "audio" && !isCellLocked });
     // Mirror `micUnavailable` into a ref so guards inside callbacks (and
     // setTimeout-deferred work like the auto-start path) can read the
     // latest value without becoming stale closures.

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -23,7 +23,7 @@ import { WhisperTranscriptionClient } from "./WhisperTranscriptionClient";
 import AudioWaveformWithTranscription from "./AudioWaveformWithTranscription";
 import { AudioValidationBadge } from "./AudioValidationBadge";
 import { useAudioValidationStatus } from "./hooks/useAudioValidationStatus";
-import { useAudioInputDevices } from "./hooks/useAudioInputDevices";
+import { useAudioInputDevices, type MicAvailability } from "./hooks/useAudioInputDevices";
 import SourceTextDisplay from "./SourceTextDisplay";
 import { AudioHistoryViewer } from "./AudioHistoryViewer";
 import { useMessageHandler } from "./hooks/useCentralizedMessageDispatcher";
@@ -92,6 +92,7 @@ import {
     RefreshCcw,
     ListOrdered,
     Mic,
+    MicOff,
     Play,
     Trash2,
     CircleDotDashed,
@@ -480,6 +481,14 @@ const CellEditor: React.FC<CellEditorProps> = ({
             return false;
         }
     });
+    // Timestamp of the user's most recent explicit "Re-record" click. In-flight
+    // audio loads (cache hydration / provider broadcasts) normally drop us back
+    // to the waveform via `setShowRecorder(false)`; if one resolves right after
+    // the user asks to re-record, that flip yanks them back to the waveform and
+    // causes a visible flicker + scroll jump. Audio-load hides are funneled
+    // through `hideRecorderAfterAudioLoad`, which honors this intent window so
+    // the user's explicit action wins the race.
+    const userRequestedRecorderAtRef = useRef<number>(0);
     const [isAudioLoading, setIsAudioLoading] = useState(false);
     const [isPlayAudioLoading, setIsPlayAudioLoading] = useState(false);
     const [hasAudioHistory, setHasAudioHistory] = useState<boolean>(false);
@@ -555,6 +564,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
     useEffect(() => {
         micUnavailableRef.current = micUnavailable;
     }, [micUnavailable]);
+    // Guards re-entry while the authoritative pre-record mic probe is running
+    // (the probe is async, so without this a second click could start a
+    // duplicate countdown).
+    const recordPrecheckInFlightRef = useRef(false);
     // Ref for the runtime classifier so `startActualRecording`'s deps stay
     // stable. `startActualRecording` is wrapped in `useCallback([audioUrl])`
     // and changing its deps to include a new function on every render would
@@ -645,6 +658,27 @@ const CellEditor: React.FC<CellEditorProps> = ({
             scrollTimeoutRef.current = null;
         }, 120);
     }, []);
+
+    // Window (ms) during which a just-issued "Re-record" intent suppresses an
+    // audio-load-driven swap back to the waveform.
+    const RECORDER_INTENT_WINDOW_MS = 1500;
+
+    // Hide the recorder in response to audio finishing loading — but only if the
+    // user hasn't just asked to re-record. This prevents an in-flight load from
+    // oscillating waveform↔recorder (and from triggering a scroll jump). When the
+    // user's intent is active, we leave the recorder up and skip the scroll.
+    const hideRecorderAfterAudioLoad = useCallback(
+        (opts?: { scroll?: boolean }) => {
+            if (Date.now() - userRequestedRecorderAtRef.current < RECORDER_INTENT_WINDOW_MS) {
+                return;
+            }
+            setShowRecorder(false);
+            if (opts?.scroll) {
+                scrollEditorBottomIntoView();
+            }
+        },
+        [scrollEditorBottomIntoView]
+    );
 
     // Conditionally scrolls only when part of the editor is hidden. Used when
     // opening a cell so we don't "jump" the page if the editor already fits in
@@ -956,6 +990,23 @@ const CellEditor: React.FC<CellEditorProps> = ({
         },
         [clearRecordingCountdownTimer]
     );
+
+    // Switch the audio tab into the recorder view (used by the waveform's
+    // "Re-record" button and the download view's record affordance). Records
+    // the user-intent timestamp so an in-flight audio load can't immediately
+    // bounce us back to the waveform (see `hideRecorderAfterAudioLoad`).
+    const handleShowRecorder = useCallback(() => {
+        userRequestedRecorderAtRef.current = Date.now();
+        setShowRecorder(true);
+        setCountdown(null);
+        setRecordingStartTime(null);
+        setRecordingElapsedTime(0);
+        clearRecordingCountdownTimer();
+        if (recordingTimerRef.current) {
+            clearInterval(recordingTimerRef.current);
+            recordingTimerRef.current = null;
+        }
+    }, [clearRecordingCountdownTimer]);
 
     // Recording elapsed time tracker - updates every 100ms while recording
     useEffect(() => {
@@ -2855,7 +2906,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
     // (backtranslation tab was removed; no automatic switching needed)
 
     // Audio recording functions
-    const startRecording = () => {
+    const startRecording = async () => {
         // Prevent recording if cell is locked
         if (isCellLocked) {
             setRecordingStatus("Cannot record: cell is locked");
@@ -2881,6 +2932,41 @@ const CellEditor: React.FC<CellEditorProps> = ({
         if (isRecording || countdown !== null || isStartingRecording) {
             return;
         }
+
+        // Authoritative pre-countdown mic check. The passive guard above can be
+        // stale: a permission revoked in OS settings while the editor was open
+        // doesn't always fire a reliable event (notably on Windows), so the
+        // cached/passive state may still say "available". Probe with a real
+        // `getUserMedia` (cache-bypassing) BEFORE the countdown so we never let
+        // the user count down to zero only to fail at the last moment. The OS
+        // indicator flash is acceptable here — the user explicitly asked to
+        // record. A re-entry guard prevents a duplicate countdown from a second
+        // click landing while this async probe is in flight.
+        if (recordPrecheckInFlightRef.current) {
+            return;
+        }
+        recordPrecheckInFlightRef.current = true;
+        setRecordingStatus("Checking microphone...");
+        let access: MicAvailability;
+        try {
+            access = await probeMicAccess({ force: true });
+        } finally {
+            recordPrecheckInFlightRef.current = false;
+        }
+        if (access !== "available") {
+            setRecordingStatus(
+                access === "permission-denied"
+                    ? "Microphone access denied"
+                    : "No microphone detected"
+            );
+            return;
+        }
+        // The probe may have taken a beat; bail if state changed underneath us
+        // (e.g. the user clicked stop, or recording already began).
+        if (isRecording || countdown !== null || isStartingRecording) {
+            return;
+        }
+        setRecordingStatus("");
 
         // Read configured countdown duration (set by the chapter header /
         // mobile menu and persisted in project settings). Default to 3.
@@ -3394,7 +3480,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         const resp = await fetch(cached);
                         const blob = await resp.blob();
                         setAudioBlob(blob);
-                        setShowRecorder(false);
+                        hideRecorderAfterAudioLoad();
                         setRecordingStatus("Audio loaded");
                         setIsAudioLoading(false);
                         setAudioFetchPending(false);
@@ -3591,11 +3677,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                 const resp = await fetch(attachmentCached);
                                 const blob = await resp.blob();
                                 setAudioBlob(blob);
-                                setShowRecorder(false);
                                 setRecordingStatus("Audio loaded");
                                 setIsAudioLoading(false);
                                 setAudioFetchPending(false);
-                                scrollEditorBottomIntoView();
+                                hideRecorderAfterAudioLoad({ scroll: true });
                             } catch {
                                 /* ignore, fall through to normal flow */
                             }
@@ -3838,11 +3923,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         } catch {
                             /* empty */
                         }
-                        setShowRecorder(false);
                         setRecordingStatus("Audio loaded");
                         setIsAudioLoading(false);
                         setAudioFetchPending(false);
-                        scrollEditorBottomIntoView();
+                        hideRecorderAfterAudioLoad({ scroll: true });
                         if (message.content.transcription) {
                             setSavedTranscription({
                                 content: message.content.transcription.content,
@@ -5513,7 +5597,11 @@ const CellEditor: React.FC<CellEditorProps> = ({
 
                     {activeTab === "audio" && (
                         <TabsContent value="audio">
-                            <div className="content-section space-y-6">
+                            {/* min-height keeps the section from collapsing when
+                                swapping the (taller) waveform card for the recorder
+                                card, which otherwise lets the browser's scroll
+                                anchoring "jump" the view during a re-record. */}
+                            <div className="content-section space-y-6 min-h-[260px]">
                                 <h3 className="text-lg font-medium">Audio Recording</h3>
 
                                 {(() => {
@@ -5538,6 +5626,21 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                             isStartingRecording,
                                         showRecorder,
                                     });
+
+                                    // Mic-aware copy for the download-view record
+                                    // affordance (mirrors the waveform "Re-record"
+                                    // button so the option is always reachable, even
+                                    // before the existing audio is downloaded).
+                                    const recordAffordanceLabel = micPermissionDenied
+                                        ? "Microphone access denied"
+                                        : noMicDetected
+                                          ? "No microphone detected"
+                                          : "Re-record";
+                                    const recordAffordanceTitle = isCellLocked
+                                        ? "Cannot record: cell is locked"
+                                        : micUnavailable
+                                          ? `${recordAffordanceLabel} — you can still upload an audio file`
+                                          : "Re-record / Upload New";
 
                                     const renderUploadHistoryRow = () => (
                                         <div className="flex flex-wrap items-center justify-center gap-2 mt-3 px-2">
@@ -5610,6 +5713,30 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     Back
                                                 </Button>
                                             )}
+
+                                            {mode === "download" && (
+                                                <Button
+                                                    variant="outline"
+                                                    className={
+                                                        micUnavailable
+                                                            ? "flex items-center justify-center h-8 px-2 text-xs border-red-500 text-red-600 hover:text-red-600 dark:text-red-400"
+                                                            : "flex items-center justify-center h-8 px-2 text-xs"
+                                                    }
+                                                    disabled={isCellLocked}
+                                                    title={recordAffordanceTitle}
+                                                    onClick={() => {
+                                                        if (isCellLocked) return;
+                                                        handleShowRecorder();
+                                                    }}
+                                                >
+                                                    {micUnavailable ? (
+                                                        <MicOff className="h-3 w-3 mr-1" />
+                                                    ) : (
+                                                        <Mic className="h-3 w-3 mr-1" />
+                                                    )}
+                                                    {recordAffordanceLabel}
+                                                </Button>
+                                            )}
                                         </div>
                                     );
 
@@ -5632,19 +5759,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     }}
                                                     onShowHistory={() => setShowAudioHistory(true)}
                                                     historyCount={audioHistoryCount}
-                                                    onShowRecorder={() => {
-                                                        setShowRecorder(true);
-                                                        setCountdown(null);
-                                                        setRecordingStartTime(null);
-                                                        setRecordingElapsedTime(0);
-                                                        clearRecordingCountdownTimer();
-                                                        if (recordingTimerRef.current) {
-                                                            clearInterval(
-                                                                recordingTimerRef.current
-                                                            );
-                                                            recordingTimerRef.current = null;
-                                                        }
-                                                    }}
+                                                    micUnavailable={micUnavailable}
+                                                    noMicDetected={noMicDetected}
+                                                    micPermissionDenied={micPermissionDenied}
+                                                    onShowRecorder={handleShowRecorder}
                                                     disabled={!audioBlob}
                                                     validationStatusProps={audioValidationIconProps}
                                                     author={audioAuthor}

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -5714,9 +5714,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                     ? stopRecording
                                                                     : startRecording
                                                             }
-                                                            disabled={
-                                                                isCellLocked || noMicDetected
-                                                            }
+                                                            disabled={isCellLocked}
+                                                            unavailable={noMicDetected}
                                                             title={recorderTitle}
                                                         />
 
@@ -5788,19 +5787,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             </div>
                                                         )}
                                                         {noMicDetected && (
-                                                            <span
-                                                                role="alert"
-                                                                className="text-xs text-muted-foreground inline-flex items-center gap-1"
-                                                            >
-                                                                <AlertTriangle
-                                                                    className="h-3 w-3"
-                                                                    style={{
-                                                                        color: "var(--vscode-errorForeground)",
-                                                                    }}
-                                                                />
-                                                                No microphone detected. Connect an
-                                                                input device to record.
-                                                            </span>
+                                                            <Alert className="w-fit border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
+                                                                <AlertCircle className="h-4 w-4 !text-yellow-600 dark:!text-yellow-400" />
+                                                                <AlertDescription className="text-yellow-800 dark:text-yellow-200">
+                                                                    No microphone detected. Connect
+                                                                    an input device to record.
+                                                                </AlertDescription>
+                                                            </Alert>
                                                         )}
                                                         {hint && (
                                                             <span className="text-xs text-muted-foreground inline-flex items-center gap-1">

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -388,6 +388,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
     // Audio-related state
     const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
     const [audioUrl, setAudioUrl] = useState<string | null>(null);
+    // Holds the partial audio captured when a recording was cut short by the
+    // mic going away; non-null drives the keep/discard prompt.
+    const [interruptedRecording, setInterruptedRecording] = useState<Blob | null>(null);
+    const [showInterruptedRecordingModal, setShowInterruptedRecordingModal] = useState(false);
     const [audioAuthor, setAudioAuthor] = useState<string | undefined>(undefined);
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
     // While awaiting provider response, avoid showing "No audio attached" to prevent flicker
@@ -408,6 +412,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
     const [recordingElapsedTime, setRecordingElapsedTime] = useState<number>(0);
     const audioSaveRequestIdRef = useRef<string | null>(null);
     const audioChunksRef = useRef<Blob[]>([]);
+    // Set true right before we stop the recorder because the mic became
+    // unavailable mid-recording (vs. the user pressing stop). `onstop` reads
+    // this to prompt keep/discard instead of silently saving the partial clip.
+    const recordingInterruptedRef = useRef<boolean>(false);
     const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null);
     /** Wall-clock end time for the active pre-record countdown (performance.now()). */
     const countdownEndTimeRef = useRef<number | null>(null);
@@ -877,6 +885,27 @@ const CellEditor: React.FC<CellEditorProps> = ({
 
             audioChunksRef.current = [];
 
+            // If the mic disappears mid-recording — device unplugged, or OS
+            // permission revoked while capturing — the audio track fires
+            // `ended`. Stop immediately so we persist the partial clip rather
+            // than continuing with a dead/silent stream, and surface the
+            // unavailability so the UI greys out without waiting on a
+            // (sometimes unreliable) device/permission event.
+            const handleMidRecordingMicLoss = () => {
+                reportRecorderErrorRef.current?.(
+                    Object.assign(new Error("Microphone disconnected"), {
+                        name: "NotFoundError",
+                    })
+                );
+                setRecordingStatus("Microphone disconnected");
+                if (recorder.state !== "inactive") {
+                    // Mark this as an interruption so `onstop` prompts the user
+                    // to keep or discard rather than auto-saving.
+                    recordingInterruptedRef.current = true;
+                    recorder.stop();
+                }
+            };
+
             recorder.ondataavailable = (e) => {
                 if (e.data.size > 0) {
                     audioChunksRef.current.push(e.data);
@@ -899,7 +928,25 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 // Release the microphone immediately — no further data will
                 // arrive after stop, and holding the tracks open delays the
                 // OS-level recording indicator from turning off.
+                stream.getAudioTracks().forEach((track) => {
+                    track.removeEventListener("ended", handleMidRecordingMicLoss);
+                });
                 stream.getTracks().forEach((track) => track.stop());
+
+                const rawBlob = new Blob(audioChunksRef.current, { type: "audio/webm" });
+
+                // If the mic became unavailable mid-recording we got here via an
+                // interruption, not a user-initiated stop. Don't silently save a
+                // half-finished clip — hand the raw audio to a keep/discard
+                // prompt and let the user decide. Skip the trailing trim too:
+                // there's no "stop click" to remove, and trimming would drop
+                // real audio from the abrupt end.
+                if (recordingInterruptedRef.current) {
+                    recordingInterruptedRef.current = false;
+                    setInterruptedRecording(rawBlob);
+                    setShowInterruptedRecordingModal(true);
+                    return;
+                }
 
                 // Trim a short tail off the recording to remove the click
                 // sound from the user pressing stop. Mirrors the leading
@@ -907,7 +954,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 // a small notice in the recorder UI. If the trim fails
                 // (decoder error, very short clip, etc.) the helper returns
                 // the original blob unchanged.
-                const rawBlob = new Blob(audioChunksRef.current, { type: "audio/webm" });
                 const blob = await trimRecordingTail(rawBlob, RECORDING_TAIL_TRIM_MS);
 
                 setAudioBlob(blob);
@@ -927,6 +973,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 }
                 setShowRecorder(false);
             };
+
+            stream.getAudioTracks().forEach((track) => {
+                track.addEventListener("ended", handleMidRecordingMicLoss);
+            });
 
             recorder.start();
             setMediaRecorder(recorder);
@@ -1008,6 +1058,37 @@ const CellEditor: React.FC<CellEditorProps> = ({
         }
     }, [clearRecordingCountdownTimer]);
 
+    // Keep the partial audio captured before the mic was lost: run it through
+    // the normal save path (URL + cell persistence) just like a clean stop.
+    const handleKeepInterruptedRecording = useCallback(() => {
+        const blob = interruptedRecording;
+        setShowInterruptedRecordingModal(false);
+        setInterruptedRecording(null);
+        if (!blob) {
+            return;
+        }
+        setAudioBlob(blob);
+        if (audioUrl) {
+            URL.revokeObjectURL(audioUrl);
+        }
+        const url = URL.createObjectURL(blob);
+        setAudioUrl(url);
+        setRecordingStatus("Recording complete");
+        saveAudioToCellRef.current?.(blob);
+        setShowRecorder(false);
+    }, [interruptedRecording, audioUrl]);
+
+    // Discard the interrupted clip entirely and return to the recorder so the
+    // user can try again once the mic is back. Nothing is persisted, so any
+    // previously saved audio for the cell is left untouched.
+    const handleDiscardInterruptedRecording = useCallback(() => {
+        setShowInterruptedRecordingModal(false);
+        setInterruptedRecording(null);
+        audioChunksRef.current = [];
+        setRecordingStatus("");
+        setShowRecorder(true);
+    }, []);
+
     // Recording elapsed time tracker - updates every 100ms while recording
     useEffect(() => {
         if (!isRecording || recordingStartTime === null) {
@@ -1033,6 +1114,48 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }
         };
     }, [isRecording, recordingStartTime]);
+
+    // React the instant the mic becomes unavailable (unplugged, or permission
+    // revoked in OS settings) rather than letting an in-progress flow run to a
+    // dead end:
+    //   • during the pre-record countdown / warmup → cancel it before it tries
+    //     (and fails) to open a stream, leaving the button greyed-out.
+    //   • mid-recording → stop the recorder now so we persist what was captured
+    //     instead of streaming silence (mid-recording device removal is also
+    //     caught immediately by the track `ended` listener in
+    //     `startActualRecording`; this covers detections surfaced by the hook).
+    useEffect(() => {
+        if (!micUnavailable) {
+            return;
+        }
+        const reason = micPermissionDenied
+            ? "Microphone access denied"
+            : "No microphone detected";
+
+        if (countdown !== null || isStartingRecording) {
+            clearRecordingCountdownTimer();
+            setCountdown(null);
+            setIsStartingRecording(false);
+            setRecordingStatus(reason);
+        }
+
+        if (isRecording && mediaRecorder && mediaRecorder.state !== "inactive") {
+            // `onstop` releases the tracks and the elapsed-time interval clears
+            // itself when `isRecording` flips false. Flag the interruption so
+            // `onstop` prompts the user to keep/discard the partial clip.
+            recordingInterruptedRef.current = true;
+            mediaRecorder.stop();
+            setRecordingStatus(reason);
+        }
+    }, [
+        micUnavailable,
+        micPermissionDenied,
+        countdown,
+        isStartingRecording,
+        isRecording,
+        mediaRecorder,
+        clearRecordingCountdownTimer,
+    ]);
 
     // Helper function to request audio timestamps for a cell
     const requestCellAudioTimestamps = useCallback((cellId: string): Promise<Timestamps | null> => {
@@ -4733,6 +4856,40 @@ const CellEditor: React.FC<CellEditorProps> = ({
                             }}
                         >
                             Discard
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Keep/discard prompt for a recording cut short by mic loss.
+                Dismissing (Esc / backdrop) defaults to Keep so we never silently
+                throw away captured audio. */}
+            <Dialog
+                open={showInterruptedRecordingModal}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        handleKeepInterruptedRecording();
+                    }
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Recording interrupted</DialogTitle>
+                    </DialogHeader>
+                    <div className="text-sm text-muted-foreground">
+                        Your microphone became unavailable while recording, so we
+                        stopped early. Do you want to keep what was captured up to
+                        that point, or discard it and try again?
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="destructive"
+                            onClick={handleDiscardInterruptedRecording}
+                        >
+                            Discard
+                        </Button>
+                        <Button onClick={handleKeepInterruptedRecording}>
+                            Keep recording
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -230,9 +230,16 @@ const mockTranslationUnits: QuillCellContent[] = [
 ];
 
 describe("Real Cell Editor Save Workflow Integration Tests", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.clearAllMocks();
         cleanup();
+        // The mic-availability hook keeps its probe result in a module-scoped
+        // cache; reset between tests so one test's permission state doesn't
+        // bleed into another.
+        const { __resetProbeCacheForTesting } = await import(
+            "../hooks/useAudioInputDevices"
+        );
+        __resetProbeCacheForTesting();
     });
 
     it("should render CellList with real translation units", async () => {
@@ -1011,9 +1018,29 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
                 toJSON: () => ({}),
             })) as MediaDeviceInfo[]
         );
-        fakeMediaDevices.getUserMedia =
-            opts.getUserMediaSpy ??
-            vi.fn().mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+        // Default `getUserMedia` matches the permission/device state so the
+        // tab-open probe (introduced in the silent-probe fix) returns a
+        // realistic answer. Pass `getUserMediaSpy` to override.
+        const defaultGetUserMedia = () => {
+            if (opts.permission === "denied") {
+                return vi
+                    .fn()
+                    .mockRejectedValue(
+                        Object.assign(new Error("denied"), { name: "NotAllowedError" })
+                    );
+            }
+            if (opts.audioInputs === 0) {
+                return vi
+                    .fn()
+                    .mockRejectedValue(
+                        Object.assign(new Error("no device"), { name: "NotFoundError" })
+                    );
+            }
+            return vi
+                .fn()
+                .mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+        };
+        fakeMediaDevices.getUserMedia = opts.getUserMediaSpy ?? defaultGetUserMedia();
         (navigator as any).mediaDevices = fakeMediaDevices;
 
         if (opts.permission === "missing") {
@@ -1059,11 +1086,9 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             audioAttachments: { "cell-1": "none" as const },
         };
 
-        const getUserMediaSpy = vi.fn();
         mockMicEnvironment({
             audioInputs: 0,
             permission: "granted",
-            getUserMediaSpy,
         });
 
         render(
@@ -1084,6 +1109,11 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             await screen.findByText(/Connect an input device to record/i)
         ).toBeTruthy();
 
+        // Probe fired on tab open and threw NotFoundError; that's how the
+        // warning got there. We now want to assert that *clicking the
+        // disabled button* doesn't separately reach `getUserMedia`.
+        const getUserMediaSpy = (navigator as any).mediaDevices.getUserMedia;
+        getUserMediaSpy.mockClear();
         fireEvent.click(startBtn);
         expect(getUserMediaSpy).not.toHaveBeenCalled();
     });
@@ -1119,11 +1149,11 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         };
 
         // Mic exists but permission denied — different state from no-device.
-        const getUserMediaSpy = vi.fn();
+        // Default mock returns NotAllowedError from getUserMedia so the probe
+        // catches the OS-level block exactly like a real macOS denial.
         mockMicEnvironment({
             audioInputs: 1,
             permission: "denied",
-            getUserMediaSpy,
         });
 
         render(
@@ -1148,8 +1178,81 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             screen.queryByText(/Connect an input device/i)
         ).toBeNull();
 
+        const getUserMediaSpy = (navigator as any).mediaDevices.getUserMedia;
+        getUserMediaSpy.mockClear();
         fireEvent.click(startBtn);
         expect(getUserMediaSpy).not.toHaveBeenCalled();
+    });
+
+    it("OS-level denial (macOS scenario): tab-open probe disables button even when Permissions API misreports as granted", async () => {
+        // This is the reviewer-reported bug: on macOS, denying mic access in
+        // System Settings doesn't propagate to Chromium's Permissions API,
+        // which keeps reporting "granted". The passive detection path
+        // (enumerateDevices + permissions.query) sees no problem, so the
+        // record button used to stay enabled until the user clicked it and
+        // it crashed. The probe-on-tab-open fix discovers the block by
+        // actually calling getUserMedia and observing the NotAllowedError.
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+
+        const props = {
+            cellMarkers: ["cell-1"],
+            cellContent: "<p>Test content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-1"],
+                cellContent: "<p>Test content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Test Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-1": "none" as const },
+        };
+
+        // Mic IS enumerated and Permissions API reports "granted" — the
+        // exact pre-probe passive view. Only `getUserMedia` knows the truth.
+        const getUserMediaSpy = vi.fn().mockRejectedValue(
+            Object.assign(new Error("denied at OS"), { name: "NotAllowedError" })
+        );
+        mockMicEnvironment({
+            audioInputs: 1,
+            permission: "granted",
+            getUserMediaSpy,
+        });
+
+        render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // After the tab-open probe runs, the button should flip to the
+        // permission-denied state without the user ever having clicked it.
+        const startBtn = await screen.findByRole("button", {
+            name: /Microphone access denied/i,
+        });
+        expect(startBtn.hasAttribute("disabled")).toBe(true);
+        expect(
+            await screen.findByText(/Enable microphone permissions/i)
+        ).toBeTruthy();
+        // The probe is the only thing that should have touched the API.
+        expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
     });
 
     it("auto-start with no mic: does not display countdown or call getUserMedia", async () => {
@@ -1161,11 +1264,9 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         // Default to 3s countdown so we'd see digits if the suppression failed.
         (window as any).__recordingCountdownSeconds = 3;
 
-        const getUserMediaSpy = vi.fn();
         mockMicEnvironment({
             audioInputs: 0,
             permission: "granted",
-            getUserMediaSpy,
         });
 
         const props = {
@@ -1205,9 +1306,13 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             </MockUnsavedChangesProvider>
         );
 
-        // Wait for the auto-start setTimeout (300ms) to fire and any
-        // subsequent renders to settle.
+        // Wait for the probe to land and the warning to render. The auto-
+        // start setTimeout is 300ms; wait past that so any countdown would
+        // have appeared if the suppression failed.
         await screen.findByText(/Connect an input device to record/i);
+        const getUserMediaSpy = (navigator as any).mediaDevices.getUserMedia;
+        // Probe ran; clear so the next assertion targets the auto-start path.
+        getUserMediaSpy.mockClear();
         await new Promise((r) => setTimeout(r, 400));
 
         // No countdown digits should ever have rendered.
@@ -1216,7 +1321,7 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         expect(
             screen.queryByRole("button", { name: /Starting in/i })
         ).toBeNull();
-        // And of course the stream API must never have been touched.
+        // And the auto-start path must not have touched the stream API.
         expect(getUserMediaSpy).not.toHaveBeenCalled();
     });
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -984,6 +984,50 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         (window as any).AudioContext = OriginalAudioContext;
     });
 
+    /**
+     * Helpers for setting up mock mic detection environments. The hook checks
+     * both `mediaDevices.enumerateDevices()` (for hardware presence) and
+     * `permissions.query({ name: "microphone" })` (for permission state),
+     * subscribing to `devicechange` and PermissionStatus `change` events for
+     * live updates. Both need EventTarget backing so `addEventListener`
+     * doesn't blow up.
+     */
+    function mockMicEnvironment(opts: {
+        audioInputs: number;
+        permission: "granted" | "denied" | "prompt" | "missing";
+        getUserMediaSpy?: ReturnType<typeof vi.fn>;
+    }) {
+        const fakeMediaDevices = new EventTarget() as EventTarget & {
+            enumerateDevices: ReturnType<typeof vi.fn>;
+            getUserMedia: ReturnType<typeof vi.fn>;
+        };
+        fakeMediaDevices.enumerateDevices = vi.fn().mockResolvedValue(
+            Array.from({ length: opts.audioInputs }, (_, i) => ({
+                deviceId: `mic-${i}`,
+                groupId: "g",
+                kind: "audioinput",
+                label: `Mic ${i}`,
+                toJSON: () => ({}),
+            })) as MediaDeviceInfo[]
+        );
+        fakeMediaDevices.getUserMedia =
+            opts.getUserMediaSpy ??
+            vi.fn().mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+        (navigator as any).mediaDevices = fakeMediaDevices;
+
+        if (opts.permission === "missing") {
+            delete (navigator as any).permissions;
+        } else {
+            const status = new EventTarget() as EventTarget & {
+                state: "granted" | "denied" | "prompt";
+            };
+            status.state = opts.permission;
+            (navigator as any).permissions = {
+                query: vi.fn().mockResolvedValue(status),
+            };
+        }
+    }
+
     it("no microphone detected: disables record button, shows warning, and skips getUserMedia", async () => {
         sessionStorage.setItem("preferred-editor-tab", "audio");
 
@@ -1014,17 +1058,12 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             audioAttachments: { "cell-1": "none" as const },
         };
 
-        // Mock an unplugged-mic environment: `enumerateDevices` returns no
-        // audioinput entries. `getUserMedia` is still mocked so we can verify
-        // the disabled button doesn't reach it on click.
         const getUserMediaSpy = vi.fn();
-        const fakeMediaDevices = new EventTarget() as EventTarget & {
-            enumerateDevices: ReturnType<typeof vi.fn>;
-            getUserMedia: ReturnType<typeof vi.fn>;
-        };
-        fakeMediaDevices.enumerateDevices = vi.fn().mockResolvedValue([]);
-        fakeMediaDevices.getUserMedia = getUserMediaSpy;
-        (navigator as any).mediaDevices = fakeMediaDevices;
+        mockMicEnvironment({
+            audioInputs: 0,
+            permission: "granted",
+            getUserMediaSpy,
+        });
 
         render(
             <MockUnsavedChangesProvider>
@@ -1036,19 +1075,147 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             </MockUnsavedChangesProvider>
         );
 
-        // The record button's title flips to the new state and it disables.
         const startBtn = await screen.findByRole("button", {
             name: /No microphone detected/i,
         });
         expect(startBtn.hasAttribute("disabled")).toBe(true);
-
-        // The inline warning row is rendered alongside the disabled button.
         expect(
             await screen.findByText(/Connect an input device to record/i)
         ).toBeTruthy();
 
-        // Clicking the disabled button must not attempt to open a stream.
         fireEvent.click(startBtn);
+        expect(getUserMediaSpy).not.toHaveBeenCalled();
+    });
+
+    it("permission denied: shows distinct warning text and disables record button", async () => {
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+
+        const props = {
+            cellMarkers: ["cell-1"],
+            cellContent: "<p>Test content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-1"],
+                cellContent: "<p>Test content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Test Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-1": "none" as const },
+        };
+
+        // Mic exists but permission denied — different state from no-device.
+        const getUserMediaSpy = vi.fn();
+        mockMicEnvironment({
+            audioInputs: 1,
+            permission: "denied",
+            getUserMediaSpy,
+        });
+
+        render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        const startBtn = await screen.findByRole("button", {
+            name: /Microphone access denied/i,
+        });
+        expect(startBtn.hasAttribute("disabled")).toBe(true);
+        // Permission-specific copy is shown, not the no-device copy.
+        expect(
+            await screen.findByText(/Enable microphone permissions/i)
+        ).toBeTruthy();
+        expect(
+            screen.queryByText(/Connect an input device/i)
+        ).toBeNull();
+
+        fireEvent.click(startBtn);
+        expect(getUserMediaSpy).not.toHaveBeenCalled();
+    });
+
+    it("auto-start with no mic: does not display countdown or call getUserMedia", async () => {
+        // Simulate the cell-list mic-button auto-start handoff: a session
+        // flag is set before the editor opens. When the mic is unavailable
+        // the countdown must not appear and getUserMedia must not be called.
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+        sessionStorage.setItem("start-audio-recording-cell-1", "1");
+        // Default to 3s countdown so we'd see digits if the suppression failed.
+        (window as any).__recordingCountdownSeconds = 3;
+
+        const getUserMediaSpy = vi.fn();
+        mockMicEnvironment({
+            audioInputs: 0,
+            permission: "granted",
+            getUserMediaSpy,
+        });
+
+        const props = {
+            cellMarkers: ["cell-1"],
+            cellContent: "<p>Test content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-1"],
+                cellContent: "<p>Test content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Test Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-1": "none" as const },
+        };
+
+        render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // Wait for the auto-start setTimeout (300ms) to fire and any
+        // subsequent renders to settle.
+        await screen.findByText(/Connect an input device to record/i);
+        await new Promise((r) => setTimeout(r, 400));
+
+        // No countdown digits should ever have rendered.
+        expect(screen.queryByText(/^[123]$/)).toBeNull();
+        // The button must reflect the unavailable state, never the countdown.
+        expect(
+            screen.queryByRole("button", { name: /Starting in/i })
+        ).toBeNull();
+        // And of course the stream API must never have been touched.
         expect(getUserMediaSpy).not.toHaveBeenCalled();
     });
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -984,6 +984,74 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         (window as any).AudioContext = OriginalAudioContext;
     });
 
+    it("no microphone detected: disables record button, shows warning, and skips getUserMedia", async () => {
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+
+        const props = {
+            cellMarkers: ["cell-1"],
+            cellContent: "<p>Test content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-1"],
+                cellContent: "<p>Test content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Test Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-1": "none" as const },
+        };
+
+        // Mock an unplugged-mic environment: `enumerateDevices` returns no
+        // audioinput entries. `getUserMedia` is still mocked so we can verify
+        // the disabled button doesn't reach it on click.
+        const getUserMediaSpy = vi.fn();
+        const fakeMediaDevices = new EventTarget() as EventTarget & {
+            enumerateDevices: ReturnType<typeof vi.fn>;
+            getUserMedia: ReturnType<typeof vi.fn>;
+        };
+        fakeMediaDevices.enumerateDevices = vi.fn().mockResolvedValue([]);
+        fakeMediaDevices.getUserMedia = getUserMediaSpy;
+        (navigator as any).mediaDevices = fakeMediaDevices;
+
+        render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // The record button's title flips to the new state and it disables.
+        const startBtn = await screen.findByRole("button", {
+            name: /No microphone detected/i,
+        });
+        expect(startBtn.hasAttribute("disabled")).toBe(true);
+
+        // The inline warning row is rendered alongside the disabled button.
+        expect(
+            await screen.findByText(/Connect an input device to record/i)
+        ).toBeTruthy();
+
+        // Clicking the disabled button must not attempt to open a stream.
+        fireEvent.click(startBtn);
+        expect(getUserMediaSpy).not.toHaveBeenCalled();
+    });
+
     it("locked cell: should disable Start Recording and not call getUserMedia", async () => {
         sessionStorage.setItem("preferred-editor-tab", "audio");
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -1170,9 +1170,10 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             name: /Microphone access denied/i,
         });
         expect(startBtn.hasAttribute("disabled")).toBe(true);
-        // Permission-specific copy is shown, not the no-device copy.
+        // Permission-specific copy is shown, not the no-device copy, and it
+        // tells the user a full quit & reopen may be needed (macOS TCC).
         expect(
-            await screen.findByText(/Enable microphone permissions/i)
+            await screen.findByText(/Enable microphone permissions.*quit and reopen/i)
         ).toBeTruthy();
         expect(
             screen.queryByText(/Connect an input device/i)

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -1384,6 +1384,157 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
         expect(getUserMediaSpy).not.toHaveBeenCalled();
     });
 
+    it("record click: authoritative pre-countdown probe blocks a mic revoked mid-session, before any countdown", async () => {
+        // The passive/cached state can be stale: a permission revoked in OS
+        // settings while the editor was open doesn't always fire an event
+        // (notably on Windows). Clicking record must re-check with a real
+        // getUserMedia BEFORE the countdown, so the user never counts down to
+        // zero only to fail.
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+        // Non-zero countdown so a missed pre-check would surface a digit.
+        (window as any).__recordingCountdownSeconds = 3;
+
+        // Start out healthy: mic present, permission granted, getUserMedia
+        // resolves — so the tab-open probe enables the record button.
+        mockMicEnvironment({ audioInputs: 1, permission: "granted" });
+
+        const props = {
+            cellMarkers: ["cell-1"],
+            cellContent: "<p>Test content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-1"],
+                cellContent: "<p>Test content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Test Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-1": "none" as const },
+        };
+
+        render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // Button is enabled once the tab-open probe lands.
+        const startBtn = await screen.findByRole("button", {
+            name: /Start Recording/i,
+        });
+        expect(startBtn.hasAttribute("disabled")).toBe(false);
+
+        // Now the user revokes mic access in OS settings — no event fires, so
+        // the passive state still says available. Only a real probe knows.
+        const revokedSpy = vi.fn().mockRejectedValue(
+            Object.assign(new Error("revoked"), { name: "NotAllowedError" })
+        );
+        (navigator as any).mediaDevices.getUserMedia = revokedSpy;
+
+        fireEvent.click(startBtn);
+
+        // The forced pre-countdown probe catches the denial and surfaces the
+        // warning — without ever starting the countdown.
+        await screen.findByText(/Enable microphone permissions/i);
+        expect(revokedSpy).toHaveBeenCalledTimes(1);
+
+        // No countdown digit and no "Starting in" state ever rendered.
+        expect(screen.queryByText(/^[123]$/)).toBeNull();
+        expect(
+            screen.queryByRole("button", { name: /Starting in/i })
+        ).toBeNull();
+    });
+
+    it("download view: offers a Re-record option that switches into the recorder", async () => {
+        // When audio exists but isn't downloaded yet, the user still needs a
+        // way to record over it — not only the download/upload buttons.
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+        // Force the download view deterministically (auto-download off), then
+        // restore the prior globals so we don't perturb sibling tests that
+        // rely on the leaked auto-download-on state.
+        const prevAutoInit = (window as any).__autoDownloadAudioOnOpenInitialized;
+        const prevAutoFlag = (window as any).__autoDownloadAudioOnOpen;
+        (window as any).__autoDownloadAudioOnOpenInitialized = true;
+        (window as any).__autoDownloadAudioOnOpen = false;
+        mockMicEnvironment({ audioInputs: 1, permission: "granted" });
+
+        const props = {
+            cellMarkers: ["cell-dl"],
+            cellContent: "<p>Has remote audio</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-dl"],
+                cellContent: "<p>Has remote audio</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Download Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-dl": "available" as const },
+        };
+
+        const { container } = render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // Confirms we're in the download view (audio not yet local).
+        await screen.findByText(/Click to download/i);
+
+        // The new record affordance is present and switches to the recorder.
+        const reRecordBtn = await screen.findByRole("button", { name: /Re-record/i });
+        fireEvent.click(reRecordBtn);
+
+        await waitFor(() => {
+            const el = container.querySelector(
+                'input#audio-file-input[type="file"]'
+            ) as HTMLInputElement | null;
+            expect(el).toBeTruthy();
+        });
+        // The recorder's "Start Recording" affordance is now shown.
+        expect(
+            await screen.findByRole("button", { name: /Start Recording/i })
+        ).toBeTruthy();
+
+        // Restore globals for sibling tests.
+        (window as any).__autoDownloadAudioOnOpenInitialized = prevAutoInit;
+        (window as any).__autoDownloadAudioOnOpen = prevAutoFlag;
+    });
+
     it("locked cell: audio upload should NOT post saveAudioAttachment", async () => {
         sessionStorage.setItem("preferred-editor-tab", "audio");
 
@@ -1527,6 +1678,108 @@ describe("Real Cell Editor Save Workflow Integration Tests", () => {
             (args: any[]) => args?.[0]?.command === "saveAudioAttachment"
         );
         expect(postedSave).toBe(false);
+    });
+
+    it("re-record: an in-flight provider audio broadcast does NOT yank the user back to the waveform", async () => {
+        // Repro for the re-record glitch: after the user clicks "Re-record",
+        // an audio load that resolves a moment later used to flip
+        // `showRecorder` back to false (waveform), causing a flicker + scroll
+        // jump. The intent guard must keep the recorder up within the window.
+        sessionStorage.setItem("preferred-editor-tab", "audio");
+        mockMicEnvironment({ audioInputs: 1, permission: "granted" });
+
+        const props = {
+            cellMarkers: ["cell-rr"],
+            cellContent: "<p>Re-record content</p>",
+            editHistory: mockTranslationUnits[0].editHistory,
+            cellIndex: 0,
+            cellType: CodexCellTypes.TEXT,
+            contentBeingUpdated: {
+                cellMarkers: ["cell-rr"],
+                cellContent: "<p>Re-record content</p>",
+                cellChanged: false,
+            },
+            setContentBeingUpdated: vi.fn(),
+            handleCloseEditor: vi.fn(),
+            handleSaveHtml: vi.fn(),
+            textDirection: "ltr" as const,
+            cellLabel: "Re-record Label",
+            cellTimestamps: { startTime: 0, endTime: 5 },
+            cellIsChild: false,
+            openCellById: vi.fn(),
+            cell: mockTranslationUnits[0],
+            isSaving: false,
+            saveError: false,
+            saveRetryCount: 0,
+            footnoteOffset: 1,
+            audioAttachments: { "cell-rr": "available" as const },
+        };
+
+        const { container } = render(
+            <MockUnsavedChangesProvider>
+                <MockSourceCellProvider>
+                    <MockScrollToContentProvider>
+                        <CellEditor {...props} />
+                    </MockScrollToContentProvider>
+                </MockSourceCellProvider>
+            </MockUnsavedChangesProvider>
+        );
+
+        // Load audio so the waveform (with its "Re-record" button) renders.
+        window.dispatchEvent(
+            new MessageEvent("message", {
+                data: {
+                    type: "providerSendsAudioData",
+                    content: {
+                        cellId: "cell-rr",
+                        audioData: "data:audio/webm;base64,test",
+                        audioId: "audio-rr-1",
+                    },
+                },
+            })
+        );
+
+        // Wait for the audio to land in the waveform first (download affordance
+        // gone), so the "Re-record" we click is the stable waveform button —
+        // not the download-view button that unmounts once the waveform renders.
+        await waitFor(() => {
+            expect(screen.queryByText(/Click to download/i)).toBeNull();
+            expect(screen.getByText(/Transcribe/i)).toBeTruthy();
+        });
+
+        // User explicitly asks to re-record → recorder view.
+        fireEvent.click(screen.getByRole("button", { name: /Re-record/i }));
+
+        await waitFor(() => {
+            const el = container.querySelector(
+                'input#audio-file-input[type="file"]'
+            ) as HTMLInputElement | null;
+            expect(el).toBeTruthy();
+        });
+
+        // An in-flight load resolves right after the click — this must NOT flip
+        // the view back to the waveform within the intent window.
+        window.dispatchEvent(
+            new MessageEvent("message", {
+                data: {
+                    type: "providerSendsAudioData",
+                    content: {
+                        cellId: "cell-rr",
+                        audioData: "data:audio/webm;base64,test",
+                        audioId: "audio-rr-1",
+                    },
+                },
+            })
+        );
+
+        // Let the async audio handler run.
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Still in recorder mode: file input present, no "Re-record" button.
+        expect(
+            container.querySelector('input#audio-file-input[type="file"]')
+        ).toBeTruthy();
+        expect(screen.queryByRole("button", { name: /Re-record/i })).toBeNull();
     });
 
     describe("Audio Loading State Fix Tests", () => {

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -568,38 +568,64 @@ describe("useAudioInputDevices", () => {
         });
     });
 
-    describe("flash-free passive refresh on window focus", () => {
+    describe("refresh on window focus", () => {
         // A mic permission can only change while the user is away from the
-        // window, so regaining focus is the cheapest moment to refresh. The
-        // refresh is *passive* (enumerateDevices + Permissions API) — it never
-        // calls getUserMedia, so the OS recording indicator never flashes.
-        it("re-evaluates passively on focus and recovers when permission is re-granted, without calling getUserMedia", async () => {
+        // window, so regaining focus is the moment to refresh. When the recorder
+        // UI is on screen (`active`) we run an authoritative probe that updates
+        // state in BOTH directions (allowed↔denied). When inactive we only
+        // invalidate the cache (no probe, no OS indicator flash).
+        it("re-probes on focus while active and recovers when permission is re-granted (denied→allowed)", async () => {
             const fake = createFakeMediaDevices([audioInputDevice()]);
             (navigator as any).mediaDevices = fake;
             const status = createFakePermissionStatus("denied");
             (navigator as any).permissions = createFakePermissions(status);
+            // Mount detects denial passively (Permissions API). getUserMedia is
+            // only hit by the focus probe, which now succeeds (re-enabled).
             const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
             fake.getUserMedia = getUserMediaSpy;
 
-            const { result } = renderHook(() => useAudioInputDevices());
+            const { result } = renderHook(() => useAudioInputDevices({ active: true }));
             await waitFor(() =>
                 expect(result.current.availability).toBe("permission-denied")
             );
 
-            // User re-enabled the mic in OS settings while away. The Permissions
-            // API now reads granted; returning focus should pick that up.
             status.state = "granted";
             await act(async () => {
                 window.dispatchEvent(new Event("focus"));
             });
 
             await waitFor(() => expect(result.current.availability).toBe("available"));
-            // Flash-free: the focus refresh must not open the mic.
-            expect(getUserMediaSpy).not.toHaveBeenCalled();
+            expect(getUserMediaSpy).toHaveBeenCalled();
             expect(result.current.micUnavailable).toBe(false);
         });
 
-        it("nulls the probe cache on focus so the next audio-tab probe re-runs getUserMedia", async () => {
+        it("re-probes on focus while active and detects a revocation (allowed→denied)", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+            // Mount sees granted (passive). The OS-level access was revoked while
+            // away, so the authoritative focus probe rejects.
+            const getUserMediaSpy = vi.fn().mockRejectedValue(
+                Object.assign(new Error("revoked"), { name: "NotAllowedError" })
+            );
+            fake.getUserMedia = getUserMediaSpy;
+
+            const { result } = renderHook(() => useAudioInputDevices({ active: true }));
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+            });
+
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+            expect(getUserMediaSpy).toHaveBeenCalled();
+        });
+
+        it("does NOT probe on focus when inactive — just invalidates the cache (no flash)", async () => {
             const fake = createFakeMediaDevices([audioInputDevice()]);
             const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
             fake.getUserMedia = getUserMediaSpy;
@@ -608,6 +634,7 @@ describe("useAudioInputDevices", () => {
                 createFakePermissionStatus("granted")
             );
 
+            // No `active` flag → the recorder UI isn't on screen.
             const { result } = renderHook(() => useAudioInputDevices());
             await waitFor(() => expect(result.current.availability).toBe("available"));
 
@@ -617,7 +644,7 @@ describe("useAudioInputDevices", () => {
             });
             expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
 
-            // Focus is passive — it invalidates the cache but must not probe.
+            // Inactive focus must not probe (no flash) — only invalidate cache.
             await act(async () => {
                 window.dispatchEvent(new Event("focus"));
             });
@@ -630,25 +657,82 @@ describe("useAudioInputDevices", () => {
             expect(getUserMediaSpy).toHaveBeenCalledTimes(2);
         });
 
-        it("debounces rapid focus events into a single passive re-evaluate", async () => {
+        it("recovers on a host-relayed windowFocusChanged message (VS Code webview path)", async () => {
+            // Webview iframes don't get native focus events on OS app-switch, so
+            // the extension host relays `vscode.window.onDidChangeWindowState` as
+            // a `windowFocusChanged` message. It must drive the same authoritative
+            // re-probe as a native focus event.
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            const status = createFakePermissionStatus("denied");
+            (navigator as any).permissions = createFakePermissions(status);
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+
+            const { result } = renderHook(() => useAudioInputDevices({ active: true }));
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+
+            status.state = "granted";
+            await act(async () => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: { type: "windowFocusChanged", focused: true },
+                    })
+                );
+            });
+
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+            expect(getUserMediaSpy).toHaveBeenCalled();
+        });
+
+        it("ignores a windowFocusChanged message with focused=false", async () => {
             const fake = createFakeMediaDevices([audioInputDevice()]);
             (navigator as any).mediaDevices = fake;
             (navigator as any).permissions = createFakePermissions(
                 createFakePermissionStatus("granted")
             );
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
 
-            const { result } = renderHook(() => useAudioInputDevices());
+            const { result } = renderHook(() => useAudioInputDevices({ active: true }));
             await waitFor(() => expect(result.current.availability).toBe("available"));
 
-            // Mount ran one evaluate (1 enumerateDevices call). Two focus events
-            // inside the cooldown window must collapse to a single extra evaluate.
-            const before = fake.enumerateDevices.mock.calls.length;
+            await act(async () => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: { type: "windowFocusChanged", focused: false },
+                    })
+                );
+            });
+
+            // A blur (focused=false) must not trigger a re-probe.
+            expect(getUserMediaSpy).not.toHaveBeenCalled();
+        });
+
+        it("debounces rapid focus events into a single authoritative probe", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("denied")
+            );
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+
+            const { result } = renderHook(() => useAudioInputDevices({ active: true }));
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+
+            // Two focus events inside the cooldown window collapse to one probe.
             await act(async () => {
                 window.dispatchEvent(new Event("focus"));
                 window.dispatchEvent(new Event("focus"));
             });
 
-            expect(fake.enumerateDevices.mock.calls.length).toBe(before + 1);
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -502,41 +502,9 @@ describe("useAudioInputDevices", () => {
             expect(second.result.current.availability).toBe("permission-denied");
             expect(second.result.current.micPermissionDenied).toBe(true);
         });
-    });
 
-    describe("self-heal on window focus (permission-denied only)", () => {
-        // A mic permission can only change while the user is away from the
-        // window, so regaining focus is the cheapest moment to re-check.
-        // This is gated to permission-denied: hardware changes already have a
-        // live `devicechange` signal and must NOT trigger a focus probe.
-        it("re-probes on window focus and recovers to available after access is re-granted", async () => {
+        it("force re-runs getUserMedia even when a verdict is already cached", async () => {
             const fake = createFakeMediaDevices([audioInputDevice()]);
-            // Passive layer reports the initial blocked state...
-            (navigator as any).mediaDevices = fake;
-            (navigator as any).permissions = createFakePermissions(
-                createFakePermissionStatus("denied")
-            );
-            // ...but getUserMedia would now succeed (user just granted access
-            // in OS settings and returned to the window).
-            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
-            fake.getUserMedia = getUserMediaSpy;
-
-            const { result } = renderHook(() => useAudioInputDevices());
-            await waitFor(() =>
-                expect(result.current.availability).toBe("permission-denied")
-            );
-
-            await act(async () => {
-                window.dispatchEvent(new Event("focus"));
-            });
-
-            await waitFor(() => expect(result.current.availability).toBe("available"));
-            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
-            expect(result.current.micUnavailable).toBe(false);
-        });
-
-        it("does NOT re-probe on focus for no-device (devicechange covers hardware)", async () => {
-            const fake = createFakeMediaDevices([]); // no audio inputs
             const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
             fake.getUserMedia = getUserMediaSpy;
             (navigator as any).mediaDevices = fake;
@@ -545,27 +513,151 @@ describe("useAudioInputDevices", () => {
             );
 
             const { result } = renderHook(() => useAudioInputDevices());
-            await waitFor(() => expect(result.current.availability).toBe("no-device"));
+            await waitFor(() => expect(result.current.availability).toBe("available"));
 
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+
+            // A normal call is a cache hit (no extra probe)...
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+
+            // ...but `force` bypasses the cache and returns the fresh verdict.
+            let forced: string | undefined;
+            await act(async () => {
+                forced = await result.current.probeMicAccess({ force: true });
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(2);
+            expect(forced).toBe("available");
+        });
+
+        it("force re-probe flips to permission-denied when access was revoked since the cached verdict", async () => {
+            // The pre-record-countdown case: passive/cached state still says
+            // available (no event fired), but the user revoked access in OS
+            // settings. A forced probe must catch it before the countdown.
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(result.current.availability).toBe("available");
+
+            getUserMediaSpy.mockRejectedValue(
+                Object.assign(new Error("revoked"), { name: "NotAllowedError" })
+            );
+
+            let forced: string | undefined;
+            await act(async () => {
+                forced = await result.current.probeMicAccess({ force: true });
+            });
+            expect(forced).toBe("permission-denied");
+            expect(result.current.availability).toBe("permission-denied");
+        });
+    });
+
+    describe("flash-free passive refresh on window focus", () => {
+        // A mic permission can only change while the user is away from the
+        // window, so regaining focus is the cheapest moment to refresh. The
+        // refresh is *passive* (enumerateDevices + Permissions API) — it never
+        // calls getUserMedia, so the OS recording indicator never flashes.
+        it("re-evaluates passively on focus and recovers when permission is re-granted, without calling getUserMedia", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            const status = createFakePermissionStatus("denied");
+            (navigator as any).permissions = createFakePermissions(status);
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+
+            // User re-enabled the mic in OS settings while away. The Permissions
+            // API now reads granted; returning focus should pick that up.
+            status.state = "granted";
             await act(async () => {
                 window.dispatchEvent(new Event("focus"));
             });
 
-            // The focus listener only attaches for permission-denied, so a
-            // no-device state must not waste a getUserMedia call.
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+            // Flash-free: the focus refresh must not open the mic.
             expect(getUserMediaSpy).not.toHaveBeenCalled();
-            expect(result.current.availability).toBe("no-device");
+            expect(result.current.micUnavailable).toBe(false);
         });
 
-        it("debounces rapid focus events into a single probe while still denied", async () => {
+        it("nulls the probe cache on focus so the next audio-tab probe re-runs getUserMedia", async () => {
             const fake = createFakeMediaDevices([audioInputDevice()]);
-            // Still denied (e.g. macOS — TCC pins the verdict to the process),
-            // so the probe keeps rejecting and the listener stays attached.
-            const getUserMediaSpy = vi.fn().mockRejectedValue(
-                Object.assign(new Error("still denied"), { name: "NotAllowedError" })
-            );
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
             fake.getUserMedia = getUserMediaSpy;
             (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            // First probe caches "available".
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+
+            // Focus is passive — it invalidates the cache but must not probe.
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+
+            // Because focus nulled the cache, the next probe re-runs fresh.
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("debounces rapid focus events into a single passive re-evaluate", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            // Mount ran one evaluate (1 enumerateDevices call). Two focus events
+            // inside the cooldown window must collapse to a single extra evaluate.
+            const before = fake.enumerateDevices.mock.calls.length;
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+                window.dispatchEvent(new Event("focus"));
+            });
+
+            expect(fake.enumerateDevices.mock.calls.length).toBe(before + 1);
+        });
+    });
+
+    describe("recovery from a lingering denied state", () => {
+        it("reportRecorderError(null) recovers availability to available from a passively-denied state", async () => {
+            // The passive layer is stuck reporting denied (e.g. Chromium's
+            // Permissions API still says denied right after the user re-enabled
+            // the mic). A successful record is ground truth and must clear it.
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
             (navigator as any).permissions = createFakePermissions(
                 createFakePermissionStatus("denied")
             );
@@ -575,14 +667,40 @@ describe("useAudioInputDevices", () => {
                 expect(result.current.availability).toBe("permission-denied")
             );
 
-            // Two focus events inside the cooldown window collapse to one probe.
-            await act(async () => {
-                window.dispatchEvent(new Event("focus"));
-                window.dispatchEvent(new Event("focus"));
+            act(() => {
+                result.current.reportRecorderError(null);
             });
 
-            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+            expect(result.current.availability).toBe("available");
+            expect(result.current.micUnavailable).toBe(false);
+        });
+
+        it("clears a denied runtime-override pin when permission transitions to granted", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).mediaDevices = fake;
+            const status = createFakePermissionStatus("granted");
+            (navigator as any).permissions = createFakePermissions(status);
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            // A real getUserMedia failure pins denied (outranks passive granted).
+            act(() => {
+                result.current.reportRecorderError(
+                    Object.assign(new Error(), { name: "NotAllowedError" })
+                );
+            });
             expect(result.current.availability).toBe("permission-denied");
+
+            // A genuine permission `change` to granted is a reliable signal the
+            // earlier denial no longer holds, so the pin must clear.
+            status.state = "granted";
+            act(() => {
+                status.dispatchEvent(new Event("change"));
+            });
+
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+            expect(result.current.micPermissionDenied).toBe(false);
         });
     });
 });

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -3,21 +3,48 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import { useAudioInputDevices } from "../hooks/useAudioInputDevices";
 
 /**
- * Tests for the microphone detection hook used by the audio recorder.
+ * Tests for the microphone availability hook used by the audio recorder.
  *
- * We back the mock with a real `EventTarget` so `devicechange` listeners
- * can be exercised via genuine `dispatchEvent` calls — the same path the
- * browser uses when a mic is plugged in or unplugged.
+ * Backed by real EventTargets so `devicechange` and PermissionStatus
+ * `change` events can be exercised via genuine `dispatchEvent` calls —
+ * the same path the browser uses on hot-plug or permission change.
  */
 
 type FakeMediaDevices = EventTarget & {
     enumerateDevices: ReturnType<typeof vi.fn>;
 };
 
+type FakePermissionStatus = EventTarget & { state: "granted" | "denied" | "prompt" };
+type FakePermissions = {
+    query: ReturnType<typeof vi.fn>;
+};
+
 function createFakeMediaDevices(devices: MediaDeviceInfo[]): FakeMediaDevices {
     const target = new EventTarget() as FakeMediaDevices;
     target.enumerateDevices = vi.fn().mockResolvedValue(devices);
     return target;
+}
+
+function createFakePermissionStatus(
+    state: "granted" | "denied" | "prompt"
+): FakePermissionStatus {
+    const status = new EventTarget() as FakePermissionStatus;
+    status.state = state;
+    return status;
+}
+
+function createFakePermissions(status: FakePermissionStatus | null): FakePermissions {
+    return {
+        query: vi.fn().mockImplementation(async ({ name }: { name: string }) => {
+            if (name !== "microphone") {
+                throw new Error(`unsupported permission name: ${name}`);
+            }
+            if (!status) {
+                throw new Error("permission query not supported");
+            }
+            return status;
+        }),
+    };
 }
 
 function audioInputDevice(label = "Mock Mic"): MediaDeviceInfo {
@@ -42,77 +69,122 @@ function videoInputDevice(): MediaDeviceInfo {
 
 describe("useAudioInputDevices", () => {
     const originalMediaDevices = (navigator as any).mediaDevices;
-
-    beforeEach(() => {
-        delete (window as any).__forceNoAudioInput;
-    });
+    const originalPermissions = (navigator as any).permissions;
 
     afterEach(() => {
-        // Always restore — some tests delete mediaDevices entirely.
         if (originalMediaDevices) {
             (navigator as any).mediaDevices = originalMediaDevices;
         } else {
             delete (navigator as any).mediaDevices;
         }
+        if (originalPermissions) {
+            (navigator as any).permissions = originalPermissions;
+        } else {
+            delete (navigator as any).permissions;
+        }
     });
 
-    it("reports hasAudioInput=true when at least one audioinput device exists", async () => {
+    it("reports availability=available when a mic exists and permission is granted", async () => {
         (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+        (navigator as any).permissions = createFakePermissions(
+            createFakePermissionStatus("granted")
+        );
 
         const { result } = renderHook(() => useAudioInputDevices());
 
-        await waitFor(() => expect(result.current.isChecking).toBe(false));
-        expect(result.current.hasAudioInput).toBe(true);
-        expect(result.current.isSupported).toBe(true);
+        await waitFor(() => expect(result.current.availability).toBe("available"));
+        expect(result.current.micUnavailable).toBe(false);
+        expect(result.current.noMicDetected).toBe(false);
+        expect(result.current.micPermissionDenied).toBe(false);
     });
 
-    it("reports hasAudioInput=false when only non-audio devices are present", async () => {
+    it("reports no-device when only non-audio devices are present", async () => {
         (navigator as any).mediaDevices = createFakeMediaDevices([videoInputDevice()]);
+        (navigator as any).permissions = createFakePermissions(
+            createFakePermissionStatus("granted")
+        );
 
         const { result } = renderHook(() => useAudioInputDevices());
 
-        await waitFor(() => expect(result.current.isChecking).toBe(false));
-        expect(result.current.hasAudioInput).toBe(false);
+        await waitFor(() => expect(result.current.availability).toBe("no-device"));
+        expect(result.current.noMicDetected).toBe(true);
+        expect(result.current.micPermissionDenied).toBe(false);
+        expect(result.current.micUnavailable).toBe(true);
     });
 
-    it("re-checks on devicechange when a mic is plugged in mid-session", async () => {
+    it("reports permission-denied even when a mic IS enumerated", async () => {
+        (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+        (navigator as any).permissions = createFakePermissions(
+            createFakePermissionStatus("denied")
+        );
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        await waitFor(() =>
+            expect(result.current.availability).toBe("permission-denied")
+        );
+        expect(result.current.micPermissionDenied).toBe(true);
+        expect(result.current.noMicDetected).toBe(false);
+        expect(result.current.micUnavailable).toBe(true);
+    });
+
+    it("re-evaluates on devicechange when a mic is plugged in mid-session", async () => {
         const fake = createFakeMediaDevices([]);
         (navigator as any).mediaDevices = fake;
+        (navigator as any).permissions = createFakePermissions(
+            createFakePermissionStatus("granted")
+        );
 
         const { result } = renderHook(() => useAudioInputDevices());
 
-        // Initial state: no audio input
-        await waitFor(() => expect(result.current.isChecking).toBe(false));
-        expect(result.current.hasAudioInput).toBe(false);
+        await waitFor(() => expect(result.current.availability).toBe("no-device"));
 
-        // Simulate plugging in a mic: next enumerate returns a device,
-        // then the browser fires `devicechange`.
         fake.enumerateDevices.mockResolvedValueOnce([audioInputDevice("Plugged-in Mic")]);
         act(() => {
             fake.dispatchEvent(new Event("devicechange"));
         });
 
-        await waitFor(() => expect(result.current.hasAudioInput).toBe(true));
+        await waitFor(() => expect(result.current.availability).toBe("available"));
     });
 
-    it("honors window.__forceNoAudioInput even when a real mic is enumerated", async () => {
-        (window as any).__forceNoAudioInput = true;
+    it("re-evaluates when microphone permission changes mid-session", async () => {
         (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+        const status = createFakePermissionStatus("granted");
+        (navigator as any).permissions = createFakePermissions(status);
 
         const { result } = renderHook(() => useAudioInputDevices());
 
-        await waitFor(() => expect(result.current.isChecking).toBe(false));
-        expect(result.current.hasAudioInput).toBe(false);
+        await waitFor(() => expect(result.current.availability).toBe("available"));
+
+        // User revokes mic access via system settings.
+        status.state = "denied";
+        act(() => {
+            status.dispatchEvent(new Event("change"));
+        });
+
+        await waitFor(() =>
+            expect(result.current.availability).toBe("permission-denied")
+        );
     });
 
-    it("falls back to isSupported=false when enumerateDevices is missing", () => {
+    it("falls back to unsupported when enumerateDevices is missing", () => {
         (navigator as any).mediaDevices = {} as MediaDevices;
 
         const { result } = renderHook(() => useAudioInputDevices());
 
-        expect(result.current.isSupported).toBe(false);
-        // Conservative default: assume present so we never false-positive disable.
-        expect(result.current.hasAudioInput).toBe(true);
-        expect(result.current.isChecking).toBe(false);
+        expect(result.current.availability).toBe("unsupported");
+        // Treated as "assume available" so we never false-positive disable.
+        expect(result.current.micUnavailable).toBe(false);
+    });
+
+    it("treats missing permissions API as 'assume granted' (no false denial)", async () => {
+        (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+        // No `navigator.permissions` at all.
+        delete (navigator as any).permissions;
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        await waitFor(() => expect(result.current.availability).toBe("available"));
+        expect(result.current.micPermissionDenied).toBe(false);
     });
 });

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useAudioInputDevices } from "../hooks/useAudioInputDevices";
+
+/**
+ * Tests for the microphone detection hook used by the audio recorder.
+ *
+ * We back the mock with a real `EventTarget` so `devicechange` listeners
+ * can be exercised via genuine `dispatchEvent` calls — the same path the
+ * browser uses when a mic is plugged in or unplugged.
+ */
+
+type FakeMediaDevices = EventTarget & {
+    enumerateDevices: ReturnType<typeof vi.fn>;
+};
+
+function createFakeMediaDevices(devices: MediaDeviceInfo[]): FakeMediaDevices {
+    const target = new EventTarget() as FakeMediaDevices;
+    target.enumerateDevices = vi.fn().mockResolvedValue(devices);
+    return target;
+}
+
+function audioInputDevice(label = "Mock Mic"): MediaDeviceInfo {
+    return {
+        deviceId: `mock-${label}`,
+        groupId: "group-1",
+        kind: "audioinput",
+        label,
+        toJSON: () => ({}),
+    } as MediaDeviceInfo;
+}
+
+function videoInputDevice(): MediaDeviceInfo {
+    return {
+        deviceId: "mock-cam",
+        groupId: "group-2",
+        kind: "videoinput",
+        label: "Mock Cam",
+        toJSON: () => ({}),
+    } as MediaDeviceInfo;
+}
+
+describe("useAudioInputDevices", () => {
+    const originalMediaDevices = (navigator as any).mediaDevices;
+
+    beforeEach(() => {
+        delete (window as any).__forceNoAudioInput;
+    });
+
+    afterEach(() => {
+        // Always restore — some tests delete mediaDevices entirely.
+        if (originalMediaDevices) {
+            (navigator as any).mediaDevices = originalMediaDevices;
+        } else {
+            delete (navigator as any).mediaDevices;
+        }
+    });
+
+    it("reports hasAudioInput=true when at least one audioinput device exists", async () => {
+        (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        await waitFor(() => expect(result.current.isChecking).toBe(false));
+        expect(result.current.hasAudioInput).toBe(true);
+        expect(result.current.isSupported).toBe(true);
+    });
+
+    it("reports hasAudioInput=false when only non-audio devices are present", async () => {
+        (navigator as any).mediaDevices = createFakeMediaDevices([videoInputDevice()]);
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        await waitFor(() => expect(result.current.isChecking).toBe(false));
+        expect(result.current.hasAudioInput).toBe(false);
+    });
+
+    it("re-checks on devicechange when a mic is plugged in mid-session", async () => {
+        const fake = createFakeMediaDevices([]);
+        (navigator as any).mediaDevices = fake;
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        // Initial state: no audio input
+        await waitFor(() => expect(result.current.isChecking).toBe(false));
+        expect(result.current.hasAudioInput).toBe(false);
+
+        // Simulate plugging in a mic: next enumerate returns a device,
+        // then the browser fires `devicechange`.
+        fake.enumerateDevices.mockResolvedValueOnce([audioInputDevice("Plugged-in Mic")]);
+        act(() => {
+            fake.dispatchEvent(new Event("devicechange"));
+        });
+
+        await waitFor(() => expect(result.current.hasAudioInput).toBe(true));
+    });
+
+    it("honors window.__forceNoAudioInput even when a real mic is enumerated", async () => {
+        (window as any).__forceNoAudioInput = true;
+        (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        await waitFor(() => expect(result.current.isChecking).toBe(false));
+        expect(result.current.hasAudioInput).toBe(false);
+    });
+
+    it("falls back to isSupported=false when enumerateDevices is missing", () => {
+        (navigator as any).mediaDevices = {} as MediaDevices;
+
+        const { result } = renderHook(() => useAudioInputDevices());
+
+        expect(result.current.isSupported).toBe(false);
+        // Conservative default: assume present so we never false-positive disable.
+        expect(result.current.hasAudioInput).toBe(true);
+        expect(result.current.isChecking).toBe(false);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -503,4 +503,86 @@ describe("useAudioInputDevices", () => {
             expect(second.result.current.micPermissionDenied).toBe(true);
         });
     });
+
+    describe("self-heal on window focus (permission-denied only)", () => {
+        // A mic permission can only change while the user is away from the
+        // window, so regaining focus is the cheapest moment to re-check.
+        // This is gated to permission-denied: hardware changes already have a
+        // live `devicechange` signal and must NOT trigger a focus probe.
+        it("re-probes on window focus and recovers to available after access is re-granted", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            // Passive layer reports the initial blocked state...
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("denied")
+            );
+            // ...but getUserMedia would now succeed (user just granted access
+            // in OS settings and returned to the window).
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+            });
+
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+            expect(result.current.micUnavailable).toBe(false);
+        });
+
+        it("does NOT re-probe on focus for no-device (devicechange covers hardware)", async () => {
+            const fake = createFakeMediaDevices([]); // no audio inputs
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("no-device"));
+
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+            });
+
+            // The focus listener only attaches for permission-denied, so a
+            // no-device state must not waste a getUserMedia call.
+            expect(getUserMediaSpy).not.toHaveBeenCalled();
+            expect(result.current.availability).toBe("no-device");
+        });
+
+        it("debounces rapid focus events into a single probe while still denied", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            // Still denied (e.g. macOS — TCC pins the verdict to the process),
+            // so the probe keeps rejecting and the listener stays attached.
+            const getUserMediaSpy = vi.fn().mockRejectedValue(
+                Object.assign(new Error("still denied"), { name: "NotAllowedError" })
+            );
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("denied")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() =>
+                expect(result.current.availability).toBe("permission-denied")
+            );
+
+            // Two focus events inside the cooldown window collapse to one probe.
+            await act(async () => {
+                window.dispatchEvent(new Event("focus"));
+                window.dispatchEvent(new Event("focus"));
+            });
+
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+            expect(result.current.availability).toBe("permission-denied");
+        });
+    });
 });

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useAudioInputDevices } from "../hooks/useAudioInputDevices";
+import {
+    useAudioInputDevices,
+    __resetProbeCacheForTesting,
+} from "../hooks/useAudioInputDevices";
 
 /**
  * Tests for the microphone availability hook used by the audio recorder.
@@ -12,7 +15,17 @@ import { useAudioInputDevices } from "../hooks/useAudioInputDevices";
 
 type FakeMediaDevices = EventTarget & {
     enumerateDevices: ReturnType<typeof vi.fn>;
+    getUserMedia?: ReturnType<typeof vi.fn>;
 };
+
+/** Make a fake MediaStream whose tracks can be stopped. */
+function fakeStream(): MediaStream {
+    const trackStops: Array<() => void> = [];
+    const tracks: MediaStreamTrack[] = [
+        { stop: () => trackStops.forEach((s) => s()) } as MediaStreamTrack,
+    ];
+    return { getTracks: () => tracks } as MediaStream;
+}
 
 type FakePermissionStatus = EventTarget & { state: "granted" | "denied" | "prompt" };
 type FakePermissions = {
@@ -70,6 +83,13 @@ function videoInputDevice(): MediaDeviceInfo {
 describe("useAudioInputDevices", () => {
     const originalMediaDevices = (navigator as any).mediaDevices;
     const originalPermissions = (navigator as any).permissions;
+
+    beforeEach(() => {
+        // The probe cache is module-scoped and persists across renders. Tests
+        // must start clean or earlier tests' cached values leak in and create
+        // confusing failures.
+        __resetProbeCacheForTesting();
+    });
 
     afterEach(() => {
         if (originalMediaDevices) {
@@ -285,6 +305,202 @@ describe("useAudioInputDevices", () => {
                 );
             });
             expect(result.current.availability).toBe("permission-denied");
+        });
+    });
+
+    describe("probeMicAccess (silent getUserMedia probe)", () => {
+        it("flips to permission-denied when probe getUserMedia throws NotAllowedError, even though Permissions API says granted", async () => {
+            // This is the central reviewer-reported case: macOS OS-level mic
+            // denial is invisible to enumerateDevices and Permissions API.
+            // The probe catches it by attempting a real getUserMedia call.
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            const getUserMediaSpy = vi
+                .fn()
+                .mockRejectedValue(
+                    Object.assign(new Error("denied"), { name: "NotAllowedError" })
+                );
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+            expect(result.current.availability).toBe("permission-denied");
+            expect(result.current.micPermissionDenied).toBe(true);
+        });
+
+        it("flips to no-device when probe throws NotFoundError", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            fake.getUserMedia = vi.fn().mockRejectedValue(
+                Object.assign(new Error("gone"), { name: "NotFoundError" })
+            );
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+
+            expect(result.current.availability).toBe("no-device");
+        });
+
+        it("stops the returned stream's tracks immediately after a successful probe", async () => {
+            const stopSpy = vi.fn();
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            fake.getUserMedia = vi.fn().mockResolvedValue({
+                getTracks: () => [{ stop: stopSpy } as MediaStreamTrack],
+            } as MediaStream);
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+
+            expect(stopSpy).toHaveBeenCalled();
+        });
+
+        it("caches the probe result so repeated calls don't re-trigger getUserMedia", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+                await result.current.probeMicAccess();
+                await result.current.probeMicAccess();
+            });
+
+            // Only the FIRST call actually probed; rest were cache hits.
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("dedupes concurrent probe calls into a single getUserMedia invocation", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            // Resolve on a microtask delay so concurrent probes race.
+            const getUserMediaSpy = vi.fn().mockImplementation(
+                () =>
+                    new Promise<MediaStream>((resolve) =>
+                        setTimeout(() => resolve(fakeStream()), 10)
+                    )
+            );
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await Promise.all([
+                    result.current.probeMicAccess(),
+                    result.current.probeMicAccess(),
+                    result.current.probeMicAccess(),
+                ]);
+            });
+
+            // All three calls awaited the single in-flight probe.
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("re-probes after a devicechange event invalidates the cache", async () => {
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            const getUserMediaSpy = vi.fn().mockResolvedValue(fakeStream());
+            fake.getUserMedia = getUserMediaSpy;
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(1);
+
+            // Simulate a device hot-plug — cache should be invalidated.
+            act(() => {
+                fake.dispatchEvent(new Event("devicechange"));
+            });
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+            expect(getUserMediaSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("preserves availability when probe getUserMedia is unavailable", async () => {
+            // No getUserMedia attached at all — probe should no-op silently.
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            await act(async () => {
+                await result.current.probeMicAccess();
+            });
+
+            expect(result.current.availability).toBe("available");
+        });
+
+        it("freshly-mounted hook inherits cached probe state from a prior mount", async () => {
+            // First mount: probe gets NotAllowedError, caches "permission-denied".
+            const fake = createFakeMediaDevices([audioInputDevice()]);
+            fake.getUserMedia = vi.fn().mockRejectedValue(
+                Object.assign(new Error(), { name: "NotAllowedError" })
+            );
+            (navigator as any).mediaDevices = fake;
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const first = renderHook(() => useAudioInputDevices());
+            await waitFor(() =>
+                expect(first.result.current.availability).toBe("available")
+            );
+            await act(async () => {
+                await first.result.current.probeMicAccess();
+            });
+            expect(first.result.current.availability).toBe("permission-denied");
+            first.unmount();
+
+            // Second mount (simulating opening a different cell): no extra
+            // probe should be needed; cached state pins immediately.
+            const second = renderHook(() => useAudioInputDevices());
+            expect(second.result.current.availability).toBe("permission-denied");
+            expect(second.result.current.micPermissionDenied).toBe(true);
         });
     });
 });

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioInputDevices.test.ts
@@ -187,4 +187,104 @@ describe("useAudioInputDevices", () => {
         await waitFor(() => expect(result.current.availability).toBe("available"));
         expect(result.current.micPermissionDenied).toBe(false);
     });
+
+    describe("reportRecorderError (runtime override)", () => {
+        it("flips to permission-denied on NotAllowedError even when Permissions API reports granted", async () => {
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            // This is the macOS "denied at OS level" case: passive APIs
+            // report granted, but getUserMedia throws.
+            const err = Object.assign(new Error("denied"), {
+                name: "NotAllowedError",
+            });
+            act(() => {
+                result.current.reportRecorderError(err);
+            });
+
+            expect(result.current.availability).toBe("permission-denied");
+            expect(result.current.micPermissionDenied).toBe(true);
+        });
+
+        it("flips to no-device on NotFoundError even when enumeration reported a device", async () => {
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            const err = Object.assign(new Error("missing"), { name: "NotFoundError" });
+            act(() => {
+                result.current.reportRecorderError(err);
+            });
+
+            expect(result.current.availability).toBe("no-device");
+        });
+
+        it("clears the runtime override when called with null (e.g. after a successful retry)", async () => {
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            act(() => {
+                result.current.reportRecorderError(
+                    Object.assign(new Error(), { name: "NotAllowedError" })
+                );
+            });
+            expect(result.current.availability).toBe("permission-denied");
+
+            act(() => {
+                result.current.reportRecorderError(null);
+            });
+            expect(result.current.availability).toBe("available");
+        });
+
+        it("ignores unrecognized error names so transient failures don't disable recording", async () => {
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            act(() => {
+                result.current.reportRecorderError(
+                    Object.assign(new Error("weird"), { name: "AbortError" })
+                );
+            });
+
+            expect(result.current.availability).toBe("available");
+        });
+
+        it("runtime override outranks the passive Permissions API state", async () => {
+            (navigator as any).mediaDevices = createFakeMediaDevices([audioInputDevice()]);
+            // Passive layer says granted...
+            (navigator as any).permissions = createFakePermissions(
+                createFakePermissionStatus("granted")
+            );
+
+            const { result } = renderHook(() => useAudioInputDevices());
+            await waitFor(() => expect(result.current.availability).toBe("available"));
+
+            // ...but runtime got denied. Runtime wins.
+            act(() => {
+                result.current.reportRecorderError(
+                    Object.assign(new Error(), { name: "NotAllowedError" })
+                );
+            });
+            expect(result.current.availability).toBe("permission-denied");
+        });
+    });
 });

--- a/webviews/codex-webviews/src/CodexCellEditor/components/RecorderCircle.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/components/RecorderCircle.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Mic, Square } from "lucide-react";
+import { Mic, MicOff, Square } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { cn } from "../../lib/utils";
 
@@ -17,6 +17,11 @@ import { cn } from "../../lib/utils";
  * `RecorderWaveform.tsx` as a single-canvas scrolling waveform rendered
  * below the button.
  *
+ * The `unavailable` prop is distinct from `disabled`: it specifically marks
+ * "no microphone present" and swaps to a grey, slashed-mic, no-pulse visual
+ * so the user reads it as a hardware issue rather than a temporary lock.
+ * `disabled` alone (e.g. locked cell) keeps the normal mic + faded primary.
+ *
  * Geometry:
  *   - Outer container is 128x128 so the ring-pulse halo can scale past the
  *     96x96 button edge without being clipped.
@@ -33,6 +38,9 @@ export interface RecorderCircleProps {
     countdown: number | null;
     onClick: () => void;
     disabled?: boolean;
+    /** True when no microphone is connected. Implies disabled and swaps to
+     *  the slashed-mic + neutral-grey + no-pulse visual treatment. */
+    unavailable?: boolean;
     title?: string;
 }
 
@@ -41,11 +49,14 @@ export const RecorderCircle: React.FC<RecorderCircleProps> = ({
     countdown,
     onClick,
     disabled = false,
+    unavailable = false,
     title,
 }) => {
     const isRecording = state === "recording";
     const isCountdown = state === "countdown";
     const isIdle = state === "idle";
+    const isUnavailable = unavailable;
+    const effectiveDisabled = disabled || isUnavailable;
 
     return (
         <div
@@ -54,9 +65,11 @@ export const RecorderCircle: React.FC<RecorderCircleProps> = ({
         >
             {/* Ring-pulse halo for idle ("mic ready") and recording.  Skipped
                 during countdown so the per-digit animation isn't competing with
-                a continuous expanding ring.  The parent's overflow-visible lets
+                a continuous expanding ring.  Also skipped when unavailable —
+                a static "no input" state shouldn't be drawing attention with
+                a continuous animation.  The parent's overflow-visible lets
                 the halo expand past the button edge. */}
-            {!isCountdown && (
+            {!isCountdown && !isUnavailable && (
                 <span
                     aria-hidden="true"
                     className={cn(
@@ -75,19 +88,29 @@ export const RecorderCircle: React.FC<RecorderCircleProps> = ({
             {/* The button itself.  Stays scale-stable; only the halo moves. */}
             <Button
                 onClick={onClick}
-                disabled={disabled}
+                disabled={effectiveDisabled}
                 title={title}
                 className={cn(
                     "rounded-full text-2xl font-bold p-0",
                     "transition-all duration-150",
-                    "hover:scale-105 active:scale-95",
-                    isIdle &&
+                    // No hover/press affordance when there's no mic — feels
+                    // wrong to invite interaction on a hardware-blocked button.
+                    !isUnavailable && "hover:scale-105 active:scale-95",
+                    isIdle && !isUnavailable &&
                         "bg-primary hover:bg-primary text-primary-foreground border-0",
                     isCountdown &&
                         "bg-emerald-600 hover:bg-emerald-600 text-white border-0",
                     isRecording &&
                         "bg-destructive hover:bg-destructive text-destructive-foreground border-0 animate-[var(--animate-recorder-glow-breathing)]",
-                    disabled && "opacity-50 cursor-not-allowed"
+                    // Unavailable wins: solid mid-grey circle with a white
+                    // icon so it reads unmistakably as "off / unavailable"
+                    // rather than the subtler `bg-muted` faded-control look.
+                    isUnavailable &&
+                        "bg-neutral-500 hover:bg-neutral-500 text-white border-0 cursor-not-allowed",
+                    // Plain `disabled` (e.g. locked cell) keeps the existing
+                    // faded-primary treatment so users still recognize it as
+                    // a recorder button that's momentarily locked.
+                    disabled && !isUnavailable && "opacity-50 cursor-not-allowed"
                 )}
                 style={{ width: BUTTON_DIAMETER, height: BUTTON_DIAMETER }}
             >
@@ -105,7 +128,8 @@ export const RecorderCircle: React.FC<RecorderCircleProps> = ({
                         {countdown}
                     </span>
                 )}
-                {isIdle && <Mic className="h-8 w-8" />}
+                {isIdle && !isUnavailable && <Mic className="h-8 w-8" />}
+                {isIdle && isUnavailable && <MicOff className="h-8 w-8" />}
             </Button>
         </div>
     );

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Detects whether the user has at least one audio input device (microphone)
+ * available. Listens for `devicechange` events so the result updates live when
+ * a microphone is plugged in or unplugged — no need to reopen the audio tab.
+ *
+ * Behavior notes:
+ *   - When `navigator.mediaDevices.enumerateDevices` is unavailable (very old
+ *     browsers, restricted contexts), `isSupported` returns `false` and the
+ *     caller should treat the result as "unknown" rather than "no device".
+ *     We default `hasAudioInput` to `true` in that case so we never
+ *     false-positive disable recording on a working machine.
+ *   - Devices show up in `enumerateDevices()` even when the user hasn't yet
+ *     granted microphone permission (their labels are blank, but the entries
+ *     still count). That's exactly what we want: we're checking for hardware
+ *     presence, not permission state.
+ *
+ * Debug-only override:
+ *   Set `window.__forceNoAudioInput = true` in the webview devtools to
+ *   simulate "no microphone detected" without unplugging hardware. Useful for
+ *   QA / styling work on machines that always have a working mic. Safe to
+ *   leave in — it does nothing unless explicitly set.
+ */
+export interface UseAudioInputDevicesResult {
+    /** True when at least one `audioinput` device exists. Defaults to `true`
+     *  while still checking and when the API is unsupported. */
+    hasAudioInput: boolean;
+    /** True during the initial enumeration (before we've heard back once). */
+    isChecking: boolean;
+    /** False when `navigator.mediaDevices.enumerateDevices` isn't available. */
+    isSupported: boolean;
+}
+
+declare global {
+    interface Window {
+        /** DEV/QA only: force `useAudioInputDevices` to report no microphone. */
+        __forceNoAudioInput?: boolean;
+    }
+}
+
+export function useAudioInputDevices(): UseAudioInputDevicesResult {
+    const isSupported =
+        typeof navigator !== "undefined" &&
+        !!navigator.mediaDevices &&
+        typeof navigator.mediaDevices.enumerateDevices === "function";
+
+    const [hasAudioInput, setHasAudioInput] = useState<boolean>(true);
+    const [isChecking, setIsChecking] = useState<boolean>(isSupported);
+
+    useEffect(() => {
+        if (!isSupported) {
+            setIsChecking(false);
+            return;
+        }
+
+        let cancelled = false;
+
+        const checkDevices = async () => {
+            try {
+                if (window.__forceNoAudioInput) {
+                    if (!cancelled) {
+                        setHasAudioInput(false);
+                        setIsChecking(false);
+                    }
+                    return;
+                }
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                const audioInputs = devices.filter((d) => d.kind === "audioinput");
+                if (!cancelled) {
+                    setHasAudioInput(audioInputs.length > 0);
+                    setIsChecking(false);
+                }
+            } catch (err) {
+                console.warn("useAudioInputDevices: enumerateDevices failed", err);
+                if (!cancelled) {
+                    // On enumeration failure, fall back to "assume present" so
+                    // we don't disable recording on a machine that may well
+                    // have a working mic. The actual `getUserMedia` call will
+                    // surface a clearer error if recording is then attempted.
+                    setHasAudioInput(true);
+                    setIsChecking(false);
+                }
+            }
+        };
+
+        checkDevices();
+
+        const handleDeviceChange = () => {
+            checkDevices();
+        };
+
+        navigator.mediaDevices.addEventListener("devicechange", handleDeviceChange);
+
+        return () => {
+            cancelled = true;
+            navigator.mediaDevices.removeEventListener("devicechange", handleDeviceChange);
+        };
+    }, [isSupported]);
+
+    return { hasAudioInput, isChecking, isSupported };
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -319,11 +319,76 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
 
     const probeMicAccess = useCallback(async () => {
         const result = await getOrRunProbe();
-        // "available" is the absence-of-block state, so we clear the local
-        // pin and let passive layers report normally. Any non-available
-        // result pins so the UI accurately reflects the block.
-        setRuntimeOverride(result === "available" ? null : result);
+        if (result === "available") {
+            // A successful `getUserMedia` is authoritative: mic access works
+            // right now. Clear the runtime pin AND force the passive layer to
+            // "available" so a stale `permission-denied`/`no-device` from an
+            // earlier `enumerateDevices`/permission read can't keep the UI
+            // blocked after a focus-regain recovery (see focus effect below).
+            setRuntimeOverride(null);
+            setAvailability("available");
+            return;
+        }
+        // Any non-available result pins so the UI accurately reflects the block.
+        setRuntimeOverride(result);
     }, []);
+
+    // ─── Self-heal on window focus while permission-denied ────────────────
+    // A mic *permission* can only change while the user is *away* from the
+    // editor (in OS settings / a portal dialog), and — unlike a device
+    // plug/unplug — there's no reliable event for it (Chromium's Permissions
+    // API reflects browser-level, not OS-level, state). So the moment the
+    // window regains focus is the single best, cheapest time to re-check.
+    //
+    // We deliberately DON'T do this for `no-device`: hardware changes already
+    // fire `devicechange` (see the detection effect above), which updates the
+    // UI live regardless of focus. Re-probing on focus there would be pure
+    // redundant `getUserMedia` work.
+    //
+    // The listener attaches ONLY while permission-denied, so the healthy path
+    // stays completely passive. Re-probing while denied is also flash-free: a
+    // still-denied `getUserMedia` rejects immediately without ever opening the
+    // mic, so the OS recording indicator never lights up. The one flash that
+    // can occur is the recovery itself (access just got granted), which is
+    // desirable feedback.
+    //
+    //   - Windows / Linux: re-grant takes effect live → button re-enables.
+    //   - macOS not-determined (e.g. a dismissed prompt) → re-prompts.
+    //   - macOS denied → keeps returning denied (TCC pins the verdict to the
+    //     process); the UI's "quit and reopen" message carries the fix.
+    const permissionBlocked = (runtimeOverride ?? availability) === "permission-denied";
+
+    useEffect(() => {
+        if (!permissionBlocked || typeof window === "undefined") return;
+
+        // Guard against alt-tab storms re-probing on every focus tick.
+        const COOLDOWN_MS = 2500;
+        let lastProbeAt = 0;
+
+        const onRegainFocus = () => {
+            if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+                return;
+            }
+            const now = Date.now();
+            if (now - lastProbeAt < COOLDOWN_MS) return;
+            lastProbeAt = now;
+            // Invalidate the cached verdict so the probe actually re-runs
+            // instead of returning the stale blocked result.
+            probeCache = null;
+            void probeMicAccess();
+        };
+
+        window.addEventListener("focus", onRegainFocus);
+        if (typeof document !== "undefined") {
+            document.addEventListener("visibilitychange", onRegainFocus);
+        }
+        return () => {
+            window.removeEventListener("focus", onRegainFocus);
+            if (typeof document !== "undefined") {
+                document.removeEventListener("visibilitychange", onRegainFocus);
+            }
+        };
+    }, [permissionBlocked, probeMicAccess]);
 
     // Runtime override (from a real `getUserMedia` failure) takes precedence
     // because it reflects ground truth, not Chromium's stale view of OS

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Detects whether the user can record audio right now. Reports separately
@@ -224,7 +224,18 @@ async function getOrRunProbe(force = false): Promise<MicAvailability> {
     }
 }
 
-export function useAudioInputDevices(): UseAudioInputDevicesResult {
+export function useAudioInputDevices(
+    options?: {
+        /**
+         * True when the recording UI is actually on screen (audio tab open and
+         * the cell is recordable). Gates the authoritative focus re-probe: we
+         * only re-check (and risk an OS indicator flash) when the user can see
+         * and use the recorder. When false, regaining focus just invalidates
+         * the cache so the next audio-tab open re-probes — no flash.
+         */
+        active?: boolean;
+    }
+): UseAudioInputDevicesResult {
     const isSupported =
         typeof navigator !== "undefined" &&
         !!navigator.mediaDevices &&
@@ -243,6 +254,12 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
     const [runtimeOverride, setRuntimeOverride] = useState<MicAvailability | null>(
         () => (probeCache !== null && probeCache !== "available" ? probeCache : null)
     );
+
+    // Mirror "is the recorder UI on screen?" into a ref so the focus handler
+    // (a stable closure) can decide whether to run an authoritative re-probe on
+    // focus regain.
+    const activeRef = useRef(options?.active ?? false);
+    activeRef.current = options?.active ?? false;
 
     useEffect(() => {
         if (FORCE_STATE_FOR_REVIEW !== null) {
@@ -296,14 +313,35 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         };
         mediaDevices.addEventListener("devicechange", handleDeviceChange);
 
-        // ─── Flash-free refresh on window focus ───────────────────────────
+        // Authoritative re-probe used by the focus handler. Unlike `evaluate()`
+        // (passive, which can't see OS-level changes the Permissions API
+        // misreports), this calls getUserMedia and applies the ground-truth
+        // result in BOTH directions: it clears a denial pin when access is
+        // re-granted, and pins a denial when access was revoked. On macOS the
+        // verdict is pinned to the process by TCC, so a re-grant correctly
+        // stays denied until the app restarts (no false recovery).
+        const reprobeAuthoritative = async () => {
+            const result = await getOrRunProbe(true);
+            if (cancelled) return;
+            if (result === "available") {
+                setRuntimeOverride(null);
+                setAvailability("available");
+            } else {
+                setRuntimeOverride(result);
+            }
+        };
+
+        // ─── Refresh on window focus ──────────────────────────────────────
         // A mic permission can only change while the user is *away* from the
         // editor (OS settings / a portal dialog), so regaining focus is the
-        // cheapest moment to refresh and "prepare the message" before the
-        // record tab is opened. We run ONLY the passive check here (no
-        // getUserMedia), so there is never an OS recording-indicator flash.
-        // We also invalidate the probe cache so the next audio-tab open does
-        // a fresh authoritative probe (which catches macOS OS-level denial).
+        // moment to refresh.
+        //   - Recorder UI on screen (`active`) → run an authoritative probe so
+        //     the status updates in BOTH directions (allowed↔denied). This can
+        //     briefly flash the OS recording indicator when access is granted,
+        //     which is the cost of reliably detecting a revocation; we accept it
+        //     only while the user is actually looking at the recorder.
+        //   - Otherwise → just invalidate the cache (no probe, no flash); the
+        //     next audio-tab open re-probes authoritatively.
         let lastFocusRefreshAt = 0;
         const FOCUS_REFRESH_COOLDOWN_MS = 1500;
         const onRegainFocus = () => {
@@ -314,13 +352,31 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
             if (now - lastFocusRefreshAt < FOCUS_REFRESH_COOLDOWN_MS) return;
             lastFocusRefreshAt = now;
             probeCache = null;
-            evaluate();
+            if (activeRef.current) {
+                void reprobeAuthoritative();
+            }
         };
         if (typeof window !== "undefined") {
             window.addEventListener("focus", onRegainFocus);
         }
         if (typeof document !== "undefined") {
             document.addEventListener("visibilitychange", onRegainFocus);
+        }
+
+        // VS Code webview iframes don't reliably receive native focus /
+        // visibilitychange events when the whole app regains OS focus. The
+        // extension host relays `vscode.window.onDidChangeWindowState` as a
+        // `windowFocusChanged` message, which is the dependable trigger for the
+        // post-OS-settings refresh. Treat a focus-regain identically to a
+        // native focus event (same cooldown + refresh policy).
+        const onHostMessage = (event: MessageEvent) => {
+            const data = event?.data as { type?: string; focused?: boolean } | undefined;
+            if (data?.type === "windowFocusChanged" && data.focused) {
+                onRegainFocus();
+            }
+        };
+        if (typeof window !== "undefined") {
+            window.addEventListener("message", onHostMessage);
         }
 
         let unsubscribePermission: (() => void) | null = null;
@@ -353,6 +409,7 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
             mediaDevices.removeEventListener("devicechange", handleDeviceChange);
             if (typeof window !== "undefined") {
                 window.removeEventListener("focus", onRegainFocus);
+                window.removeEventListener("message", onHostMessage);
             }
             if (typeof document !== "undefined") {
                 document.removeEventListener("visibilitychange", onRegainFocus);

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -1,41 +1,97 @@
 import { useEffect, useState } from "react";
 
 /**
- * Detects whether the user has at least one audio input device (microphone)
- * available. Listens for `devicechange` events so the result updates live when
- * a microphone is plugged in or unplugged — no need to reopen the audio tab.
+ * Detects whether the user can record audio right now. Reports separately
+ * for two different failure modes:
+ *   - "no-device" — there is no audioinput hardware enumerated. The user
+ *     needs to plug in / connect a microphone.
+ *   - "permission-denied" — a device exists but the OS / browser blocks
+ *     access. The user needs to grant microphone access in system settings.
+ *   - "available" — at least one device exists and permission is not blocked.
+ *   - "checking" — initial detection still in flight.
+ *   - "unsupported" — the necessary APIs aren't available. Treated as
+ *     "assume available" by callers so we never false-positive disable on a
+ *     working machine.
  *
- * Behavior notes:
- *   - When `navigator.mediaDevices.enumerateDevices` is unavailable (very old
- *     browsers, restricted contexts), `isSupported` returns `false` and the
- *     caller should treat the result as "unknown" rather than "no device".
- *     We default `hasAudioInput` to `true` in that case so we never
- *     false-positive disable recording on a working machine.
- *   - Devices show up in `enumerateDevices()` even when the user hasn't yet
- *     granted microphone permission (their labels are blank, but the entries
- *     still count). That's exactly what we want: we're checking for hardware
- *     presence, not permission state.
+ * Reacts live to two signals so the UI stays in sync without a reload:
+ *   - `devicechange` on `navigator.mediaDevices` (mic plugged / unplugged)
+ *   - `change` on the `microphone` PermissionStatus (user grants/revokes
+ *     access via the address bar or system settings)
  *
- * Debug-only override:
- *   Set `window.__forceNoAudioInput = true` in the webview devtools to
- *   simulate "no microphone detected" without unplugging hardware. Useful for
- *   QA / styling work on machines that always have a working mic. Safe to
- *   leave in — it does nothing unless explicitly set.
+ * Devices typically show up in `enumerateDevices()` even before the user has
+ * granted permission (their labels are blank, but the entries still count).
+ * That means device count alone can't tell us if access is *blocked* — only
+ * the permissions API can. We query both independently.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * REVIEWER NOTE — testing without unplugging your microphone:
+ *
+ *   Edit the `FORCE_STATE_FOR_REVIEW` constant below to force a specific
+ *   state regardless of real hardware. Rebuild the webview
+ *   (`pnpm run build:CodexCellEditor`) and reload the extension host to
+ *   see the corresponding UI. **Set back to `null` before committing.**
+ *
+ *     FORCE_STATE_FOR_REVIEW = "no-device"         // grey slashed-mic + "no microphone detected" alert
+ *     FORCE_STATE_FOR_REVIEW = "permission-denied" // grey slashed-mic + "access denied" alert
+ *     FORCE_STATE_FOR_REVIEW = null                // real detection (default)
+ * ─────────────────────────────────────────────────────────────────────────
  */
+
+/** Override real detection for visual review. MUST be `null` in committed code. */
+const FORCE_STATE_FOR_REVIEW: MicAvailability | null = 'permission-denied';//null;
+
+export type MicAvailability =
+    | "available"
+    | "checking"
+    | "no-device"
+    | "permission-denied"
+    | "unsupported";
+
 export interface UseAudioInputDevicesResult {
-    /** True when at least one `audioinput` device exists. Defaults to `true`
-     *  while still checking and when the API is unsupported. */
-    hasAudioInput: boolean;
-    /** True during the initial enumeration (before we've heard back once). */
-    isChecking: boolean;
-    /** False when `navigator.mediaDevices.enumerateDevices` isn't available. */
-    isSupported: boolean;
+    /** High-level state for branching UI. */
+    availability: MicAvailability;
+    /** True when the user can't record (no device or permission denied). */
+    micUnavailable: boolean;
+    /** True specifically when no audioinput hardware exists. */
+    noMicDetected: boolean;
+    /** True specifically when permission is denied for an existing mic. */
+    micPermissionDenied: boolean;
 }
 
-declare global {
-    interface Window {
-        /** DEV/QA only: force `useAudioInputDevices` to report no microphone. */
-        __forceNoAudioInput?: boolean;
+type PermissionState = "granted" | "denied" | "prompt" | "unknown";
+
+async function queryMicPermission(): Promise<PermissionState> {
+    try {
+        if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+            return "unknown";
+        }
+        // `microphone` isn't in TS's PermissionName union in all lib versions.
+        const status = (await navigator.permissions.query({
+            name: "microphone" as PermissionName,
+        })) as PermissionStatus;
+        return status.state as PermissionState;
+    } catch {
+        // Some environments (Safari, restricted contexts) throw for
+        // unsupported permission names. Treat as "we don't know".
+        return "unknown";
+    }
+}
+
+async function subscribeToMicPermission(
+    onChange: (state: PermissionState) => void
+): Promise<(() => void) | null> {
+    try {
+        if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+            return null;
+        }
+        const status = (await navigator.permissions.query({
+            name: "microphone" as PermissionName,
+        })) as PermissionStatus;
+        const handler = () => onChange(status.state as PermissionState);
+        status.addEventListener("change", handler);
+        return () => status.removeEventListener("change", handler);
+    } catch {
+        return null;
     }
 }
 
@@ -45,62 +101,81 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         !!navigator.mediaDevices &&
         typeof navigator.mediaDevices.enumerateDevices === "function";
 
-    const [hasAudioInput, setHasAudioInput] = useState<boolean>(true);
-    const [isChecking, setIsChecking] = useState<boolean>(isSupported);
+    const [availability, setAvailability] = useState<MicAvailability>(
+        isSupported ? "checking" : "unsupported"
+    );
 
     useEffect(() => {
-        if (!isSupported) {
-            setIsChecking(false);
+        if (FORCE_STATE_FOR_REVIEW !== null) {
+            setAvailability(FORCE_STATE_FOR_REVIEW);
             return;
         }
 
-        // Capture the `mediaDevices` reference at mount so the cleanup path
-        // can always remove its own listener — even if something later swaps
-        // `navigator.mediaDevices` (tests, mocks, hot-reload).
+        if (!isSupported) {
+            setAvailability("unsupported");
+            return;
+        }
+
+        // Capture `mediaDevices` at mount so the cleanup path can remove its
+        // listener even if the global is later swapped (tests, hot-reload).
         const mediaDevices = navigator.mediaDevices;
         let cancelled = false;
 
-        const checkDevices = async () => {
+        const evaluate = async () => {
             try {
-                if (window.__forceNoAudioInput) {
-                    if (!cancelled) {
-                        setHasAudioInput(false);
-                        setIsChecking(false);
-                    }
+                const [devices, permission] = await Promise.all([
+                    mediaDevices.enumerateDevices(),
+                    queryMicPermission(),
+                ]);
+                if (cancelled) return;
+
+                if (permission === "denied") {
+                    setAvailability("permission-denied");
                     return;
                 }
-                const devices = await mediaDevices.enumerateDevices();
                 const audioInputs = devices.filter((d) => d.kind === "audioinput");
-                if (!cancelled) {
-                    setHasAudioInput(audioInputs.length > 0);
-                    setIsChecking(false);
-                }
+                setAvailability(audioInputs.length > 0 ? "available" : "no-device");
             } catch (err) {
-                console.warn("useAudioInputDevices: enumerateDevices failed", err);
+                console.warn("useAudioInputDevices: detection failed", err);
                 if (!cancelled) {
-                    // On enumeration failure, fall back to "assume present" so
+                    // On detection failure, fall back to "assume present" so
                     // we don't disable recording on a machine that may well
                     // have a working mic. The actual `getUserMedia` call will
                     // surface a clearer error if recording is then attempted.
-                    setHasAudioInput(true);
-                    setIsChecking(false);
+                    setAvailability("available");
                 }
             }
         };
 
-        checkDevices();
+        evaluate();
 
-        const handleDeviceChange = () => {
-            checkDevices();
-        };
-
+        const handleDeviceChange = () => evaluate();
         mediaDevices.addEventListener("devicechange", handleDeviceChange);
+
+        let unsubscribePermission: (() => void) | null = null;
+        subscribeToMicPermission(() => evaluate()).then((unsub) => {
+            if (cancelled) {
+                unsub?.();
+                return;
+            }
+            unsubscribePermission = unsub;
+        });
 
         return () => {
             cancelled = true;
             mediaDevices.removeEventListener("devicechange", handleDeviceChange);
+            unsubscribePermission?.();
         };
     }, [isSupported]);
 
-    return { hasAudioInput, isChecking, isSupported };
+    const noMicDetected = availability === "no-device";
+    const micPermissionDenied = availability === "permission-denied";
+    const micUnavailable = noMicDetected || micPermissionDenied;
+
+    return {
+        availability,
+        micUnavailable,
+        noMicDetected,
+        micPermissionDenied,
+    };
 }

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -54,6 +54,10 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
             return;
         }
 
+        // Capture the `mediaDevices` reference at mount so the cleanup path
+        // can always remove its own listener — even if something later swaps
+        // `navigator.mediaDevices` (tests, mocks, hot-reload).
+        const mediaDevices = navigator.mediaDevices;
         let cancelled = false;
 
         const checkDevices = async () => {
@@ -65,7 +69,7 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
                     }
                     return;
                 }
-                const devices = await navigator.mediaDevices.enumerateDevices();
+                const devices = await mediaDevices.enumerateDevices();
                 const audioInputs = devices.filter((d) => d.kind === "audioinput");
                 if (!cancelled) {
                     setHasAudioInput(audioInputs.length > 0);
@@ -90,11 +94,11 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
             checkDevices();
         };
 
-        navigator.mediaDevices.addEventListener("devicechange", handleDeviceChange);
+        mediaDevices.addEventListener("devicechange", handleDeviceChange);
 
         return () => {
             cancelled = true;
-            navigator.mediaDevices.removeEventListener("devicechange", handleDeviceChange);
+            mediaDevices.removeEventListener("devicechange", handleDeviceChange);
         };
     }, [isSupported]);
 

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -89,8 +89,13 @@ export interface UseAudioInputDevicesResult {
      * Side effect to be aware of: triggers the OS permission prompt on
      * first ever call for a user who has never been asked, and briefly
      * flashes the OS recording indicator. Cache prevents repetition.
+     *
+     * Pass `{ force: true }` to bypass the cache for an authoritative
+     * re-check (e.g. right before starting a recording, in case the
+     * permission was toggled mid-session). Resolves to the resulting
+     * `MicAvailability` so callers can branch without reading state.
      */
-    probeMicAccess: () => Promise<void>;
+    probeMicAccess: (opts?: { force?: boolean }) => Promise<MicAvailability>;
 }
 
 type PermissionState = "granted" | "denied" | "prompt" | "unknown";
@@ -165,6 +170,8 @@ function classifyRecorderError(err: unknown): MicAvailability | null {
 //
 // Invalidated by:
 //   - `devicechange` events (hardware presence may have changed)
+//   - window focus regain (the user may have changed OS permissions while away)
+//   - permission `change` events that transition to granted/prompt
 //   - `reportRecorderError` calls (recorder learned real state from
 //     a record-button click)
 // ─────────────────────────────────────────────────────────────────────────
@@ -200,8 +207,12 @@ async function performProbe(): Promise<MicAvailability> {
     }
 }
 
-async function getOrRunProbe(): Promise<MicAvailability> {
-    if (probeCache !== null) return probeCache;
+async function getOrRunProbe(force = false): Promise<MicAvailability> {
+    // `force` bypasses the cached verdict for an authoritative re-check (e.g.
+    // the user clicked record and a permission may have been toggled mid-
+    // session). An in-flight probe is still shared — it hasn't resolved yet,
+    // so its result is already fresh.
+    if (!force && probeCache !== null) return probeCache;
     if (inflightProbe) return inflightProbe;
     inflightProbe = performProbe();
     try {
@@ -285,8 +296,51 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         };
         mediaDevices.addEventListener("devicechange", handleDeviceChange);
 
+        // ─── Flash-free refresh on window focus ───────────────────────────
+        // A mic permission can only change while the user is *away* from the
+        // editor (OS settings / a portal dialog), so regaining focus is the
+        // cheapest moment to refresh and "prepare the message" before the
+        // record tab is opened. We run ONLY the passive check here (no
+        // getUserMedia), so there is never an OS recording-indicator flash.
+        // We also invalidate the probe cache so the next audio-tab open does
+        // a fresh authoritative probe (which catches macOS OS-level denial).
+        let lastFocusRefreshAt = 0;
+        const FOCUS_REFRESH_COOLDOWN_MS = 1500;
+        const onRegainFocus = () => {
+            if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+                return;
+            }
+            const now = Date.now();
+            if (now - lastFocusRefreshAt < FOCUS_REFRESH_COOLDOWN_MS) return;
+            lastFocusRefreshAt = now;
+            probeCache = null;
+            evaluate();
+        };
+        if (typeof window !== "undefined") {
+            window.addEventListener("focus", onRegainFocus);
+        }
+        if (typeof document !== "undefined") {
+            document.addEventListener("visibilitychange", onRegainFocus);
+        }
+
         let unsubscribePermission: (() => void) | null = null;
-        subscribeToMicPermission(() => evaluate()).then((unsub) => {
+        subscribeToMicPermission((state) => {
+            // A real permission transition to granted/prompt is a reliable
+            // signal that an earlier denial no longer holds, so clear a stale
+            // runtime pin and re-probe fresh. On macOS OS-level changes this
+            // `change` event typically does NOT fire, so the pin correctly
+            // persists until the app is restarted (TCC pins the verdict to
+            // the process). We deliberately do NOT clear the pin from the
+            // passive `evaluate()` "available" path, because Chromium can
+            // misreport macOS OS-level denial as granted.
+            if (state === "granted" || state === "prompt") {
+                probeCache = null;
+                setRuntimeOverride((prev) =>
+                    prev === "permission-denied" ? null : prev
+                );
+            }
+            evaluate();
+        }).then((unsub) => {
             if (cancelled) {
                 unsub?.();
                 return;
@@ -297,6 +351,12 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         return () => {
             cancelled = true;
             mediaDevices.removeEventListener("devicechange", handleDeviceChange);
+            if (typeof window !== "undefined") {
+                window.removeEventListener("focus", onRegainFocus);
+            }
+            if (typeof document !== "undefined") {
+                document.removeEventListener("visibilitychange", onRegainFocus);
+            }
             unsubscribePermission?.();
         };
     }, [isSupported]);
@@ -305,9 +365,14 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         if (err === null) {
             // Successful getUserMedia is ground truth that the mic works.
             // Update the cache so other hook instances learn the good news
-            // on next render, and clear the local pin.
+            // on next render, clear the local pin, AND force the passive
+            // layer to "available". Without the last step a stale passive
+            // `permission-denied` (e.g. Chromium's Permissions API still
+            // reporting denied after the user re-enabled) would keep the UI
+            // blocked even though we just recorded successfully.
             probeCache = "available";
             setRuntimeOverride(null);
+            setAvailability("available");
             return;
         }
         const classified = classifyRecorderError(err);
@@ -317,78 +382,25 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         }
     }, []);
 
-    const probeMicAccess = useCallback(async () => {
-        const result = await getOrRunProbe();
-        if (result === "available") {
-            // A successful `getUserMedia` is authoritative: mic access works
-            // right now. Clear the runtime pin AND force the passive layer to
-            // "available" so a stale `permission-denied`/`no-device` from an
-            // earlier `enumerateDevices`/permission read can't keep the UI
-            // blocked after a focus-regain recovery (see focus effect below).
-            setRuntimeOverride(null);
-            setAvailability("available");
-            return;
-        }
-        // Any non-available result pins so the UI accurately reflects the block.
-        setRuntimeOverride(result);
-    }, []);
-
-    // ─── Self-heal on window focus while permission-denied ────────────────
-    // A mic *permission* can only change while the user is *away* from the
-    // editor (in OS settings / a portal dialog), and — unlike a device
-    // plug/unplug — there's no reliable event for it (Chromium's Permissions
-    // API reflects browser-level, not OS-level, state). So the moment the
-    // window regains focus is the single best, cheapest time to re-check.
-    //
-    // We deliberately DON'T do this for `no-device`: hardware changes already
-    // fire `devicechange` (see the detection effect above), which updates the
-    // UI live regardless of focus. Re-probing on focus there would be pure
-    // redundant `getUserMedia` work.
-    //
-    // The listener attaches ONLY while permission-denied, so the healthy path
-    // stays completely passive. Re-probing while denied is also flash-free: a
-    // still-denied `getUserMedia` rejects immediately without ever opening the
-    // mic, so the OS recording indicator never lights up. The one flash that
-    // can occur is the recovery itself (access just got granted), which is
-    // desirable feedback.
-    //
-    //   - Windows / Linux: re-grant takes effect live → button re-enables.
-    //   - macOS not-determined (e.g. a dismissed prompt) → re-prompts.
-    //   - macOS denied → keeps returning denied (TCC pins the verdict to the
-    //     process); the UI's "quit and reopen" message carries the fix.
-    const permissionBlocked = (runtimeOverride ?? availability) === "permission-denied";
-
-    useEffect(() => {
-        if (!permissionBlocked || typeof window === "undefined") return;
-
-        // Guard against alt-tab storms re-probing on every focus tick.
-        const COOLDOWN_MS = 2500;
-        let lastProbeAt = 0;
-
-        const onRegainFocus = () => {
-            if (typeof document !== "undefined" && document.visibilityState === "hidden") {
-                return;
+    const probeMicAccess = useCallback(
+        async (opts?: { force?: boolean }): Promise<MicAvailability> => {
+            const result = await getOrRunProbe(opts?.force ?? false);
+            if (result === "available") {
+                // A successful `getUserMedia` is authoritative: mic access works
+                // right now. Clear the runtime pin AND force the passive layer to
+                // "available" so a stale `permission-denied`/`no-device` from an
+                // earlier `enumerateDevices`/permission read can't keep the UI
+                // blocked after a focus-regain recovery (see focus effect below).
+                setRuntimeOverride(null);
+                setAvailability("available");
+                return result;
             }
-            const now = Date.now();
-            if (now - lastProbeAt < COOLDOWN_MS) return;
-            lastProbeAt = now;
-            // Invalidate the cached verdict so the probe actually re-runs
-            // instead of returning the stale blocked result.
-            probeCache = null;
-            void probeMicAccess();
-        };
-
-        window.addEventListener("focus", onRegainFocus);
-        if (typeof document !== "undefined") {
-            document.addEventListener("visibilitychange", onRegainFocus);
-        }
-        return () => {
-            window.removeEventListener("focus", onRegainFocus);
-            if (typeof document !== "undefined") {
-                document.removeEventListener("visibilitychange", onRegainFocus);
-            }
-        };
-    }, [permissionBlocked, probeMicAccess]);
+            // Any non-available result pins so the UI accurately reflects the block.
+            setRuntimeOverride(result);
+            return result;
+        },
+        []
+    );
 
     // Runtime override (from a real `getUserMedia` failure) takes precedence
     // because it reflects ground truth, not Chromium's stale view of OS

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -13,16 +13,21 @@ import { useCallback, useEffect, useState } from "react";
  *     "assume available" by callers so we never false-positive disable on a
  *     working machine.
  *
- * Reacts live to three signals so the UI stays in sync without a reload:
+ * Reacts live to four signals so the UI stays in sync without a reload:
  *   - `devicechange` on `navigator.mediaDevices` (mic plugged / unplugged)
  *   - `change` on the `microphone` PermissionStatus (user grants/revokes
  *     access via the address bar or browser-level settings)
- *   - Runtime reports from the recorder via `reportRecorderError(err)` — the
- *     only reliable way to observe an OS-level block on macOS / Linux (the
- *     Permissions API only reflects browser-level state, not OS settings,
- *     so a user who denies in System Settings will still see `"granted"`
- *     from `navigator.permissions.query`; we only learn the real state
- *     when `getUserMedia()` throws `NotAllowedError`).
+ *   - `probeMicAccess()` — caller-initiated probe via a silent
+ *     `getUserMedia({ audio: true })` + immediate `track.stop()`. The
+ *     ONLY way to detect OS-level mic blocks (macOS System Settings /
+ *     Windows Privacy settings) because Chromium's Permissions API
+ *     reflects browser-level state, not the OS's. Result is cached at
+ *     module scope so we don't re-probe (and re-flash the OS recording
+ *     indicator) on every cell switch.
+ *   - Runtime reports from the recorder via `reportRecorderError(err)` —
+ *     a complementary path: the user clicked record and `getUserMedia`
+ *     threw. Updates the cache so the rest of the session reflects the
+ *     newly-discovered state.
  *
  * Devices typically show up in `enumerateDevices()` even before the user has
  * granted permission (their labels are blank, but the entries still count).
@@ -71,6 +76,21 @@ export interface UseAudioInputDevicesResult {
      * (e.g. after a successful `getUserMedia` call).
      */
     reportRecorderError: (err: unknown | null) => void;
+    /**
+     * Silently probe whether mic access actually works by calling
+     * `getUserMedia({ audio: true })` and immediately stopping the
+     * resulting tracks. Updates `availability` based on the outcome. The
+     * result is cached at module scope so repeated calls within the same
+     * webview session are no-ops (returns the cached state). This is the
+     * recommended fix for the macOS / Windows OS-level permission gap:
+     * call it when the user opens the audio recording UI so the button
+     * disables before they click.
+     *
+     * Side effect to be aware of: triggers the OS permission prompt on
+     * first ever call for a user who has never been asked, and briefly
+     * flashes the OS recording indicator. Cache prevents repetition.
+     */
+    probeMicAccess: () => Promise<void>;
 }
 
 type PermissionState = "granted" | "denied" | "prompt" | "unknown";
@@ -135,6 +155,64 @@ function classifyRecorderError(err: unknown): MicAvailability | null {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Module-level probe cache.
+//
+// Shared across all hook instances in the webview so opening multiple cells
+// during a session doesn't trigger a probe (and the recording-indicator
+// flash) on every cell switch. Lifetime = webview lifetime, which is
+// typically one work session.
+//
+// Invalidated by:
+//   - `devicechange` events (hardware presence may have changed)
+//   - `reportRecorderError` calls (recorder learned real state from
+//     a record-button click)
+// ─────────────────────────────────────────────────────────────────────────
+let probeCache: MicAvailability | null = null;
+let inflightProbe: Promise<MicAvailability> | null = null;
+
+/** Test-only: reset module state between cases. Not part of public API. */
+export function __resetProbeCacheForTesting(): void {
+    probeCache = null;
+    inflightProbe = null;
+}
+
+async function performProbe(): Promise<MicAvailability> {
+    if (
+        typeof navigator === "undefined" ||
+        !navigator.mediaDevices?.getUserMedia
+    ) {
+        // No API to probe with — fall back to optimistic so we never disable
+        // recording on a working machine just because we couldn't check.
+        return "available";
+    }
+    try {
+        // Minimal constraints: this is a permission probe, not a recording.
+        // Less to negotiate = less time the mic indicator flashes.
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        // Stop tracks in the same microtask as the resolution to release
+        // the mic immediately. OS recording indicator turns off as soon as
+        // the last track on a stream transitions to "ended".
+        stream.getTracks().forEach((t) => t.stop());
+        return "available";
+    } catch (err) {
+        return classifyRecorderError(err) ?? "available";
+    }
+}
+
+async function getOrRunProbe(): Promise<MicAvailability> {
+    if (probeCache !== null) return probeCache;
+    if (inflightProbe) return inflightProbe;
+    inflightProbe = performProbe();
+    try {
+        const result = await inflightProbe;
+        probeCache = result;
+        return result;
+    } finally {
+        inflightProbe = null;
+    }
+}
+
 export function useAudioInputDevices(): UseAudioInputDevicesResult {
     const isSupported =
         typeof navigator !== "undefined" &&
@@ -144,12 +222,16 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
     const [availability, setAvailability] = useState<MicAvailability>(
         isSupported ? "checking" : "unsupported"
     );
-    // When the recorder reports an error, we pin the state until cleared.
-    // Passive signals (`devicechange`, permission `change`) won't override it,
-    // because on macOS those signals are unreliable for OS-level mic blocks.
-    // The recorder calls `reportRecorderError(null)` after a successful
-    // `getUserMedia` to release the pin.
-    const [runtimeOverride, setRuntimeOverride] = useState<MicAvailability | null>(null);
+    // Pinned state set by either the explicit probe or by a real
+    // `getUserMedia` failure reported by the recorder. Passive signals
+    // (`devicechange`, permission `change`) won't override it, because on
+    // macOS / Windows those signals are unreliable for OS-level mic blocks.
+    // Initial value reads from the module cache so a freshly-mounted hook
+    // instance (e.g. opening a new cell) inherits whatever the last cell
+    // discovered, with no re-probe required.
+    const [runtimeOverride, setRuntimeOverride] = useState<MicAvailability | null>(
+        () => (probeCache !== null && probeCache !== "available" ? probeCache : null)
+    );
 
     useEffect(() => {
         if (FORCE_STATE_FOR_REVIEW !== null) {
@@ -195,7 +277,12 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
 
         evaluate();
 
-        const handleDeviceChange = () => evaluate();
+        const handleDeviceChange = () => {
+            // Hardware changed — the cached probe is no longer trustworthy.
+            // The next time the user opens the audio tab, we'll re-probe.
+            probeCache = null;
+            evaluate();
+        };
         mediaDevices.addEventListener("devicechange", handleDeviceChange);
 
         let unsubscribePermission: (() => void) | null = null;
@@ -216,11 +303,26 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
 
     const reportRecorderError = useCallback((err: unknown | null) => {
         if (err === null) {
+            // Successful getUserMedia is ground truth that the mic works.
+            // Update the cache so other hook instances learn the good news
+            // on next render, and clear the local pin.
+            probeCache = "available";
             setRuntimeOverride(null);
             return;
         }
         const classified = classifyRecorderError(err);
-        if (classified) setRuntimeOverride(classified);
+        if (classified) {
+            probeCache = classified;
+            setRuntimeOverride(classified);
+        }
+    }, []);
+
+    const probeMicAccess = useCallback(async () => {
+        const result = await getOrRunProbe();
+        // "available" is the absence-of-block state, so we clear the local
+        // pin and let passive layers report normally. Any non-available
+        // result pins so the UI accurately reflects the block.
+        setRuntimeOverride(result === "available" ? null : result);
     }, []);
 
     // Runtime override (from a real `getUserMedia` failure) takes precedence
@@ -240,5 +342,6 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         noMicDetected,
         micPermissionDenied,
         reportRecorderError,
+        probeMicAccess,
     };
 }

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useAudioInputDevices.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Detects whether the user can record audio right now. Reports separately
@@ -13,15 +13,21 @@ import { useEffect, useState } from "react";
  *     "assume available" by callers so we never false-positive disable on a
  *     working machine.
  *
- * Reacts live to two signals so the UI stays in sync without a reload:
+ * Reacts live to three signals so the UI stays in sync without a reload:
  *   - `devicechange` on `navigator.mediaDevices` (mic plugged / unplugged)
  *   - `change` on the `microphone` PermissionStatus (user grants/revokes
- *     access via the address bar or system settings)
+ *     access via the address bar or browser-level settings)
+ *   - Runtime reports from the recorder via `reportRecorderError(err)` — the
+ *     only reliable way to observe an OS-level block on macOS / Linux (the
+ *     Permissions API only reflects browser-level state, not OS settings,
+ *     so a user who denies in System Settings will still see `"granted"`
+ *     from `navigator.permissions.query`; we only learn the real state
+ *     when `getUserMedia()` throws `NotAllowedError`).
  *
  * Devices typically show up in `enumerateDevices()` even before the user has
  * granted permission (their labels are blank, but the entries still count).
  * That means device count alone can't tell us if access is *blocked* — only
- * the permissions API can. We query both independently.
+ * the permissions API or a real `getUserMedia()` attempt can.
  *
  * ─────────────────────────────────────────────────────────────────────────
  * REVIEWER NOTE — testing without unplugging your microphone:
@@ -38,7 +44,7 @@ import { useEffect, useState } from "react";
  */
 
 /** Override real detection for visual review. MUST be `null` in committed code. */
-const FORCE_STATE_FOR_REVIEW: MicAvailability | null = 'permission-denied';//null;
+const FORCE_STATE_FOR_REVIEW: MicAvailability | null = null;
 
 export type MicAvailability =
     | "available"
@@ -56,6 +62,15 @@ export interface UseAudioInputDevicesResult {
     noMicDetected: boolean;
     /** True specifically when permission is denied for an existing mic. */
     micPermissionDenied: boolean;
+    /**
+     * Call from the recorder's `getUserMedia` catch block with the thrown
+     * error. The hook classifies the error name (`NotAllowedError`,
+     * `NotFoundError`, etc.) and updates `availability` accordingly. This
+     * is the only reliable path for catching OS-level mic blocks where the
+     * Permissions API misreports. Pass `null` to clear a runtime-set state
+     * (e.g. after a successful `getUserMedia` call).
+     */
+    reportRecorderError: (err: unknown | null) => void;
 }
 
 type PermissionState = "granted" | "denied" | "prompt" | "unknown";
@@ -95,6 +110,31 @@ async function subscribeToMicPermission(
     }
 }
 
+/**
+ * Map a `getUserMedia` rejection to a `MicAvailability` value. Returns `null`
+ * for transient or unknown errors so the caller leaves the state untouched.
+ *
+ * The `name` property is set by the browser per the WebRTC spec and is the
+ * supported way to distinguish these cases. Older browsers used different
+ * names (e.g. `DevicesNotFoundError`), so we accept the most common aliases.
+ */
+function classifyRecorderError(err: unknown): MicAvailability | null {
+    if (!err || typeof err !== "object") return null;
+    const name = (err as { name?: string }).name;
+    switch (name) {
+        case "NotAllowedError":
+        case "PermissionDeniedError": // Legacy Chromium alias.
+        case "SecurityError":
+            return "permission-denied";
+        case "NotFoundError":
+        case "DevicesNotFoundError": // Legacy alias.
+        case "OverconstrainedError":
+            return "no-device";
+        default:
+            return null;
+    }
+}
+
 export function useAudioInputDevices(): UseAudioInputDevicesResult {
     const isSupported =
         typeof navigator !== "undefined" &&
@@ -104,6 +144,12 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
     const [availability, setAvailability] = useState<MicAvailability>(
         isSupported ? "checking" : "unsupported"
     );
+    // When the recorder reports an error, we pin the state until cleared.
+    // Passive signals (`devicechange`, permission `change`) won't override it,
+    // because on macOS those signals are unreliable for OS-level mic blocks.
+    // The recorder calls `reportRecorderError(null)` after a successful
+    // `getUserMedia` to release the pin.
+    const [runtimeOverride, setRuntimeOverride] = useState<MicAvailability | null>(null);
 
     useEffect(() => {
         if (FORCE_STATE_FOR_REVIEW !== null) {
@@ -168,14 +214,31 @@ export function useAudioInputDevices(): UseAudioInputDevicesResult {
         };
     }, [isSupported]);
 
-    const noMicDetected = availability === "no-device";
-    const micPermissionDenied = availability === "permission-denied";
+    const reportRecorderError = useCallback((err: unknown | null) => {
+        if (err === null) {
+            setRuntimeOverride(null);
+            return;
+        }
+        const classified = classifyRecorderError(err);
+        if (classified) setRuntimeOverride(classified);
+    }, []);
+
+    // Runtime override (from a real `getUserMedia` failure) takes precedence
+    // because it reflects ground truth, not Chromium's stale view of OS
+    // permissions. The dev-only `FORCE_STATE_FOR_REVIEW` still wins above
+    // everything for visual testing.
+    const effectiveAvailability: MicAvailability =
+        FORCE_STATE_FOR_REVIEW ?? runtimeOverride ?? availability;
+
+    const noMicDetected = effectiveAvailability === "no-device";
+    const micPermissionDenied = effectiveAvailability === "permission-denied";
     const micUnavailable = noMicDetected || micPermissionDenied;
 
     return {
-        availability,
+        availability: effectiveAvailability,
         micUnavailable,
         noMicDetected,
         micPermissionDenied,
+        reportRecorderError,
     };
 }

--- a/webviews/codex-webviews/src/StartupFlow/components/projects-list/ProjectCard.tsx
+++ b/webviews/codex-webviews/src/StartupFlow/components/projects-list/ProjectCard.tsx
@@ -76,6 +76,8 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     const [isZippingMini, setIsZippingMini] = useState<boolean>(false);
     const [zipProgress, setZipProgress] = useState<number>(0);
     const [isCleaning, setIsCleaning] = useState<boolean>(false);
+    const [isDeleting, setIsDeleting] = useState<boolean>(false);
+    const [deletingStage, setDeletingStage] = useState<"verifying" | "deleting">("verifying");
     const userInitiatedStrategyChangeRef = React.useRef<boolean>(false);
     const [isApplyingStrategyDuringOtherOp, setIsApplyingStrategyDuringOtherOp] =
         useState<boolean>(false);
@@ -117,6 +119,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
         isZipping ||
         isZippingMini ||
         isCleaning ||
+        isDeleting ||
         isApplyingStrategyDuringOtherOp ||
         isCalculatingStrategy;
 
@@ -280,6 +283,15 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
             if (msg?.command === "project.cleaningInProgress") {
                 if (msg.projectPath === project.path) {
                     setIsCleaning(msg.cleaning);
+                }
+                return;
+            }
+            if (msg?.command === "project.deletingInProgress") {
+                if (msg.projectPath === project.path) {
+                    setIsDeleting(msg.deleting);
+                    if (msg.deleting && msg.stage) {
+                        setDeletingStage(msg.stage);
+                    }
                 }
                 return;
             }
@@ -836,12 +848,30 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                                     <Button
                                         variant="outline"
                                         size="sm"
-                                        onClick={() => onDeleteProject(project)}
+                                        onClick={() => {
+                                            // Optimistically disable actions right away so the
+                                            // confirmation-dialog window can't accept repeated
+                                            // Delete clicks. Start in "verifying" until the host
+                                            // confirms; it echoes deletingInProgress to advance the
+                                            // stage and to clear this on cancel/failure.
+                                            setDeletingStage("verifying");
+                                            setIsDeleting(true);
+                                            onDeleteProject(project);
+                                        }}
                                         className="h-6 text-xs text-red-500 hover:text-red-600"
                                         disabled={disableControls}
                                     >
-                                        <i className="codicon codicon-trash mr-1" />
-                                        Delete
+                                        {isDeleting ? (
+                                            <>
+                                                <i className="codicon codicon-loading codicon-modifier-spin mr-1" />
+                                                {deletingStage === "deleting" ? "Deleting..." : "Verifying..."}
+                                            </>
+                                        ) : (
+                                            <>
+                                                <i className="codicon codicon-trash mr-1" />
+                                                Delete
+                                            </>
+                                        )}
                                     </Button>
                                 )}
                             </div>


### PR DESCRIPTION
… (#980)

Add useAudioInputDevices hook that enumerates audioinput devices and listens for `devicechange` events so plugging/unplugging a mic updates the UI live. When no device is present, the recorder button is disabled, its tooltip reads "No microphone detected", and an inline warning row appears below the button.

Includes a `window.__forceNoAudioInput` debug flag for QA on machines with a working mic.