### PR TITLE
fix(editor): restore unmerge option + in-editor merge confirmation (#691)

### DIFF
--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -3121,7 +3121,7 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
 
     confirmCellMerge: async ({ event, document, webviewPanel, provider }) => {
         const typedEvent = event as Extract<EditorPostMessages, { command: "confirmCellMerge"; }>;
-        const { currentCellId, previousCellId, currentContent, previousContent, message } = typedEvent.content;
+        const { currentCellId, previousCellId, currentContent, previousContent } = typedEvent.content;
 
         debug("confirmCellMerge message received for cells:", { currentCellId, previousCellId });
 
@@ -3149,45 +3149,36 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 }
             }
 
-            // No child cells found, proceed with existing confirmation flow
-            const confirmed = await vscode.window.showWarningMessage(
-                message,
-                { modal: false },
-                "Yes",
-                "No"
-            );
-
-            if (confirmed === "Yes") {
-                // User confirmed, proceed with merge
-                const mergeEvent: EditorPostMessages = {
-                    command: "mergeCellWithPrevious" as const,
-                    content: {
-                        currentCellId,
-                        previousCellId,
-                        currentContent,
-                        previousContent
-                    }
-                };
-
-                // Call the existing merge handler
-                await messageHandlers.mergeCellWithPrevious({
-                    event: mergeEvent,
-                    document,
-                    webviewPanel,
-                    provider,
-                    updateWebview: () => {
-                        provider.refreshWebview(webviewPanel, document);
-                    }
-                });
-
-                // Only merge in target if we're working with a source file
-                if (isSourceFile) {
-                    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-                    if (!workspaceFolder) {
-                        throw new Error("No workspace folder found");
-                    }
-                    await provider.mergeMatchingCellsInTargetFile(currentCellId, previousCellId, document.uri.toString(), workspaceFolder);
+            // No child cells found. Confirmation already happened in the webview modal, so
+            // proceed directly with the merge.
+            const mergeEvent: EditorPostMessages = {
+                command: "mergeCellWithPrevious" as const,
+                content: {
+                    currentCellId,
+                    previousCellId,
+                    currentContent,
+                    previousContent
                 }
+            };
+
+            // Call the existing merge handler
+            await messageHandlers.mergeCellWithPrevious({
+                event: mergeEvent,
+                document,
+                webviewPanel,
+                provider,
+                updateWebview: () => {
+                    provider.refreshWebview(webviewPanel, document);
+                }
+            });
+
+            // Only merge in target if we're working with a source file
+            if (isSourceFile) {
+                const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+                if (!workspaceFolder) {
+                    throw new Error("No workspace folder found");
+                }
+                await provider.mergeMatchingCellsInTargetFile(currentCellId, previousCellId, document.uri.toString(), workspaceFolder);
             }
         } catch (error) {
             console.error("Error in confirmCellMerge:", error);

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -3294,6 +3294,19 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                 merged: false
             });
 
+            // Resolve the user performing the unmerge so the edit is attributed to
+            // them — matching the merge edit — instead of a hardcoded "anonymous"
+            // (PR #1024 review). Best-effort lookup with an anonymous fallback, done
+            // before the edit push so a lookup failure can't drop the edit itself.
+            let unmergeAuthor = "anonymous";
+            try {
+                const authApi = await this.getAuthApi();
+                const userInfo = await authApi?.getUserInfo();
+                unmergeAuthor = userInfo?.username || "anonymous";
+            } catch (e) {
+                console.warn("Could not resolve user for unmerge edit, using 'anonymous':", e);
+            }
+
             // Append edit history entry for merged=false on the target cell
             try {
                 const cell = (targetDocument as any).getCell(cellIdToUnmerge);
@@ -3304,7 +3317,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                         value: false,
                         timestamp: Date.now(),
                         type: "user-edit",
-                        author: "anonymous",
+                        author: unmergeAuthor,
                         validatedBy: []
                     });
                     // updateCellData() above already fired the change event, which can

