### PR TITLE
fix(export): make Files Without Audio modal list scrollable (#998)

### DIFF
--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -619,6 +619,8 @@ function getWebviewContent(
                     border: 1px solid rgba(202, 138, 4, 0.25);
                     border-radius: 4px;
                     font-size: 0.9em;
+                    max-height: 40vh;
+                    overflow-y: auto;
                 }
                 .popup-file-list div { padding: 2px 0; }
             </style>


### PR DESCRIPTION
Closes #998

## What
When an audio export option is selected with files that have no audio, the **"Files Without Audio"** warning modal lists the affected files in an amber box. With a long list, that box grew past the viewport and couldn't be scrolled — so you couldn't see all the files (and couldn't scroll the page behind the modal either).

This caps the list box (`.popup-file-list`) at `max-height: 40vh` with `overflow-y: auto`, so the list scrolls within the modal and the whole dialog stays on-screen.

## Scope
Intentionally scoped to the **scroll behavior only** (issue criterion 3). The warning itself and the audio-export folder behavior are left unchanged by design.

## Changes
- `src/projectManager/projectExportView.ts` — add `max-height: 40vh; overflow-y: auto` to `.popup-file-list` (shared by the "Files Without Audio" and "Files Without Text" modals, so both benefit). +2 lines, no logic changes.

## Testing
- `npm run compile` succeeds; lint clean.
- Verified in the Extension Dev Host: Export → "All Text" → audio option → "Files Without Audio" modal; with many text-only books selected the file list now scrolls and the modal stays within the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
