### PR TITLE
fix(editor): preserve consecutive spaces in cell editor (#1010)

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import Quill, { Delta, Op } from "quill";
 import "quill/dist/quill.snow.css";
+import { installPreserveWhitespaceMatcher } from "./utils/preserveWhitespace";
 import { getCleanedHtml } from "./utils";
 import {
     isSuperscriptibleDigit,
@@ -506,7 +507,20 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
             const clipboardModule = quill.getModule("clipboard") as {
                 addMatcher: (selector: number, matcher: typeof matchSuperscriptUnicodeDigits) => void;
                 convert: (args: { html?: string; text?: string }) => Delta;
+                matchers: Array<[number | string, (node: Node, delta: Delta, scroll: unknown) => Delta]>;
             };
+
+            // Replace Quill's built-in whitespace-collapsing text matcher with
+            // a non-destructive variant so runs of consecutive spaces survive
+            // the HTML → Delta conversion on cell open. See issue #1010 and
+            // utils/preserveWhitespace.ts.
+            const swapped = installPreserveWhitespaceMatcher(clipboardModule);
+            if (!swapped && DEBUG_ENABLED) {
+                console.warn(
+                    "[Editor] Could not locate Quill's built-in matchText to replace; double spaces may collapse on cell open (issue #1010)."
+                );
+            }
+
             clipboardModule.addMatcher(Node.TEXT_NODE, matchSuperscriptUnicodeDigits);
 
             // Apply minimal direct styles; rely on CSS file for look-and-feel
@@ -1518,7 +1532,16 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                     display: block;
                 }
                 .ql-editor {
-                    white-space: normal !important;
+                    /*
+                     * Keep Quill's default rendering posture (pre-wrap) so that
+                     * runs of consecutive spaces stay visible and editable while
+                     * a cell is open. The previous "normal" override collapsed
+                     * them at paint time, which (combined with Quill's clipboard
+                     * matcher dropping them at convert time — fixed separately
+                     * via preserveWhitespaceMatchText) made double spaces in
+                     * source text impossible to correct in place. See #1010.
+                     */
+                    white-space: pre-wrap !important;
                     background-color: var(--vscode-editor-background) !important;
                     color: var(--vscode-editor-foreground) !important;
                 }

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/preserveWhitespace.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/preserveWhitespace.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test for issue #1010: double spaces in source content must
+ * survive Quill's HTML → Delta conversion when a cell is opened.
+ *
+ * The test uses a real Quill instance (no mocks) and exercises the same code
+ * path the editor uses on cell open. If a future Quill upgrade restructures
+ * its clipboard module such that we can no longer locate the built-in
+ * `matchText` by reference (or changes its semantics), this test will fail
+ * loudly — that's the regression signal to revisit utils/preserveWhitespace.ts.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import Quill, { Delta } from "quill";
+import { installPreserveWhitespaceMatcher } from "../utils/preserveWhitespace";
+
+type ClipboardModule = {
+    convert: (args: { html?: string; text?: string }) => Delta;
+    matchers: Array<[number | string, unknown]>;
+};
+
+function makeQuillWithPreservedWhitespace(): { quill: Quill; clipboard: ClipboardModule } {
+    const container = document.createElement("div");
+    container.id = "quill-host";
+    document.body.appendChild(container);
+
+    const quill = new Quill(container, { theme: "snow" });
+    const clipboard = quill.getModule("clipboard") as unknown as ClipboardModule;
+
+    const swapped = installPreserveWhitespaceMatcher(clipboard as never);
+    if (!swapped) {
+        throw new Error(
+            "installPreserveWhitespaceMatcher failed: Quill's built-in matchText could not be located. " +
+                "If you just upgraded Quill, check that `matchText` is still exported from quill/modules/clipboard."
+        );
+    }
+
+    return { quill, clipboard };
+}
+
+function deltaText(delta: Delta): string {
+    return delta.ops
+        .map((op) => (typeof op.insert === "string" ? op.insert : ""))
+        .join("");
+}
+
+describe("preserveWhitespaceMatchText (issue #1010)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("preserves mid-line double ASCII spaces in a <p>", () => {
+        const { clipboard } = makeQuillWithPreservedWhitespace();
+
+        const delta = clipboard.convert({ html: "<p>hello  world</p>", text: "" });
+
+        expect(deltaText(delta)).toContain("hello  world");
+    });
+
+    it("preserves runs of 3+ ASCII spaces verbatim", () => {
+        const { clipboard } = makeQuillWithPreservedWhitespace();
+
+        const delta = clipboard.convert({ html: "<p>a   b    c</p>", text: "" });
+
+        expect(deltaText(delta)).toContain("a   b    c");
+    });
+
+    it("normalizes &nbsp; to a regular space (matches Quill's existing semantics)", () => {
+        // We don't want to silently let \u00A0 leak into the saved Delta — the
+        // user-visible text should be regular spaces. Only the *count* of
+        // consecutive spaces should be preserved.
+        const { clipboard } = makeQuillWithPreservedWhitespace();
+
+        const delta = clipboard.convert({ html: "<p>foo&nbsp;&nbsp;bar</p>", text: "" });
+
+        const text = deltaText(delta);
+        expect(text).toContain("foo  bar");
+        expect(text).not.toContain("\u00a0");
+    });
+
+    it("still strips a single leading space at the start of a block", () => {
+        // This is Quill's existing semantics for handling indented HTML —
+        // we want to preserve it. A leading single space at a block boundary
+        // should still be dropped.
+        const { clipboard } = makeQuillWithPreservedWhitespace();
+
+        const delta = clipboard.convert({ html: "<p> leading</p>", text: "" });
+
+        expect(deltaText(delta)).not.toMatch(/^ leading/);
+    });
+
+    it("still drops pure-whitespace text nodes between block elements", () => {
+        // Multi-paragraph HTML with newline indentation between <p> tags
+        // shouldn't produce phantom whitespace ops in the Delta.
+        const { clipboard } = makeQuillWithPreservedWhitespace();
+
+        const delta = clipboard.convert({
+            html: "<p>one</p>\n    <p>two</p>",
+            text: "",
+        });
+
+        const inserts = delta.ops
+            .map((op) => op.insert)
+            .filter((insert): insert is string => typeof insert === "string");
+
+        // No op should be purely indentation whitespace.
+        expect(inserts.every((s) => s.trim().length > 0 || s === "\n")).toBe(true);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/preserveWhitespace.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/preserveWhitespace.ts
@@ -1,0 +1,156 @@
+import type { Delta } from "quill";
+import { Parchment } from "quill";
+import { matchText as builtinMatchText } from "quill/modules/clipboard";
+
+/**
+ * Whitespace-preserving replacement for Quill's built-in `matchText` matcher.
+ *
+ * ### Why this exists
+ *
+ * Quill's default text matcher (quill/modules/clipboard.js → `matchText`)
+ * actively destroys data by collapsing runs of 2+ ASCII spaces into a single
+ * space when converting HTML → Delta. For a general-purpose rich-text editor
+ * that matches HTML rendering semantics, but for a scripture translation
+ * editor it silently corrupts content imported from source texts — e.g.
+ * mid-line double spaces in Portuguese source materials become invisible and
+ * uneditable in the open cell while still present in the closed-cell view.
+ * See issue #1010.
+ *
+ * ### What this does
+ *
+ * Mirrors Quill 2.0.3's `matchText` exactly except for the single offending
+ * line that collapses `/ {2,}/g → ' '`. All other behavior is preserved:
+ *
+ *  - Microsoft Word `<o:p>&nbsp;</o:p>` empty-line marker handling.
+ *  - `<pre>` ancestor pass-through (Quill preserves whitespace inside `<pre>`).
+ *  - Dropping pure-whitespace text nodes that sit between block elements
+ *    (mimics how browsers ignore indentation between block tags).
+ *  - Normalizing non-NBSP whitespace (tabs, CR, LF) to a regular space.
+ *  - Stripping single leading/trailing spaces at block boundaries.
+ *  - Final NBSP → space normalization, so user-typed double spaces (which
+ *    browsers in contenteditable convert to ` \u00A0`) round-trip as two
+ *    regular spaces in the saved HTML.
+ *
+ * ### Future
+ *
+ * Upstream PR https://github.com/slab/quill/pull/4319 ("Fix white spaces not
+ * being preserved when pasted into editor") would make `Clipboard#convert()`
+ * respect inline `white-space` style and obsolete this whole module. As of
+ * 2026-06 it remains open and unmerged. When/if it lands, remove this file
+ * and the matcher splice in Editor.tsx.
+ *
+ * The `isLine`, `isPreNode`, and `isBetweenInlineElements` helpers mirror
+ * Quill's private versions (clipboard.js lines 236–258 in 2.0.3) which are
+ * not exported. They've been structurally stable across recent Quill versions.
+ */
+
+const preNodes = new WeakMap<Node, boolean>();
+function isPreNode(node: Node | null): boolean {
+    if (node == null) return false;
+    const cached = preNodes.get(node);
+    if (cached !== undefined) return cached;
+    const result =
+        node instanceof Element && node.tagName === "PRE" ? true : isPreNode(node.parentNode);
+    preNodes.set(node, result);
+    return result;
+}
+
+// `scroll` is Quill's ScrollBlot; we don't depend on its full shape, just the
+// `query` method that resolves a DOM node to a registered blot definition.
+type ScrollLike = { query?: (node: Node) => unknown };
+
+function isLine(node: Node | null, scroll: ScrollLike | undefined | null): boolean {
+    if (!(node instanceof Element)) return false;
+    const match = scroll?.query?.(node) as { prototype?: unknown } | null | undefined;
+    return match != null && match.prototype instanceof Parchment.BlockBlot;
+}
+
+function isBetweenInlineElements(node: Node, scroll: ScrollLike | undefined | null): boolean {
+    const prev = (node as ChildNode).previousElementSibling;
+    const next = (node as ChildNode).nextElementSibling;
+    return !!(prev && next && !isLine(prev, scroll) && !isLine(next, scroll));
+}
+
+export function preserveWhitespaceMatchText(
+    node: Text,
+    delta: Delta,
+    scroll: ScrollLike | undefined | null
+): Delta {
+    let text = node.data;
+
+    if (node.parentElement?.tagName === "O:P") {
+        return delta.insert(text.trim());
+    }
+
+    if (isPreNode(node)) {
+        return delta.insert(text);
+    }
+
+    if (
+        text.trim().length === 0 &&
+        text.includes("\n") &&
+        !isBetweenInlineElements(node, scroll)
+    ) {
+        return delta;
+    }
+
+    text = text.replace(/[^\S\u00a0]/g, " ");
+    // NOTE: Quill's matchText collapses runs here with `text.replace(/ {2,}/g, ' ')`.
+    // We intentionally do NOT collapse — that's the entire point of this file.
+
+    const prevSibling = node.previousSibling;
+    const nextSibling = node.nextSibling;
+    if (
+        (prevSibling == null && node.parentElement != null && isLine(node.parentElement, scroll)) ||
+        (prevSibling instanceof Element && isLine(prevSibling, scroll))
+    ) {
+        text = text.replace(/^ /, "");
+    }
+    if (
+        (nextSibling == null && node.parentElement != null && isLine(node.parentElement, scroll)) ||
+        (nextSibling instanceof Element && isLine(nextSibling, scroll))
+    ) {
+        text = text.replace(/ $/, "");
+    }
+
+    text = text.replaceAll("\u00a0", " ");
+    return delta.insert(text);
+}
+
+/**
+ * Shape of the parts of Quill's Clipboard module we touch. Mirrors what
+ * `quill.getModule("clipboard")` actually returns at runtime; declared inline
+ * here so consumers don't need to depend on Quill's internal types.
+ */
+type ClipboardModuleLike = {
+    matchers?: Array<[number | string, (node: Node, delta: Delta, scroll: unknown) => Delta]>;
+};
+
+/**
+ * Swaps Quill's built-in TEXT_NODE `matchText` matcher with the
+ * whitespace-preserving version above. Identifies the existing entry by
+ * function reference (using the imported `builtinMatchText`) rather than by
+ * position, so the replacement is robust to Quill reordering its default
+ * matchers in a future patch release.
+ *
+ * Returns `true` if the swap succeeded, `false` if Quill's built-in matcher
+ * couldn't be located (e.g. because Quill's internals changed shape in an
+ * upgrade). Callers should treat `false` as a regression signal.
+ */
+export function installPreserveWhitespaceMatcher(clipboardModule: ClipboardModuleLike): boolean {
+    // Defensive against test doubles that stub out `clipboard` without a
+    // `matchers` array — silently no-op there.
+    if (!Array.isArray(clipboardModule?.matchers)) return false;
+
+    const entry = clipboardModule.matchers.find(
+        ([selector, matcher]) =>
+            selector === Node.TEXT_NODE && matcher === (builtinMatchText as unknown)
+    );
+    if (!entry) return false;
+    entry[1] = preserveWhitespaceMatchText as (
+        node: Node,
+        delta: Delta,
+        scroll: unknown
+    ) => Delta;
+    return true;
+}


### PR DESCRIPTION
TLDR: Quill editor is sloppy with whitespace, so we replaced a few of the troublesome functions

Claude says: _Quill's built-in `matchText` clipboard matcher collapses runs of 2+ ASCII spaces into a single space when converting HTML → Delta on cell open. For scripture translation, every character is meaningful: double spaces in imported source text (e.g. the Portuguese project) were silently dropped in the open editor view while still present in the closed-cell display, making them appear "hidden" and uneditable.

Fixes this at the root by:

1. Swapping Quill's built-in TEXT_NODE matcher for a non-destructive variant in `utils/preserveWhitespace.ts`. Mirrors Quill 2.0.3's matchText exactly minus the offending collapse line; all other semantics (Word `<o:p>` handling, `<pre>` passthrough, leading/ trailing-space stripping at block boundaries, NBSP normalization) are preserved. The matcher is located by function reference so a future Quill reordering doesn't silently re-introduce the bug.

2. Restoring `.ql-editor`'s `white-space` to `pre-wrap` (Quill's actual default) so the now-preserved spaces render visibly while editing.

Adds a vitest regression suite that exercises the matcher against a real Quill instance to catch any future Quill upgrade that breaks the splice.

If upstream PR https://github.com/slab/quill/pull/4319 ever lands, `utils/preserveWhitespace.ts` and the splice in `Editor.tsx` can be removed entirely._