--- a/src/test/suite/codexCellEditorProvider.test.ts
+++ b/src/test/suite/codexCellEditorProvider.test.ts
@@ -2676,6 +2676,14 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 }
                 return originalExec(command, ...args);
             };
+            // Attribute the unmerge to a known user so we can assert the recorded
+            // edit author is the real user, not "anonymous" (PR #1024 review).
+            const UNMERGE_USER = "unmerge-test-user";
+            const originalGetAuthApi = (provider as any).getAuthApi;
+            (provider as any).getAuthApi = async () => {
+                const base = (await originalGetAuthApi?.call(provider)) || {};
+                return { ...base, getUserInfo: async () => ({ username: UNMERGE_USER }) };
+            };
             try {
                 // Now unmerge from source and confirm target unmerges with edit
                 await handleMessages({
@@ -2687,6 +2695,7 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 await provider.unmergeMatchingCellsInTargetFile(currentCellId, sourceUri.toString(), workspaceFolder);
             } finally {
                 vscode.commands.executeCommand = originalExec;
+                (provider as any).getAuthApi = originalGetAuthApi;
             }
 
             // Re-read both docs
@@ -2694,16 +2703,18 @@ suite("CodexCellEditorProvider Test Suite", () => {
             const srcCellAfter = (srcAfterUnmerge.cells || []).find((c: any) => c?.metadata?.id === currentCellId);
             assert.ok(srcCellAfter, "Source should still contain the current cell after unmerge");
             assert.strictEqual(!!srcCellAfter.metadata?.data?.merged, false, "Source current cell should be unmerged (merged=false)");
-            const srcHasUnmergeEdit = (srcCellAfter.metadata?.edits || []).some((e: any) => Array.isArray(e.editMap) && e.editMap.join(".") === "metadata.data.merged" && e.value === false);
-            assert.ok(srcHasUnmergeEdit, "Source current cell should have an edit recording merged=false");
+            const srcUnmergeEdit = (srcCellAfter.metadata?.edits || []).find((e: any) => Array.isArray(e.editMap) && e.editMap.join(".") === "metadata.data.merged" && e.value === false);
+            assert.ok(srcUnmergeEdit, "Source current cell should have an edit recording merged=false");
+            assert.strictEqual(srcUnmergeEdit.author, UNMERGE_USER, "Source unmerge edit should be attributed to the unmerging user, not 'anonymous'");
 
             // Re-open/refresh target by reading from disk to capture external mutation
             const targetDisk = JSON.parse(new TextDecoder().decode(await vscode.workspace.fs.readFile(targetUri)));
             const targetCellAfter = (targetDisk.cells || []).find((c: any) => c?.metadata?.id === currentCellId);
             assert.ok(targetCellAfter, "Target should still contain the current cell after unmerge");
             assert.strictEqual(!!targetCellAfter.metadata?.data?.merged, false, "Target current cell should be unmerged (merged=false)");
-            const targetHasUnmergeEdit = (targetCellAfter.metadata?.edits || []).some((e: any) => Array.isArray(e.editMap) && e.editMap.join(".") === "metadata.data.merged" && e.value === false);
-            assert.ok(targetHasUnmergeEdit, "Target current cell should have an edit recording merged=false");
+            const targetUnmergeEdit = (targetCellAfter.metadata?.edits || []).find((e: any) => Array.isArray(e.editMap) && e.editMap.join(".") === "metadata.data.merged" && e.value === false);
+            assert.ok(targetUnmergeEdit, "Target current cell should have an edit recording merged=false");
+            assert.strictEqual(targetUnmergeEdit.author, UNMERGE_USER, "Target unmerge edit should be attributed to the unmerging user, not 'anonymous' (#1024)");
         } finally {
             // Cleanup temp files
             await deleteIfExists(sourceUri);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -603,7 +603,6 @@ export type EditorPostMessages =
             previousCellId: string;
             currentContent: string;
             previousContent: string;
-            message: string;
         };
     }
     | {

--- a/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
@@ -137,6 +137,13 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
         const [showSparkleButton, setShowSparkleButton] = useState(false);
         const [showAuthModal, setShowAuthModal] = useState(false);
         const [showOfflineModal, setShowOfflineModal] = useState(false);
+        // Pending merge awaiting in-editor confirmation (replaces the native VS Code popup)
+        const [pendingMerge, setPendingMerge] = useState<{
+            currentCellId: string;
+            previousCellId: string;
+            currentContent: string;
+            previousContent: string;
+        } | null>(null);
         const [isLockButtonGlowing, setIsLockButtonGlowing] = useState(false);
         const [isLockButtonFlashing, setIsLockButtonFlashing] = useState(false);
         const [isResolvingStructure, setIsResolvingStructure] = useState(false);
@@ -390,18 +397,27 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                 return;
             }
 
-            // Send confirmation request to VS Code instead of using window.confirm
+            // Open an in-editor confirmation modal instead of the native VS Code popup
+            // (which appears in the bottom-right corner of the screen, far from the cell).
+            setPendingMerge({
+                currentCellId: currentCell.cellMarkers[0],
+                previousCellId: targetCell.cellMarkers[0],
+                currentContent: currentCell.cellContent,
+                previousContent: targetCell.cellContent,
+            });
+        };
+
+        const handleConfirmMerge = () => {
+            if (!pendingMerge) return;
             vscode.postMessage({
                 command: "confirmCellMerge",
-                content: {
-                    currentCellId: currentCell.cellMarkers[0],
-                    previousCellId: targetCell.cellMarkers[0],
-                    currentContent: currentCell.cellContent,
-                    previousContent: targetCell.cellContent,
-                    message:
-                        "Are you sure you want to merge this cell with the previous non-merged cell? This action cannot be undone.",
-                },
+                content: pendingMerge,
             } as any);
+            setPendingMerge(null);
+        };
+
+        const handleCancelMergeConfirmation = () => {
+            setPendingMerge(null);
         };
 
         // Line numbers are always generated and shown at the beginning of each line
@@ -977,6 +993,34 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                                             </Button>
                                         </div>
                                     )}
