### PR TITLE
fix(export): add OK button + align list icons in content-mismatch modal (#998)

### DIFF
--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -620,7 +620,8 @@ function getWebviewContent(
                     border-radius: 4px;
                     font-size: 0.9em;
                 }
-                .popup-file-list div { padding: 2px 0; }
+                .popup-file-list div { padding: 2px 0; display: flex; align-items: center; }
+                .popup-footer { display: flex; justify-content: flex-end; margin-top: 16px; }
             </style>
         </head>
         <body>
@@ -873,6 +874,9 @@ function getWebviewContent(
                         <p style="margin-top: 8px; color: var(--vscode-descriptionForeground); font-size: 0.85em;">
                             The export will still proceed, but the listed files will produce empty output for the selected format.
                         </p>
+                    </div>
+                    <div class="popup-footer">
+                        <button onclick="closeContentMismatchPopup()">OK</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Refs #998 (follow-up polish to the "Files Without Audio/Text" modal; companion to #1002)

## What
Two small UX tweaks to the content-mismatch warning modal in the Export Project view:

1. **OK button** — added a primary **OK** button at the bottom-right of the modal so users have an obvious way to dismiss it, instead of having to aim for the small `✕` in the corner.
2. **Icon alignment** — the file icon in each list row is now vertically centered with its filename (`display: flex; align-items: center`), instead of sitting slightly above the text baseline.

## Scope
- The OK button is added to the content-mismatch modal (shared by "Files Without Audio" and "Files Without Text").
- The alignment fix applies to the shared `.popup-file-list` rows, so both that modal and the HTML-structure-mismatch modal benefit.
- No behavior/logic changes — markup + CSS only.

## Changes
- `src/projectManager/projectExportView.ts` — add `.popup-footer` (flex, right-aligned) + OK button; add `display: flex; align-items: center` to `.popup-file-list div`. +5 / -1.

## Testing
- `npm run compile` succeeds; lint clean.
- Verified in the Extension Dev Host: Export → "All Text" → audio option → "Files Without Audio" modal now shows a bottom-right OK button that dismisses it, and the file icons line up with their names.

## Note
Independent of #1002 (the scroll-fix PR) — different CSS/HTML lines, no conflict, can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
