### PR TITLE
feat(migration): retain cell validations through the Migration Tool

### DIFF
--- a/src/codexMigrationTool/codexMigrationTool.ts
+++ b/src/codexMigrationTool/codexMigrationTool.ts
@@ -5,6 +5,7 @@ import { safePostMessageToPanel } from "../utils/webviewUtils";
 import { matchMigrationCells } from "./matcher";
 import { applyMigrationToTargetFile } from "./updater";
 import { getSQLiteIndexManager } from "../activationHelpers/contextAware/contentIndexes/indexes/sqliteIndexManager";
+import { FileSyncManager } from "../activationHelpers/contextAware/contentIndexes/fileSyncManager";
 import type { FileData } from "../activationHelpers/contextAware/contentIndexes/indexes/fileReaders";
 import type { MigrationMatchResult, MigrationRunConfig, SourceFileUIData } from "./types";
 
@@ -192,7 +193,23 @@ export async function openCodexMigrationTool(context: vscode.ExtensionContext) {
                         toFileUri: toTargetFile.uri,
                         matches,
                         forceOverride: data.forceOverride,
+                        // Default ON: an older webview that omits the field still keeps validations.
+                        keepValidations: data.keepValidations ?? true,
                     });
+
+                    // Re-index the just-written target file so validation counts / indicators
+                    // refresh in-session. Content-hash gated (only the changed file re-indexes)
+                    // and writes solely to the local SQLite index — no git/remote sync.
+                    if (updated > 0 && sqliteManager) {
+                        try {
+                            await new FileSyncManager(sqliteManager).syncFiles({});
+                        } catch (reindexError) {
+                            console.warn(
+                                "[CodexMigrationTool] post-migration reindex failed:",
+                                reindexError
+                            );
+                        }
+                    }
 
                     safePostMessageToPanel(panel, {
                         command: "migrationResults",

--- a/src/codexMigrationTool/types.ts
+++ b/src/codexMigrationTool/types.ts
@@ -30,6 +30,8 @@ export interface MigrationRunConfig {
     toFilePath: string;
     matchMode: CodexMigrationMatchMode;
     forceOverride: boolean;
+    /** When true, carry text + audio validation status over to migrated cells. */
+    keepValidations: boolean;
     /** 1-based starting line in the source file (lineNumber mode only). */
     fromStartLine?: number;
     /** 1-based starting line in the target file (lineNumber mode only). */

--- a/src/codexMigrationTool/updater.ts
+++ b/src/codexMigrationTool/updater.ts
@@ -5,6 +5,7 @@ import { EditMapUtils } from "../utils/editMapUtils";
 import { EditType } from "../../types/enums";
 import { getAuthApi } from "../extension";
 import type { CustomNotebookCellData } from "../../types";
+import type { EditHistory, ValidationEntry } from "../../types/index.d";
 import type { MigrationMatchResult } from "./types";
 
 const cloneCell = (cell: CustomNotebookCellData): CustomNotebookCellData => {
@@ -57,13 +58,97 @@ const ensureValueEditForMerge = (
     addMigrationEdit(cell, 0, author);
 };
 
+const isObjectValidationEntry = (entry: any): entry is ValidationEntry =>
+    !!entry && typeof entry === "object" && typeof entry.username === "string";
+
+/**
+ * Returns the cell's current ("live") value edit — the last value edit in array
+ * order. This mirrors exactly how the SQLite indexer + editor UI decide which
+ * edit's `validatedBy` represents the cell's text-validation status
+ * (`extractMetadataFields` in sqliteIndex.ts reads `valueEdits[valueEdits.length - 1]`).
+ */
+const getLastValueEdit = (cell: CustomNotebookCellData): EditHistory | null => {
+    const edits = cell.metadata?.edits ?? [];
+    const valueEdits = edits.filter((edit) => edit.editMap && EditMapUtils.isValue(edit.editMap));
+    return valueEdits.length > 0 ? valueEdits[valueEdits.length - 1] : null;
+};
+
+/**
+ * Snapshot of the validations that currently apply to a cell's live text, plus the
+ * exact value string they were attached to. Captured BEFORE the cell copy is mutated
+ * so the validations can later be re-attached only to identical surviving content.
+ */
+const collectCurrentTextValidations = (
+    cell: CustomNotebookCellData
+): { validations: ValidationEntry[]; value: string | undefined } => {
+    const lastValueEdit = getLastValueEdit(cell);
+    const validatedBy = lastValueEdit?.validatedBy;
+    return {
+        validations: Array.isArray(validatedBy)
+            ? validatedBy.filter(isObjectValidationEntry)
+            : [],
+        value: typeof lastValueEdit?.value === "string" ? lastValueEdit.value : undefined,
+    };
+};
+
+/**
+ * Union `incoming` validation entries into `existing`, deduped by username. Mirrors
+ * the semantics of `mergeValidatedByArrays` in the shared resolver: the original
+ * `creationTimestamp` is kept, and a newer `updatedTimestamp` wins. Returns a new array.
+ */
+const unionValidationEntries = (
+    existing: ValidationEntry[],
+    incoming: ValidationEntry[]
+): ValidationEntry[] => {
+    const result = existing.map((entry) => ({ ...entry }));
+    for (const entry of incoming) {
+        const index = result.findIndex((e) => e.username === entry.username);
+        if (index === -1) {
+            result.push({ ...entry });
+        } else if (entry.updatedTimestamp > result[index].updatedTimestamp) {
+            result[index] = { ...entry, creationTimestamp: result[index].creationTimestamp };
+        }
+    }
+    return result;
+};
+
+/**
+ * Remove all validation status from a cell copy: clears `validatedBy` from every edit
+ * and from every attachment. Used on the SOURCE copy when "Keep validation status" is
+ * OFF so the merge cannot carry any source validations into the target.
+ */
+const stripValidations = (cell: CustomNotebookCellData): void => {
+    for (const edit of cell.metadata?.edits ?? []) {
+        if (edit.validatedBy) {
+            delete edit.validatedBy;
+        }
+    }
+    const attachments = cell.metadata?.attachments;
+    if (attachments) {
+        for (const id of Object.keys(attachments)) {
+            const attachment = attachments[id] as { validatedBy?: ValidationEntry[]; };
+            if (attachment?.validatedBy) {
+                delete attachment.validatedBy;
+            }
+        }
+    }
+};
+
 export async function applyMigrationToTargetFile(params: {
     fromFileUri: vscode.Uri;
     toFileUri: vscode.Uri;
     matches: MigrationMatchResult[];
     forceOverride: boolean;
+    /**
+     * When true, text + audio validations are carried over to migrated cells
+     * (preserving the original validator identity/timestamps); when false, no
+     * validation status is transferred from the source. Defaults to false so
+     * programmatic callers keep the historical behavior; the UI handler always
+     * passes an explicit value (defaulting ON).
+     */
+    keepValidations?: boolean;
 }): Promise<{ updated: number; skipped: number; }> {
-    const { fromFileUri, toFileUri, matches, forceOverride } = params;
+    const { fromFileUri, toFileUri, matches, forceOverride, keepValidations = false } = params;
     const serializer = new CodexContentSerializer();
 
     let currentUser = "anonymous";
@@ -116,6 +201,21 @@ export async function applyMigrationToTargetFile(params: {
         const fromCellCopy = cloneCell(fromCell);
         const toCellCopy = cloneCell(toEntry.cell);
 
+        // Capture the live text validations (and the exact value they apply to) from
+        // both sides BEFORE mutating the copies, so we can re-attach them afterwards.
+        const sourceValidationState = keepValidations
+            ? collectCurrentTextValidations(fromCellCopy)
+            : null;
+        const targetValidationState = keepValidations
+            ? collectCurrentTextValidations(toCellCopy)
+            : null;
+
+        if (!keepValidations) {
+            // Discard: strip validations from the SOURCE copy only so the resolver
+            // cannot carry them into the target. The target copy keeps its own.
+            stripValidations(fromCellCopy);
+        }
+
         if (forceOverride) {
             addMigrationEdit(fromCellCopy, migrationTimestamp, currentUser);
         } else {
@@ -123,6 +223,33 @@ export async function applyMigrationToTargetFile(params: {
         }
 
         const mergedCell = mergeDuplicateCellsUsingResolverLogic([toCellCopy, fromCellCopy]);
+
+        // Re-attach validations onto the merged cell's live text edit, but only those
+        // whose original validated value is exactly the content that survived the merge.
+        // This keeps a validation tied to the precise text it was applied to (we never
+        // stamp "validated" onto text the validator never saw) and prevents the resolver's
+        // same-value/different-timestamp edit handling from silently dropping a still-valid
+        // validation when a newer edit displaces the one it lived on.
+        if (keepValidations) {
+            const mergedLastValueEdit = getLastValueEdit(mergedCell);
+            if (mergedLastValueEdit && typeof mergedLastValueEdit.value === "string") {
+                const finalValue = mergedLastValueEdit.value;
+                const incoming: ValidationEntry[] = [];
+                if (sourceValidationState && sourceValidationState.value === finalValue) {
+                    incoming.push(...sourceValidationState.validations);
+                }
+                if (targetValidationState && targetValidationState.value === finalValue) {
+                    incoming.push(...targetValidationState.validations);
+                }
+                if (incoming.length > 0) {
+                    const existing = Array.isArray(mergedLastValueEdit.validatedBy)
+                        ? mergedLastValueEdit.validatedBy.filter(isObjectValidationEntry)
+                        : [];
+                    mergedLastValueEdit.validatedBy = unionValidationEntries(existing, incoming);
+                }
+            }
+        }
+
         toNotebook.cells[toEntry.index] = mergedCell;
         updated += 1;
     }

--- a/src/test/suite/codexMigrationTool.integration.test.ts
+++ b/src/test/suite/codexMigrationTool.integration.test.ts
@@ -86,6 +86,104 @@ const buildFileDataWithTypes = (params: {
     })),
 });
 
+// ── Validation-retention test helpers (issue #1005) ────────────────────────────
+const mkValidation = (username: string, timestamp: number, isDeleted = false) => ({
+    username,
+    creationTimestamp: timestamp,
+    updatedTimestamp: timestamp,
+    isDeleted,
+});
+
+const valueEditsOf = (cell: any): any[] =>
+    (cell.metadata?.edits ?? []).filter((e: any) => e.editMap && EditMapUtils.isValue(e.editMap));
+
+const lastValueEdit = (cell: any): any => {
+    const ve = valueEditsOf(cell);
+    return ve[ve.length - 1];
+};
+
+/** Attach text validations to a cell's last value edit (mutates + returns the cell). */
+const withTextValidations = (
+    cell: CustomNotebookCellData,
+    validators: Array<{ username: string; timestamp: number; isDeleted?: boolean; }>
+): CustomNotebookCellData => {
+    lastValueEdit(cell).validatedBy = validators.map((v) =>
+        mkValidation(v.username, v.timestamp, v.isDeleted)
+    );
+    return cell;
+};
+
+/** Attach a selected, validated audio attachment to a cell (mutates + returns the cell). */
+const withAudioValidation = (
+    cell: CustomNotebookCellData,
+    attachmentId: string,
+    validators: Array<{ username: string; timestamp: number; isDeleted?: boolean; }>,
+    timestamp: number
+): CustomNotebookCellData => {
+    (cell.metadata as any).attachments = {
+        [attachmentId]: {
+            type: "audio",
+            url: `attachments/${attachmentId}.wav`,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            isDeleted: false,
+            validatedBy: validators.map((v) => mkValidation(v.username, v.timestamp, v.isDeleted)),
+        },
+    };
+    (cell.metadata as any).selectedAudioId = attachmentId;
+    (cell.metadata as any).selectionTimestamp = timestamp;
+    return cell;
+};
+
+/** Active (non-deleted) text validator usernames on the cell's live edit — mirrors the indexer. */
+const activeTextValidators = (cell: any): string[] =>
+    ((lastValueEdit(cell)?.validatedBy ?? []) as any[])
+        .filter((v) => v && typeof v === "object" && v.isDeleted === false)
+        .map((v) => v.username)
+        .sort();
+
+const activeAudioValidators = (cell: any, attachmentId: string): string[] =>
+    ((cell.metadata?.attachments?.[attachmentId]?.validatedBy ?? []) as any[])
+        .filter((v) => v && typeof v === "object" && v.isDeleted === false)
+        .map((v) => v.username)
+        .sort();
+
+const readNotebook = async (uri: vscode.Uri) => {
+    const serializer = new CodexContentSerializer();
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return serializer.deserializeNotebook(bytes, new vscode.CancellationTokenSource().token);
+};
+
+/** Create temp from/to files, run a single-cell migration, return the migrated target cell. */
+const migrateSingleCell = async (
+    baseName: string,
+    fromCell: CustomNotebookCellData,
+    toCell: CustomNotebookCellData,
+    opts: { forceOverride: boolean; keepValidations: boolean; }
+): Promise<CustomNotebookCellData> => {
+    const fromUri = await createTempCodexFile(
+        `${baseName}-from.codex`,
+        buildNotebook([fromCell], `${baseName}-from`, `${baseName}-from.codex`)
+    );
+    const toUri = await createTempCodexFile(
+        `${baseName}-to.codex`,
+        buildNotebook([toCell], `${baseName}-to`, `${baseName}-to.codex`)
+    );
+    try {
+        await applyMigrationToTargetFile({
+            fromFileUri: fromUri,
+            toFileUri: toUri,
+            matches: [{ fromCellId: fromCell.metadata!.id, toCellId: toCell.metadata!.id }],
+            forceOverride: opts.forceOverride,
+            keepValidations: opts.keepValidations,
+        });
+        return (await readNotebook(toUri)).cells[0];
+    } finally {
+        await deleteIfExists(fromUri);
+        await deleteIfExists(toUri);
+    }
+};
+
 suite("Codex migration tool integration", function () {
     this.timeout(30_000);
 
@@ -247,6 +345,113 @@ suite("Codex migration tool integration", function () {
             await deleteIfExists(fromUri);
             await deleteIfExists(toUri);
         }
+    });
+
+    // ── Validation retention (issue #1005) ─────────────────────────────────────
+    test("keepValidations ON: preserves source text validation + identity (force override)", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-keep-force",
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "from value", edits: [{ value: "from value", timestamp: 1000 }] }),
+                [{ username: "alice", timestamp: 500 }]
+            ),
+            buildCell({ id: "cell-1", value: "to value", edits: [{ value: "to value", timestamp: 2000 }] }),
+            { forceOverride: true, keepValidations: true }
+        );
+        assert.strictEqual(migrated.value, "from value", "migrated content should win");
+        assert.deepStrictEqual(activeTextValidators(migrated), ["alice"], "alice validation should carry over");
+        const alice = (lastValueEdit(migrated).validatedBy as any[]).find((v) => v.username === "alice");
+        assert.strictEqual(alice.creationTimestamp, 500, "original creation timestamp preserved");
+    });
+
+    test("keepValidations OFF: source text validation not transferred; target's own survives", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-discard",
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+                [{ username: "alice", timestamp: 500 }]
+            ),
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 2000 }] }),
+                [{ username: "bob", timestamp: 1500 }]
+            ),
+            { forceOverride: false, keepValidations: false }
+        );
+        assert.deepStrictEqual(activeTextValidators(migrated), ["bob"], "only the target's own validation should remain");
+    });
+
+    test("keepValidations ON: unions source + target validators on identical content (no duplicates)", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-union",
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+                [{ username: "alice", timestamp: 500 }]
+            ),
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 2000 }] }),
+                [{ username: "bob", timestamp: 1500 }]
+            ),
+            { forceOverride: false, keepValidations: true }
+        );
+        assert.deepStrictEqual(activeTextValidators(migrated), ["alice", "bob"], "both validators preserved, deduped");
+    });
+
+    test("keepValidations ON: does not stamp validation onto unseen surviving content (force off)", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-nograft",
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "S", edits: [{ value: "S", timestamp: 1000 }] }),
+                [{ username: "alice", timestamp: 500 }]
+            ),
+            buildCell({ id: "cell-1", value: "T", edits: [{ value: "T", timestamp: 2000 }] }),
+            { forceOverride: false, keepValidations: true }
+        );
+        assert.strictEqual(lastValueEdit(migrated).value, "T", "target content should survive");
+        assert.deepStrictEqual(activeTextValidators(migrated), [], "source validation must not apply to unseen text");
+    });
+
+    test("keepValidations ON: preserves source audio validation", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-audio-keep",
+            withAudioValidation(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+                "att-1", [{ username: "alice", timestamp: 500 }], 600
+            ),
+            buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+            { forceOverride: false, keepValidations: true }
+        );
+        assert.deepStrictEqual(activeAudioValidators(migrated, "att-1"), ["alice"], "audio validation should carry over");
+    });
+
+    test("keepValidations OFF: source audio validation not transferred", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-audio-discard",
+            withAudioValidation(
+                buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+                "att-1", [{ username: "alice", timestamp: 500 }], 600
+            ),
+            buildCell({ id: "cell-1", value: "X", edits: [{ value: "X", timestamp: 1000 }] }),
+            { forceOverride: false, keepValidations: false }
+        );
+        assert.deepStrictEqual(activeAudioValidators(migrated, "att-1"), [], "audio validation must not transfer when discarding");
+    });
+
+    test("keepValidations ON: original validator can remove their migrated validation", async () => {
+        const migrated = await migrateSingleCell(
+            "mig-val-remove",
+            withTextValidations(
+                buildCell({ id: "cell-1", value: "from value", edits: [{ value: "from value", timestamp: 1000 }] }),
+                [{ username: "alice", timestamp: 500 }]
+            ),
+            buildCell({ id: "cell-1", value: "to value", edits: [{ value: "to value", timestamp: 2000 }] }),
+            { forceOverride: true, keepValidations: true }
+        );
+        // The grafted entry retains alice's identity, so removal-by-username (as the editor does) works.
+        const alice = (lastValueEdit(migrated).validatedBy as any[]).find((v) => v.username === "alice");
+        assert.ok(alice, "alice entry present after migration");
+        alice.isDeleted = true;
+        alice.updatedTimestamp = 9999;
+        assert.deepStrictEqual(activeTextValidators(migrated), [], "validation removable by the original validator");
     });
 
     test("sequential match + applyMigrationToTargetFile migrates content", async () => {

--- a/webviews/codex-webviews/src/CodexMigrationToolView/App.tsx
+++ b/webviews/codex-webviews/src/CodexMigrationToolView/App.tsx
@@ -42,6 +42,7 @@ type AppState = {
     toFilePath: string;
     matchMode: CodexMigrationMatchMode;
     forceOverride: boolean;
+    keepValidations: boolean;
     fromStartLine: number;
     toStartLine: number;
     maxCells: string;
@@ -153,6 +154,8 @@ const App: React.FC = () => {
             toFilePath: (persisted?.toFilePath as string) || "",
             matchMode: (persisted?.matchMode as CodexMigrationMatchMode) || "globalReferences",
             forceOverride: (persisted?.forceOverride as boolean) || false,
+            // Default ON — must use ?? so a persisted `false` is not flipped back to true.
+            keepValidations: (persisted?.keepValidations as boolean) ?? true,
             fromStartLine: (persisted?.fromStartLine as number) || 1,
             toStartLine: (persisted?.toStartLine as number) || 1,
             maxCells: (persisted?.maxCells as string) || "",
@@ -215,6 +218,7 @@ const App: React.FC = () => {
             toFilePath: state.toFilePath,
             matchMode: state.matchMode,
             forceOverride: state.forceOverride,
+            keepValidations: state.keepValidations,
         };
         if (state.matchMode === "lineNumber") {
             data.fromStartLine = state.fromStartLine;
@@ -380,6 +384,23 @@ const App: React.FC = () => {
                             />
                             <Label htmlFor="forceOverride" className="cursor-pointer">
                                 Force migrated edits to supersede existing content
+                            </Label>
+                        </div>
+
+                        {/* Keep validations checkbox */}
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="keepValidations"
+                                checked={state.keepValidations}
+                                onCheckedChange={(checked) =>
+                                    setState((prev) => ({
+                                        ...prev,
+                                        keepValidations: checked === true,
+                                    }))
+                                }
+                            />
+                            <Label htmlFor="keepValidations" className="cursor-pointer">
+                                Keep validation status for cells
                             </Label>
                         </div>
 


### PR DESCRIPTION
## Summary

Adds a **"Keep validation status for cells"** option (default ON) to the Codex Migration Tool so that, when merging two `.codex` files, cell **validations** (both text and audio) carry over to the migrated cells — preserving each original validator's identity and timestamps. Previously only cell *content* migrated; validations were dropped.

Closes #1005.

## Behavior

- **Keep ON (default):** a source cell's current validations are grafted onto the merged cell's live value edit, **gated by exact value-equality** so a validation only follows the precise content it was applied to (never stamping "validated" onto text the validator never saw). Validators are **unioned** by username (dedup; original `creationTimestamp` kept, newer `updatedTimestamp` wins). The target cell's own still-applicable validations are retained too. Audio validations ride along via the existing attachment merge.
- **Keep OFF:** `validatedBy` is stripped from the **source copy only** (edits + attachments) before the merge, so no validation status transfers; the target's own validations are untouched.
- **Identity preserved** → the original validator can still remove their validation after migration.
- After a successful migration the changed file is re-indexed (content-hash-gated, local only) so validation indicators refresh **in-session** without reopening the project.

## Implementation

- `src/codexMigrationTool/updater.ts` — `keepValidations` flow + helpers (`getLastValueEdit`, `collectCurrentTextValidations`, `unionValidationEntries`, `stripValidations`). The shared merge resolver is **reused, not modified**.
- `src/codexMigrationTool/types.ts` / `codexMigrationTool.ts` — thread `keepValidations` (defaults ON in the handler) + post-migration `FileSyncManager.syncFiles` reindex.
- `webviews/.../CodexMigrationToolView/App.tsx` — persisted "Keep validation status for cells" checkbox under the existing force-supersede option.

## Testing

- Added 7 integration tests (`codexMigrationTool.integration.test.ts`): text/audio preserve + discard, source↔target union without duplicates, no-graft when surviving content differs, and original-validator removal.
- Full migration suite **25/25 passing**; `npm run compile` + ESLint clean; `CodexMigrationToolView` webview bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