+                                    <Dialog
+                                        open={!!pendingMerge}
+                                        onOpenChange={(open) => {
+                                            if (!open) handleCancelMergeConfirmation();
+                                        }}
+                                    >
+                                        <DialogContent>
+                                            <DialogHeader>
+                                                <DialogTitle>Merge with previous cell</DialogTitle>
+                                                <DialogDescription>
+                                                    This cell will be merged into the previous
+                                                    non-merged cell. You can reverse this later by
+                                                    unmerging the cell.
+                                                </DialogDescription>
+                                            </DialogHeader>
+                                            <DialogFooter>
+                                                <Button
+                                                    variant="secondary"
+                                                    onClick={handleCancelMergeConfirmation}
+                                                >
+                                                    Cancel
+                                                </Button>
+                                                <Button autoFocus onClick={handleConfirmMerge}>
+                                                    Merge
+                                                </Button>
+                                            </DialogFooter>
+                                        </DialogContent>
+                                    </Dialog>
                                 </div>
                             </div>
                         )}

--- a/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
@@ -157,24 +157,21 @@ const CellList: React.FC<CellListProps> = ({
     // State to track unresolved comments count for each cell
     const [cellCommentsCount, setCellCommentsCount] = useState<Map<string, number>>(new Map());
 
-    // Filter out merged cells if we're in correction editor mode for source text
     const filteredTranslationUnits = useMemo(() => {
         let filtered = translationUnits;
 
-        // Filter out merged cells if we're in correction editor mode for source text
-        if (isSourceText && isCorrectionEditorMode) {
-            filtered = filtered.filter((unit) => {
-                // Check if cell has merged metadata in the data property
-                const cellData = unit.data as any;
-                return !cellData?.merged;
-            });
-        }
+        // NOTE: Do NOT filter out merged cells here. In source + correction editor mode the
+        // provider intentionally keeps merged cells in the translation units (see
+        // mergeRangesAndProcess) so they render greyed-out with the "unmerge" button. In every
+        // other mode the provider already strips merged cells, so they never reach this list.
+        // Filtering them here previously hid them in correction mode, which removed the only
+        // place the unmerge button could appear (issue #691).
 
         // Filter out milestone cells from the view (they remain in JSON)
         filtered = filtered.filter((unit) => unit.cellType !== CodexCellTypes.MILESTONE);
 
         return filtered;
-    }, [translationUnits, isSourceText, isCorrectionEditorMode]);
+    }, [translationUnits]);
     // Use filtered units for all operations
     const workingTranslationUnits = filteredTranslationUnits;
     // State to track completed translations (only successful ones) - REMOVED: Now handled by parent

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.mergeConfirm.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.mergeConfirm.test.tsx
@@ -1,0 +1,173 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuillCellContent } from "../../../../../types";
+import { CodexCellTypes } from "../../../../../types/enums";
+import CellContentDisplay from "../CellContentDisplay";
+
+// Regression test for the #691 follow-up: the merge confirmation is now an in-editor modal
+// (rendered inside the source editor) instead of a native VS Code popup in the screen corner.
+// Clicking the merge button must open the modal and NOT post `confirmCellMerge` until the user
+// confirms in the modal.
+
+const mockVscode = {
+    postMessage: vi.fn(),
+    getState: vi.fn(),
+    setState: vi.fn(),
+};
+
+Object.defineProperty(window, "vscodeApi", {
+    value: mockVscode,
+    writable: true,
+});
+
+global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
+
+vi.mock("@sharedUtils", () => ({
+    shouldDisableValidation: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../contextProviders/UnsavedChangesContext", () => ({
+    default: React.createContext({
+        setUnsavedChanges: vi.fn(),
+        showFlashingBorder: false,
+        unsavedChanges: false,
+        toggleFlashingBorder: vi.fn(),
+    }),
+}));
+
+vi.mock("../contextProviders/TooltipContext", () => ({
+    useTooltip: () => ({
+        showTooltip: vi.fn(),
+        hideTooltip: vi.fn(),
+    }),
+}));
+
+vi.mock("../hooks/useCentralizedMessageDispatcher", () => ({
+    useMessageHandler: vi.fn(() => {}),
+}));
+
+vi.mock("../lib/audioController", () => ({
+    globalAudioController: {
+        playExclusive: vi.fn().mockResolvedValue(undefined),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+    },
+}));
+
+vi.mock("../lib/audioCache", () => ({
+    getCachedAudioDataUrl: vi.fn().mockReturnValue(null),
+    setCachedAudioDataUrl: vi.fn(),
+}));
+
+vi.mock("../ValidationButton", () => ({
+    default: () => <div className="validation-button-container" data-testid="validation-button" />,
+}));
+
+vi.mock("../AudioValidationButton", () => ({
+    default: () => (
+        <div className="audio-validation-button-container" data-testid="audio-validation-button" />
+    ),
+}));
+
+vi.mock("../CommentsBadge", () => ({
+    default: () => <div data-testid="comments-badge" />,
+}));
+
+vi.mock("react-markdown", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const createMockCell = (cellId: string, content: string): QuillCellContent => ({
+    cellMarkers: [cellId],
+    cellContent: content,
+    cellType: CodexCellTypes.TEXT,
+    editHistory: [
+        {
+            editMap: ["value"],
+            value: content,
+            author: "test-user",
+            validatedBy: [],
+            timestamp: Date.now(),
+            type: "user-edit" as any,
+        },
+    ],
+    cellLabel: cellId,
+    timestamps: { startTime: 0, endTime: 5 },
+});
+
+const renderSecondCell = () => {
+    const firstCell = createMockCell("cell-1", "<p>First</p>");
+    const secondCell = createMockCell("cell-2", "<p>Second</p>");
+    const props = {
+        cell: secondCell,
+        vscode: mockVscode as any,
+        textDirection: "ltr" as const,
+        isSourceText: true,
+        hasDuplicateId: false,
+        highlightedCellId: null,
+        scrollSyncEnabled: true,
+        lineNumber: "2",
+        label: "Test Label",
+        lineNumbersEnabled: true,
+        isInTranslationProcess: false,
+        translationState: null as any,
+        allTranslationsComplete: false,
+        handleCellClick: vi.fn(),
+        audioAttachments: { "cell-2": "available" as const },
+        currentUsername: "test-user",
+        requiredValidations: 1,
+        requiredAudioValidations: 1,
+        isCorrectionEditorMode: true,
+        translationUnits: [firstCell, secondCell],
+    };
+    return render(<CellContentDisplay {...props} />);
+};
+
+const clickMergeButton = (container: HTMLElement) => {
+    const mergeButton = container.querySelector(".codicon-merge")?.closest("button");
+    expect(mergeButton).toBeTruthy();
+    fireEvent.click(mergeButton!);
+};
+
+const confirmCellMergeCalls = () =>
+    mockVscode.postMessage.mock.calls.filter(([msg]) => msg?.command === "confirmCellMerge");
+
+describe("CellContentDisplay - merge confirmation modal (#691 follow-up)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("opens the in-editor modal on merge click and does not post confirmCellMerge yet", () => {
+        const { container } = renderSecondCell();
+        clickMergeButton(container);
+
+        // Modal is shown...
+        expect(screen.getByText("Merge with previous cell")).toBeTruthy();
+        // ...but nothing is committed until the user confirms.
+        expect(confirmCellMergeCalls()).toHaveLength(0);
+    });
+
+    it("posts confirmCellMerge (without a message field) when the merge is confirmed", () => {
+        const { container } = renderSecondCell();
+        clickMergeButton(container);
+        fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+        const calls = confirmCellMergeCalls();
+        expect(calls).toHaveLength(1);
+        const msg = calls[0][0];
+        expect(msg.content.currentCellId).toBe("cell-2");
+        expect(msg.content.previousCellId).toBe("cell-1");
+        expect(msg.content).not.toHaveProperty("message");
+    });
+
+    it("does not post confirmCellMerge when the modal is cancelled", () => {
+        const { container } = renderSecondCell();
+        clickMergeButton(container);
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(confirmCellMergeCalls()).toHaveLength(0);
+        expect(screen.queryByText("Merge with previous cell")).toBeNull();
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellList.mergedCellUnmerge.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellList.mergedCellUnmerge.test.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { QuillCellContent } from "../../../../../types";
+import { CodexCellTypes } from "../../../../../types/enums";
+import CellList from "../CellList";
+
+// Regression test for issue #691: "merged content no longer shows the option to unmerge".
+//
+// In source + correction-editor mode the provider intentionally keeps merged cells in the
+// translation units so they render greyed-out with an "unmerge" (Cancel merge) button.
+// A filter in CellList used to strip merged cells in exactly that mode, which removed the
+// only place the unmerge button could appear. This test locks in that merged cells survive
+// to render and expose the unmerge control.
+
+// Mock the VSCode API
+const mockVscode = {
+    postMessage: vi.fn(),
+    getState: vi.fn(),
+    setState: vi.fn(),
+};
+
+Object.defineProperty(window, "vscodeApi", {
+    value: mockVscode,
+    writable: true,
+});
+
+global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
+
+vi.mock("@sharedUtils", () => ({
+    shouldDisableValidation: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../contextProviders/UnsavedChangesContext", () => ({
+    default: React.createContext({
+        setUnsavedChanges: vi.fn(),
+        showFlashingBorder: false,
+        unsavedChanges: false,
+        toggleFlashingBorder: vi.fn(),
+    }),
+}));
+
+vi.mock("../contextProviders/TooltipContext", () => ({
+    useTooltip: () => ({
+        showTooltip: vi.fn(),
+        hideTooltip: vi.fn(),
+    }),
+}));
+
+vi.mock("../hooks/useCentralizedMessageDispatcher", () => ({
+    useMessageHandler: vi.fn(() => {}),
+}));
+
+vi.mock("../lib/audioController", () => ({
+    globalAudioController: {
+        playExclusive: vi.fn().mockResolvedValue(undefined),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+    },
+}));
+
+vi.mock("../lib/audioCache", () => ({
+    getCachedAudioDataUrl: vi.fn().mockReturnValue(null),
+    setCachedAudioDataUrl: vi.fn(),
+}));
+
+vi.mock("../ValidationButton", () => ({
+    default: () => <div className="validation-button-container" data-testid="validation-button" />,
+}));
+
+vi.mock("../AudioValidationButton", () => ({
+    default: () => (
+        <div className="audio-validation-button-container" data-testid="audio-validation-button" />
+    ),
+}));
+
+vi.mock("../CommentsBadge", () => ({
+    default: () => <div data-testid="comments-badge" />,
+}));
+
+vi.mock("react-markdown", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const createCell = (
+    uuid: string,
+    content: string,
+    overrides: Partial<QuillCellContent> = {}
+): QuillCellContent => ({
+    cellMarkers: [uuid],
+    cellContent: content,
+    cellType: CodexCellTypes.TEXT,
+    data: {},
+    editHistory: [
+        {
+            editMap: ["value"],
+            value: content,
+            author: "test-user",
+            validatedBy: [],
+            timestamp: Date.now(),
+            type: "user-edit" as any,
+        },
+    ],
+    cellLabel: uuid,
+    timestamps: { startTime: 0, endTime: 5 },
+    ...overrides,
+});
+
+const baseProps = (translationUnits: QuillCellContent[], isCorrectionEditorMode: boolean) => ({
+    translationUnits,
+    fullDocumentTranslationUnits: translationUnits,
+    contentBeingUpdated: {
+        cellMarkers: [],
+        cellContent: "",
+        cellChanged: false,
+    },
+    setContentBeingUpdated: vi.fn(),
+    handleCloseEditor: vi.fn(),
+    handleSaveHtml: vi.fn(),
+    vscode: mockVscode,
+    textDirection: "ltr" as const,
+    isSourceText: true,
+    isCorrectionEditorMode,
+    windowHeight: 800,
+    headerHeight: 100,
+    highlightedCellId: null,
+    scrollSyncEnabled: true,
+    currentUsername: "test-user",
+    requiredValidations: 1,
+    milestoneIndex: null,
+    currentMilestoneIndex: 0,
+    currentSubsectionIndex: 0,
+    cellsPerPage: 50,
+});
+
+describe("CellList - merged cell unmerge button (issue #691)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("renders a merged cell with the unmerge button in source + correction editor mode", () => {
+        const translationUnits: QuillCellContent[] = [
+            createCell("uuid-1", "<p>First cell</p>"),
+            createCell("uuid-2", "<p>Merged cell</p>", {
+                merged: true,
+                data: { merged: true },
+            }),
+        ];
+
+        const { container } = render(
+            <CellList {...baseProps(translationUnits, /* isCorrectionEditorMode */ true)} />
+        );
+
+        // The merged cell content must still render (not filtered out)...
+        expect(container.textContent).toContain("Merged cell");
+        // ...and it must expose the unmerge ("Cancel merge") control.
+        expect(container.querySelector('[title="Cancel merge"]')).not.toBeNull();
+    });
+
+    it("does not show the unmerge button when not in correction editor mode", () => {
+        // Outside correction mode the provider never sends merged cells, but even if one slipped
+        // through, the unmerge button should only appear in correction mode.
+        const translationUnits: QuillCellContent[] = [
+            createCell("uuid-1", "<p>First cell</p>"),
+            createCell("uuid-2", "<p>Merged cell</p>", {
+                merged: true,
+                data: { merged: true },
+            }),
+        ];
+
+        const { container } = render(
+            <CellList {...baseProps(translationUnits, /* isCorrectionEditorMode */ false)} />
+        );
+
+        expect(container.querySelector('[title="Cancel merge"]')).toBeNull();
+    });
+});


### PR DESCRIPTION
## What & why

Fixes #691 — _"merged content no longer shows the option to unmerge"_ — plus a UX follow-up on the merge confirmation.

### 1. Unmerge button no longer showed (the reported bug)
In Source Editing (correction) mode the provider intentionally keeps merged cells in the translation units so they can be unmerged, and `CellContentDisplay` renders a **Cancel merge** button on them. But `CellList` was filtering merged cells out in **exactly that mode** (`filteredTranslationUnits`), so the merged cell never reached `CellContentDisplay` and the button could never render.

The filter contradicted the rest of `CellList`, which already styles merged cells (greyed at `opacity: 0.5`, `❌` line number). Removing it restores the intended behavior; it's safe because the provider already strips merged cells in every other mode.

### 2. Merge confirmation moved into the editor
Confirming a merge used a native `vscode.window.showWarningMessage`, which pops up in the **bottom-right corner of the screen** — far from the cell — and wrongly said the action _"cannot be undone"_ (merges are reversible via unmerge).

It's now a small **in-editor modal** (the same `Dialog` pattern as the existing auth/offline modals) with reversible wording and **Cancel** / **Merge** buttons. `confirmCellMerge` is only posted once the user confirms; the handler no longer shows the native dialog (its child-cell guard is preserved), and the now-unused `message` payload field is removed from the type.

> Note: per the ticket, unmerge intentionally only re-exposes the cell (sets `merged: false`); it does **not** reverse the content concatenation. That behavior is unchanged here.

## Changes
- `webviews/.../CodexCellEditor/CellList.tsx` — remove the merged-cell filter.
- `webviews/.../CodexCellEditor/CellContentDisplay.tsx` — in-editor merge-confirmation modal.
- `src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts` — drop the native confirmation from `confirmCellMerge`.
- `types/index.d.ts` — remove the unused `message` field from `confirmCellMerge`.
- Tests: `CellList.mergedCellUnmerge.test.tsx`, `CellContentDisplay.mergeConfirm.test.tsx`.

## Test Checklist

### Unmerge option restored
- [x] After merging cells in **Source Editing Mode** (correction editor mode for source text), the merged cell still renders (greyed-out) and shows the **unmerge / revert merge** button
- [x] Clicking unmerge adds a new edit to the cell and marks it `merged: false`
- [x] Unmerging only marks the cell as unmerged — it does **not** attempt to revert the content of the cell above (expected behavior)
- [x] Merged cells are **not** hidden in source + correction editor mode (the old `cellData?.merged` filter no longer strips them)
- [x] In all other (non-correction) modes, merged cells remain absent from the list because the provider strips them upstream

### In-editor merge confirmation modal
- [x] Clicking **Merge** opens an in-editor confirmation dialog near the cell (no longer the native VS Code bottom-right popup)
- [x] The dialog title/description explain the merge and that it can be reversed via unmerge
- [x] Clicking **Merge** in the dialog posts `confirmCellMerge` and closes the modal
- [x] Clicking **Cancel** (or dismissing via overlay/Esc) closes the modal and posts **nothing**
- [x] No merge occurs until the in-editor dialog is confirmed

### Message contract / provider (regression)
- [x] `confirmCellMerge` payload no longer includes a `message` field (`types/index.d.ts` and webview agree)
- [x] `confirmCellMerge` handler proceeds directly to merge without showing a second native `showWarningMessage` confirmation
- [x] Cells with child cells still follow the existing pre-merge handling path (not bypassed)
- [x] For **source files**, merging also merges matching cells in the target file (`mergeMatchingCellsInTargetFile`)
- [x] For **non-source files**, the target-file merge step is skipped
- [x] Merge errors are caught and logged without crashing the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)