### PR TITLE
Adding a delete confirmation for urls and video files

### DIFF
--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -1783,7 +1783,12 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             const oldKind = classifyVideo(oldVideoUrl);
             const newKind = classifyVideo(newVideoUrl);
             if (oldKind === "local") {
-                const proceed = await confirmVideoReplacement(oldKind, newKind);
+                // The metadata modal already runs a robust type-to-confirm step
+                // before any video removal/replace, so it sets skipVideoConfirm to
+                // avoid a redundant second prompt. Other callers still confirm.
+                const proceed = typedEvent.skipVideoConfirm
+                    ? true
+                    : await confirmVideoReplacement(oldKind, newKind);
                 if (!proceed) {
                     // Revert the webview's optimistic edit by re-sending current
                     // metadata, and restore the player's URL to the unchanged video.
@@ -2044,15 +2049,18 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         }
     },
 
-    pickVideoFile: async ({ document, webviewPanel, provider }) => {
+    pickVideoFile: async ({ event, document, webviewPanel, provider }) => {
         debug("pickVideoFile message received");
+        const typedEvent = event as Extract<EditorPostMessages, { command: "pickVideoFile"; }>;
 
         // If a local video already exists, confirm replacement up front so the
         // user can back out before choosing a new file (deletion happens after
-        // the new file is written successfully).
+        // the new file is written successfully). The metadata modal only reveals
+        // the picker after its own type-to-confirm removal step, so it sets
+        // skipVideoConfirm to avoid a redundant prompt.
         const existingVideoUrl = document.getNotebookMetadata()?.videoUrl;
         const existingKind = classifyVideo(existingVideoUrl);
-        if (existingKind === "local") {
+        if (existingKind === "local" && !typedEvent.skipVideoConfirm) {
             const proceed = await confirmVideoReplacement("local", "local");
             if (!proceed) {
                 return;

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -510,7 +510,8 @@ export async function resolveAndPostVideoStreamUrl(
         provider.postMessageToWebview(webviewPanel, {
             type: "videoStreamUnavailable",
             reason: "not-found",
-            message: "The video is not available locally and no LFS reference was found.",
+            message:
+                "This video isn't available yet. It may still be syncing, or the file couldn't be found.",
         });
         return;
     }
@@ -2129,7 +2130,8 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             provider.postMessageToWebview(webviewPanel, {
                 type: "videoStreamUnavailable",
                 reason: "not-found",
-                message: "No LFS reference found for this video.",
+                message:
+                    "This video isn't available yet. It may still be syncing, or the file couldn't be found.",
             });
             return;
         }

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -187,6 +187,166 @@ async function confirmVideoReplacement(
 }
 
 /**
+ * Imports a video file the user picked from the OS dialog into the project's
+ * attachments. This is deliberately run at *save* time (not at pick time) so
+ * that picking a file and then cancelling the metadata modal leaves the project
+ * untouched. It writes the bytes into files/ (and best-effort into pointers/),
+ * deletes any previous local video, and — in stream-only mode — offers to keep
+ * the file via the persisted allowlist.
+ *
+ * In stream-only mode the user is asked up front whether to keep the video.
+ * Cancelling that prompt aborts the import before anything is written/deleted,
+ * in which case this resolves to `null` and the existing video is left intact.
+ *
+ * @returns the workspace-relative path to store in `videoUrl`, or `null` if the
+ * user cancelled the import.
+ */
+async function importPickedVideoIntoProject(
+    document: CodexCellDocument,
+    sourceFsPath: string
+): Promise<string | null> {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (!workspaceFolder) {
+        throw new Error("No workspace folder found");
+    }
+
+    // Read the picked file (still at its original location on the user's disk).
+    const fileData = await vscode.workspace.fs.readFile(vscode.Uri.file(sourceFsPath));
+
+    // Enforce a reasonable max size (1.5 GB) for video files.
+    const MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
+    if (fileData.length > MAX_BYTES) {
+        throw new Error("Video file exceeds the maximum allowed size (1.5 GB).");
+    }
+
+    // In stream-only, a newly added local video would be reverted to an LFS
+    // pointer after the next sync (to free space), so ask up front whether to
+    // keep it saved in the project ("Save to project" → persisted allowlist) or
+    // treat it as a session-only stream ("Stream only"). Asking *before* any
+    // write means Cancel can abort the whole import cleanly — nothing is written
+    // and the previous video is left untouched. Other strategies never prompt.
+    let persistInStreamOnly = false;
+    try {
+        const { getMediaFilesStrategy } = await import("../../utils/localProjectSettings");
+        const strategy = (await getMediaFilesStrategy(workspaceFolder.uri)) ?? "auto-download";
+        if (strategy === "stream-only") {
+            const SAVE = "Save to project";
+            const STREAM = "Stream only";
+            const choice = await vscode.window.showInformationMessage(
+                "Save this video to the project?",
+                {
+                    modal: true,
+                    detail: "Save keeps it until you remove it. Stream only keeps it for this session.",
+                },
+                SAVE,
+                STREAM
+            );
+            // Cancel / dismissed (Escape) → abort the import entirely.
+            if (choice !== SAVE && choice !== STREAM) {
+                return null;
+            }
+            persistInStreamOnly = choice === SAVE;
+        }
+    } catch (storageChoiceErr) {
+        console.warn("Could not determine stream-only storage choice for video:", storageChoiceErr);
+    }
+
+    const documentSegment = getDocumentSegment(document);
+
+    // Generate a safe filename from the original file.
+    const originalFileName = path.basename(sourceFsPath);
+    const ext = path.extname(originalFileName).toLowerCase().slice(1);
+    const allowedExtensions = new Set(["mp4", "mkv", "avi", "mov", "webm", "m4v"]);
+    const safeExt = allowedExtensions.has(ext) ? ext : "mp4";
+    const baseName = path.basename(originalFileName, path.extname(originalFileName));
+    const sanitizedBaseName = baseName.replace(/[^a-zA-Z0-9._-]/g, "-");
+    const fileName = `${sanitizedBaseName}.${safeExt}`;
+
+    const pointersDir = path.join(
+        workspaceFolder.uri.fsPath,
+        ".project",
+        "attachments",
+        "pointers",
+        documentSegment
+    );
+    const filesDir = path.join(
+        workspaceFolder.uri.fsPath,
+        ".project",
+        "attachments",
+        "files",
+        documentSegment
+    );
+
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(pointersDir));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(filesDir));
+
+    const pointersPath = path.join(pointersDir, fileName);
+    const filesPath = path.join(filesDir, fileName);
+
+    // Atomic write helper (write to temp then rename).
+    const writeFileAtomically = async (finalFsPath: string, data: Uint8Array): Promise<void> => {
+        const tmpPath = `${finalFsPath}.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const tmpUri = vscode.Uri.file(tmpPath);
+        const finalUri = vscode.Uri.file(finalFsPath);
+        await vscode.workspace.fs.writeFile(tmpUri, data);
+        await vscode.workspace.fs.rename(tmpUri, finalUri, { overwrite: true });
+        try {
+            const stat = await vscode.workspace.fs.stat(finalUri);
+            if (typeof stat.size === "number" && stat.size !== data.length) {
+                console.warn("Size mismatch after write for", finalFsPath, {
+                    expected: data.length,
+                    actual: stat.size,
+                });
+            }
+        } catch {
+            // ignore stat issues
+        }
+    };
+
+    // Write actual file (primary). Pointer write is best-effort.
+    await writeFileAtomically(filesPath, fileData);
+    try {
+        await writeFileAtomically(pointersPath, fileData);
+    } catch (pointerErr) {
+        console.warn("Pointer write failed; proceeding with saved file only", pointerErr);
+    }
+
+    // Delete the previous local video (if any) now that the new file is written,
+    // skipping the freshly-written paths in case the replacement reuses the same
+    // filename.
+    const existingVideoUrl = document.getNotebookMetadata()?.videoUrl;
+    if (classifyVideo(existingVideoUrl) === "local") {
+        await deleteLocalVideoFiles(
+            existingVideoUrl,
+            workspaceFolder.uri,
+            new Set([filesPath, pointersPath])
+        );
+    }
+
+    const relativePath = toPosixPath(path.relative(workspaceFolder.uri.fsPath, filesPath));
+
+    // "Save to project" in stream-only → record the rel-path on the persisted
+    // allowlist so post-sync / strategy-switch cleanup never reverts this saved
+    // video to a pointer.
+    if (persistInStreamOnly) {
+        try {
+            const { addPersistedMediaFile } = await import("../../utils/localProjectSettings");
+            const FILES_SEG = "attachments/files/";
+            const savedRel = relativePath.includes(FILES_SEG)
+                ? relativePath.slice(relativePath.indexOf(FILES_SEG) + FILES_SEG.length)
+                : null;
+            if (savedRel) {
+                await addPersistedMediaFile(savedRel, workspaceFolder.uri);
+            }
+        } catch (storageChoiceErr) {
+            console.warn("Could not persist stream-only video to allowlist:", storageChoiceErr);
+        }
+    }
+
+    return relativePath;
+}
+
+/**
  * Tracks stream-only "session cache" videos that were activated (downloaded)
  * during the current extension-host session, keyed by `${projectPath}::${rel}`.
  * Module-level so it is naturally empty after a reload, which is what makes a
@@ -1773,13 +1933,39 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         debug("updateNotebookMetadata message received", { event });
         const newMetadata = typedEvent.content;
 
+        // A staged video pick is imported here, at save time, so that picking a
+        // file and then cancelling the modal leaves nothing behind. The import
+        // both writes the new file and deletes any previous local video, so it
+        // takes the place of the generic video-change guard below.
+        const pendingVideoFilePath = typedEvent.pendingVideoFilePath;
+        if (pendingVideoFilePath) {
+            try {
+                const imported = await importPickedVideoIntoProject(
+                    document,
+                    pendingVideoFilePath
+                );
+                // `null` means the user cancelled the import (nothing was written);
+                // keep whatever video was already saved.
+                newMetadata.videoUrl =
+                    imported ?? document.getNotebookMetadata()?.videoUrl ?? "";
+            } catch (error) {
+                console.error("Error saving video file:", error);
+                vscode.window.showErrorMessage(
+                    `Failed to save video file: ${error instanceof Error ? error.message : "Unknown error"}`
+                );
+                // Keep the previously saved video so a failed import doesn't drop it.
+                newMetadata.videoUrl = document.getNotebookMetadata()?.videoUrl ?? "";
+            }
+        }
+
         // Guard the video field: if the user is replacing an existing local
         // video (file -> URL, file -> file, or removal), confirm first and
-        // delete the old local file from files/ and pointers/.
+        // delete the old local file from files/ and pointers/. Skipped for a
+        // staged pick, which already handled the previous file during import.
         const oldVideoUrl = document.getNotebookMetadata()?.videoUrl;
         const newVideoUrl = newMetadata.videoUrl;
         const videoChanged = (oldVideoUrl ?? "") !== (newVideoUrl ?? "");
-        if (videoChanged) {
+        if (!pendingVideoFilePath && videoChanged) {
             const oldKind = classifyVideo(oldVideoUrl);
             const newKind = classifyVideo(newVideoUrl);
             if (oldKind === "local") {
@@ -2049,24 +2235,15 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         }
     },
 
-    pickVideoFile: async ({ event, document, webviewPanel, provider }) => {
+    pickVideoFile: async ({ webviewPanel, provider }) => {
         debug("pickVideoFile message received");
-        const typedEvent = event as Extract<EditorPostMessages, { command: "pickVideoFile"; }>;
 
-        // If a local video already exists, confirm replacement up front so the
-        // user can back out before choosing a new file (deletion happens after
-        // the new file is written successfully). The metadata modal only reveals
-        // the picker after its own type-to-confirm removal step, so it sets
-        // skipVideoConfirm to avoid a redundant prompt.
-        const existingVideoUrl = document.getNotebookMetadata()?.videoUrl;
-        const existingKind = classifyVideo(existingVideoUrl);
-        if (existingKind === "local" && !typedEvent.skipVideoConfirm) {
-            const proceed = await confirmVideoReplacement("local", "local");
-            if (!proceed) {
-                return;
-            }
-        }
-
+        // Stage the selection only — the file is NOT written into the project
+        // here. The metadata modal shows it as a pending video and the host
+        // imports it (writing files/pointers + deleting any previous local
+        // video) when the user clicks "Save Changes" (see
+        // updateNotebookMetadata's pendingVideoFilePath). Cancelling the modal
+        // therefore leaves the project untouched.
         const result = await vscode.window.showOpenDialog({
             canSelectMany: false,
             openLabel: "Select Video File",
@@ -2075,149 +2252,15 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             },
         });
         const fileUri = result?.[0];
-        if (fileUri) {
-            try {
-                const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-                if (!workspaceFolder) {
-                    throw new Error("No workspace folder found");
-                }
-
-                // Read the video file content
-                const fileData = await vscode.workspace.fs.readFile(fileUri);
-
-                // Enforce a reasonable max size (1.5 GB) for video files
-                const MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
-                if (fileData.length > MAX_BYTES) {
-                    throw new Error("Video file exceeds the maximum allowed size (1.5 GB).");
-                }
-
-                // Determine document segment
-                const documentSegment = getDocumentSegment(document);
-
-                // Generate safe filename from original file
-                const originalFileName = path.basename(fileUri.fsPath);
-                const ext = path.extname(originalFileName).toLowerCase().slice(1); // Remove leading dot
-                const allowedExtensions = new Set(["mp4", "mkv", "avi", "mov", "webm", "m4v"]);
-                const safeExt = allowedExtensions.has(ext) ? ext : "mp4";
-
-                // Sanitize filename (keep base name, replace unsafe chars)
-                const baseName = path.basename(originalFileName, path.extname(originalFileName));
-                const sanitizedBaseName = baseName.replace(/[^a-zA-Z0-9._-]/g, "-");
-                const fileName = `${sanitizedBaseName}.${safeExt}`;
-
-                // Create directory paths
-                const pointersDir = path.join(
-                    workspaceFolder.uri.fsPath,
-                    ".project",
-                    "attachments",
-                    "pointers",
-                    documentSegment
-                );
-                const filesDir = path.join(
-                    workspaceFolder.uri.fsPath,
-                    ".project",
-                    "attachments",
-                    "files",
-                    documentSegment
-                );
-
-                // Create directories if they don't exist
-                await vscode.workspace.fs.createDirectory(vscode.Uri.file(pointersDir));
-                await vscode.workspace.fs.createDirectory(vscode.Uri.file(filesDir));
-
-                const pointersPath = path.join(pointersDir, fileName);
-                const filesPath = path.join(filesDir, fileName);
-
-                // Atomic write helper (write to temp then rename)
-                const writeFileAtomically = async (finalFsPath: string, data: Uint8Array): Promise<void> => {
-                    const tmpPath = `${finalFsPath}.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-                    const tmpUri = vscode.Uri.file(tmpPath);
-                    const finalUri = vscode.Uri.file(finalFsPath);
-                    await vscode.workspace.fs.writeFile(tmpUri, data);
-                    await vscode.workspace.fs.rename(tmpUri, finalUri, { overwrite: true });
-                    // Optional sanity check to ensure size matches
-                    try {
-                        const stat = await vscode.workspace.fs.stat(finalUri);
-                        if (typeof stat.size === 'number' && stat.size !== data.length) {
-                            console.warn("Size mismatch after write for", finalFsPath, { expected: data.length, actual: stat.size });
-                        }
-                    } catch {
-                        // ignore stat issues
-                    }
-                };
-
-                // Write actual file (primary). Pointer write is best-effort.
-                await writeFileAtomically(filesPath, fileData);
-                try {
-                    await writeFileAtomically(pointersPath, fileData);
-                } catch (pointerErr) {
-                    console.warn("Pointer write failed; proceeding with saved file only", pointerErr);
-                }
-
-                // Delete the previous local video (if any) now that the new
-                // file is written, skipping the freshly-written paths in case
-                // the replacement reuses the same filename.
-                if (existingKind === "local") {
-                    await deleteLocalVideoFiles(existingVideoUrl, workspaceFolder.uri, new Set([filesPath, pointersPath]));
-                }
-
-                // Store the files path in metadata (relative path from workspace root)
-                const relativePath = toPosixPath(path.relative(workspaceFolder.uri.fsPath, filesPath));
-                await document.updateNotebookMetadata({ videoUrl: relativePath });
-                await document.save(new vscode.CancellationTokenSource().token);
-
-                // In stream-only, a newly added local video would be reverted to an
-                // LFS pointer after the next sync (to free space). Ask whether to keep
-                // it saved in the project or treat it as a session-only stream.
-                // "Save to project" → add to the persisted allowlist so cleanup never
-                // pointerizes it (kept until removed). "Stream only" → leave it out, so
-                // after sync it streams on demand (with a session disk cache).
-                try {
-                    const { getMediaFilesStrategy, addPersistedMediaFile } = await import(
-                        "../../utils/localProjectSettings"
-                    );
-                    const strategy =
-                        (await getMediaFilesStrategy(workspaceFolder.uri)) ?? "auto-download";
-                    if (strategy === "stream-only") {
-                        const SAVE = "Save to project";
-                        const STREAM = "Stream only";
-                        const choice = await vscode.window.showInformationMessage(
-                            "Save this video to the project?",
-                            {
-                                modal: true,
-                                detail: "Save keeps it until you remove it. Stream only keeps it for this session.",
-                            },
-                            SAVE,
-                            STREAM
-                        );
-                        if (choice === SAVE) {
-                            const FILES_SEG = "attachments/files/";
-                            const savedRel = relativePath.includes(FILES_SEG)
-                                ? relativePath.slice(
-                                      relativePath.indexOf(FILES_SEG) + FILES_SEG.length
-                                  )
-                                : null;
-                            if (savedRel) {
-                                await addPersistedMediaFile(savedRel, workspaceFolder.uri);
-                            }
-                        }
-                    }
-                } catch (storageChoiceErr) {
-                    console.warn(
-                        "Could not apply stream-only storage choice for video:",
-                        storageChoiceErr
-                    );
-                }
-
-                provider.refreshWebview(webviewPanel, document);
-                await postVideoReferenceStatus(document, webviewPanel, provider);
-            } catch (error) {
-                console.error("Error saving video file:", error);
-                vscode.window.showErrorMessage(
-                    `Failed to save video file: ${error instanceof Error ? error.message : "Unknown error"}`
-                );
-            }
+        if (!fileUri) {
+            return;
         }
+
+        provider.postMessageToWebview(webviewPanel, {
+            type: "videoFilePicked",
+            fsPath: fileUri.fsPath,
+            fileName: path.basename(fileUri.fsPath),
+        });
     },
 
     replaceDuplicateCells: ({ event, document }) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -414,8 +414,8 @@ export type EditorPostMessages =
     | { command: "updateCellLabel"; content: { cellId: string; cellLabel: string; }; }
     | { command: "updateCellIsLocked"; content: { cellId: string; isLocked: boolean; }; }
     | { command: "resolveHtmlStructure"; content: { cellId: string; }; }
-    | { command: "updateNotebookMetadata"; content: CustomNotebookMetadata; }
-    | { command: "pickVideoFile"; }
+    | { command: "updateNotebookMetadata"; content: CustomNotebookMetadata; skipVideoConfirm?: boolean; }
+    | { command: "pickVideoFile"; skipVideoConfirm?: boolean; }
     | { command: "deleteVideoFile"; }
     | { command: "freeVideoDiskSpace"; }
     | { command: "requestVideoStreamUrl"; }
@@ -470,7 +470,7 @@ export type EditorPostMessages =
     | { command: "updateTextDirection"; direction: "ltr" | "rtl"; }
     | { command: "openSourceText"; content: { chapterNumber: number; }; }
     | { command: "updateCellLabel"; content: { cellId: string; cellLabel: string; }; }
-    | { command: "pickVideoFile"; }
+    | { command: "pickVideoFile"; skipVideoConfirm?: boolean; }
     | {
         command: "exportFile";
         content: { subtitleData: string; format: string; includeStyles: boolean; };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -414,7 +414,18 @@ export type EditorPostMessages =
     | { command: "updateCellLabel"; content: { cellId: string; cellLabel: string; }; }
     | { command: "updateCellIsLocked"; content: { cellId: string; isLocked: boolean; }; }
     | { command: "resolveHtmlStructure"; content: { cellId: string; }; }
-    | { command: "updateNotebookMetadata"; content: CustomNotebookMetadata; skipVideoConfirm?: boolean; }
+    | {
+        command: "updateNotebookMetadata";
+        content: CustomNotebookMetadata;
+        skipVideoConfirm?: boolean;
+        /**
+         * Absolute path of a video file the user picked but hasn't committed yet.
+         * The picker stages the selection (it is NOT written on pick); the host
+         * imports it into the project as part of this save, so cancelling the
+         * modal leaves nothing behind.
+         */
+        pendingVideoFilePath?: string;
+    }
     | { command: "pickVideoFile"; skipVideoConfirm?: boolean; }
     | { command: "deleteVideoFile"; }
     | { command: "freeVideoDiskSpace"; }
@@ -2098,6 +2109,14 @@ type EditorReceiveMessages =
     | { type: "providerUpdatesNotebookMetadataForWebview"; content: CustomNotebookMetadata; }
     | { type: "updateVideoUrlInWebview"; content: string; }
     | { type: "videoStreamResolving"; }
+    | {
+          // The user picked a video file in the OS dialog. It is staged (not yet
+          // imported into the project); the editor shows it as pending until the
+          // metadata modal is saved.
+          type: "videoFilePicked";
+          fsPath: string;
+          fileName: string;
+      }
     | { type: "videoStreamUnavailable"; reason: "offline" | "not-authenticated" | "not-found" | "error"; message?: string; }
     | { type: "videoNeedsDownload"; strategy: "auto-download" | "stream-and-save" | "stream-only"; }
     | {

--- a/webviews/codex-webviews/src/CodexCellEditor/ChapterNavigationHeader.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/ChapterNavigationHeader.tsx
@@ -53,8 +53,12 @@ interface ChapterNavigationHeaderProps {
     documentHasVideoAvailable: boolean;
     metadata: CustomNotebookMetadata | undefined;
     onMetadataChange: (key: string, value: string) => void;
-    onSaveMetadata: (updated: CustomNotebookMetadata) => void;
+    onSaveMetadata: (updated: CustomNotebookMetadata, pendingVideoFilePath?: string) => void;
     onPickFile: () => void;
+    // A staged video pick delivered from the host (not yet imported); shown in
+    // the metadata modal as a pending video until "Save Changes".
+    pickedVideoFile?: { fsPath: string; fileName: string; } | null;
+    onPickedVideoConsumed?: () => void;
     videoCanFreeDiskSpace: boolean;
     onFreeVideoDiskSpace: () => void;
     videoReferenceStatus: "none" | "url" | "local-usable" | "missing" | null;
@@ -117,6 +121,8 @@ export function ChapterNavigationHeader({
     onMetadataChange,
     onSaveMetadata,
     onPickFile,
+    pickedVideoFile,
+    onPickedVideoConsumed,
     videoCanFreeDiskSpace,
     onFreeVideoDiskSpace,
     videoReferenceStatus,
@@ -409,8 +415,11 @@ ChapterNavigationHeaderProps) {
         setIsMetadataModalOpen(false);
     };
 
-    const handleSaveMetadata = (updated: CustomNotebookMetadata) => {
-        onSaveMetadata(updated);
+    const handleSaveMetadata = (
+        updated: CustomNotebookMetadata,
+        pendingVideoFilePath?: string
+    ) => {
+        onSaveMetadata(updated, pendingVideoFilePath);
         setIsMetadataModalOpen(false);
     };
 
@@ -1184,6 +1193,8 @@ ChapterNavigationHeaderProps) {
                     metadata={metadata}
                     onSave={handleSaveMetadata}
                     onPickFile={onPickFile}
+                    pickedVideoFile={pickedVideoFile}
+                    onPickedVideoConsumed={onPickedVideoConsumed}
                     canFreeDiskSpace={videoCanFreeDiskSpace}
                     onFreeDiskSpace={onFreeVideoDiskSpace}
                     videoReferenceStatus={videoReferenceStatus}

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -3139,6 +3139,44 @@ const CodexCellEditor: React.FC = () => {
         vscode.postMessage({ command: "requestVideoStreamUrl" } as EditorPostMessages);
     }, []);
 
+    // Keep the latest resolved URL in a ref so the error handler reads the
+    // current value (not a stale closure) and can guard retries by URL.
+    const videoUrlRef = useRef(videoUrl);
+    useEffect(() => {
+        videoUrlRef.current = videoUrl;
+    }, [videoUrl]);
+    // Guards auto-retry on playback error. This lives in the parent (not in
+    // VideoPlayer) on purpose: requesting a fresh URL clears videoUrl and
+    // unmounts the player, so a guard inside the player would reset on every
+    // remount and loop forever on a persistently-failing URL.
+    const videoErrorRetryRef = useRef<{ url: string; at: number; }>({ url: "", at: 0 });
+
+    // Called when the player reports a load/playback error. A remote stream URL
+    // may have expired, so re-resolve it once; if the SAME URL keeps failing we
+    // stop and surface the "unavailable" state (with a manual retry) instead of
+    // looping — which is what an invalid URL like "https://www.ffdsf" would
+    // otherwise do, flooding the console with errors.
+    const VIDEO_ERROR_RETRY_WINDOW_MS = 10000;
+    const handleVideoStreamError = useCallback(() => {
+        const url = videoUrlRef.current;
+        const now = Date.now();
+        const guard = videoErrorRetryRef.current;
+        const retriedRecently =
+            guard.url === url && now - guard.at < VIDEO_ERROR_RETRY_WINDOW_MS;
+        if (retriedRecently) {
+            // Already retried this URL once recently → give up to avoid a loop.
+            setVideoUrl("");
+            setVideoResolving(false);
+            setVideoNeedsDownloadStrategy(null);
+            setVideoUnavailableMessage(
+                "This video couldn't be played. Please check that the URL is correct and reachable."
+            );
+            return;
+        }
+        videoErrorRetryRef.current = { url, at: now };
+        requestVideoStreamUrl();
+    }, [requestVideoStreamUrl]);
+
     // Download the LFS-backed video so it can play locally. `persist` controls
     // whether stream-only keeps the file ("Save to project") or treats it as a
     // session cache that re-streams next session (the default "Load").
@@ -3849,7 +3887,7 @@ const CodexCellEditor: React.FC = () => {
                             playerRef={playerRef}
                             audioAttachments={audioAttachments}
                             muteVideoWhenPlayingAudio={muteVideoAudioDuringPlayback}
-                            onRequestStreamUrl={requestVideoStreamUrl}
+                            onRequestStreamUrl={handleVideoStreamError}
                         />
                     </div>
                 )}

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -3061,7 +3061,13 @@ const CodexCellEditor: React.FC = () => {
     };
 
     const handlePickFile = () => {
-        vscode.postMessage({ command: "pickVideoFile" } as EditorPostMessages);
+        // The metadata modal only exposes the file picker once the video field is
+        // empty, which requires passing its type-to-confirm removal step first.
+        // So the host's own replace/delete confirmation would be redundant here.
+        vscode.postMessage({
+            command: "pickVideoFile",
+            skipVideoConfirm: true,
+        } as EditorPostMessages);
     };
 
     // Stream-and-save: revert the downloaded local copy back to an LFS pointer to
@@ -3079,9 +3085,13 @@ const CodexCellEditor: React.FC = () => {
         setMetadata(updatedMetadata);
         setVideoUrl(updatedMetadata.videoUrl || "");
         debug("metadata", "Saving metadata:", updatedMetadata);
+        // Any video change in the modal already passed its robust type-to-confirm
+        // removal step, so the host's own replace/delete confirmation would be a
+        // redundant second prompt — skip it. The host still deletes the old file.
         vscode.postMessage({
             command: "updateNotebookMetadata",
             content: updatedMetadata,
+            skipVideoConfirm: true,
         } as EditorPostMessages);
         setIsMetadataModalOpen(false);
     };

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -196,6 +196,13 @@ const CodexCellEditor: React.FC = () => {
     // Size (bytes) of the referenced video when known (local bytes or LFS pointer
     // size). null until reported / unknown (e.g. remote URLs).
     const [videoSizeBytes, setVideoSizeBytes] = useState<number | null>(null);
+    // A video the user picked in the OS dialog but hasn't committed yet. It is
+    // only imported into the project when the metadata modal is saved, so it
+    // lives here as a staged selection (cleared on cancel/save).
+    const [pickedVideoFile, setPickedVideoFile] = useState<{
+        fsPath: string;
+        fileName: string;
+    } | null>(null);
     const playerRef = useRef<ReactPlayerRef>(null);
     const [shouldShowVideoPlayer, setShouldShowVideoPlayer] = useState<boolean>(false);
     const [muteVideoAudioDuringPlayback, setMuteVideoAudioDuringPlayback] = useState(true);
@@ -1772,6 +1779,11 @@ const CodexCellEditor: React.FC = () => {
                 setVideoResolving(false);
             }
         },
+        videoFilePicked: (fsPath: string, fileName: string) => {
+            // The user selected a file in the OS dialog. Stage it so the modal can
+            // show it as a pending video; nothing is written until "Save Changes".
+            setPickedVideoFile({ fsPath, fileName });
+        },
         videoStreamResolving: () => {
             // An action started elsewhere (e.g. "Load video" / "Save to project"
             // from a navigation card) is fetching this chapter's video. Reflect
@@ -3081,18 +3093,30 @@ const CodexCellEditor: React.FC = () => {
     // calls this on "Save Changes", so removals/edits are deferred until here.
     // When the saved videoUrl changes, the host confirms and (for a local file)
     // deletes the old file from disk as part of updateNotebookMetadata.
-    const handleSaveMetadata = (updatedMetadata: CustomNotebookMetadata) => {
-        setMetadata(updatedMetadata);
-        setVideoUrl(updatedMetadata.videoUrl || "");
+    const handleSaveMetadata = (
+        updatedMetadata: CustomNotebookMetadata,
+        pendingVideoFilePath?: string
+    ) => {
+        // Don't optimistically clobber videoUrl when a staged pick is being
+        // imported: the host computes the real project-relative path and pushes
+        // it back via providerUpdatesNotebookMetadataForWebview.
+        if (!pendingVideoFilePath) {
+            setMetadata(updatedMetadata);
+            setVideoUrl(updatedMetadata.videoUrl || "");
+        }
         debug("metadata", "Saving metadata:", updatedMetadata);
         // Any video change in the modal already passed its robust type-to-confirm
         // removal step, so the host's own replace/delete confirmation would be a
         // redundant second prompt — skip it. The host still deletes the old file.
+        // A staged pick (pendingVideoFilePath) is imported by the host as part of
+        // this save, so cancelling instead of saving leaves the project untouched.
         vscode.postMessage({
             command: "updateNotebookMetadata",
             content: updatedMetadata,
             skipVideoConfirm: true,
+            pendingVideoFilePath,
         } as EditorPostMessages);
+        setPickedVideoFile(null);
         setIsMetadataModalOpen(false);
     };
 
@@ -3640,6 +3664,8 @@ const CodexCellEditor: React.FC = () => {
                             onMetadataChange={handleMetadataChange}
                             onSaveMetadata={handleSaveMetadata}
                             onPickFile={handlePickFile}
+                            pickedVideoFile={pickedVideoFile}
+                            onPickedVideoConsumed={() => setPickedVideoFile(null)}
                             videoCanFreeDiskSpace={videoCanFreeDiskSpace}
                             onFreeVideoDiskSpace={handleFreeVideoDiskSpace}
                             videoSizeBytes={videoSizeBytes}

--- a/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
@@ -190,7 +190,10 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         const currentValue = draft[key as keyof CustomNotebookMetadata] || "";
         
         return (
-            <div key={key} className="space-y-2">
+            // min-w-0 lets this grid item shrink below its content's intrinsic
+            // width so a long, unbreakable video URL truncates instead of forcing
+            // the whole modal wider than the viewport.
+            <div key={key} className="space-y-2 min-w-0">
                 <div className="flex items-center gap-2">
                     <Label htmlFor={key} className="text-sm font-medium">
                         {config.label}
@@ -238,7 +241,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                             title={pendingVideoFile.fsPath}
                                         >
                                             <i className="codicon codicon-device-camera-video shrink-0 text-muted-foreground" />
-                                            <span className="truncate">{pendingVideoFile.fileName}</span>
+                                            <span className="truncate min-w-0">{pendingVideoFile.fileName}</span>
                                             <Badge variant="secondary" className="ml-auto shrink-0">
                                                 Pending
                                             </Badge>
@@ -307,8 +310,8 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                         // the field becomes editable for the next URL or picked file.
                         if (reflectsSavedVideo) {
                             return (
-                                <div className="space-y-3">
-                                    <div className="flex flex-wrap items-center gap-2">
+                                <div className="space-y-3 min-w-0">
+                                    <div className="flex flex-wrap items-center gap-2 min-w-0">
                                         <div
                                             className={`flex-1 min-w-0 basis-0 flex items-center gap-2 rounded-md border px-3 py-2 text-sm overflow-hidden ${
                                                 isMissing
@@ -322,7 +325,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                                     isLocalFile ? "codicon-device-camera-video" : "codicon-link"
                                                 } text-muted-foreground`}
                                             />
-                                            <span className="truncate">{displayLabel}</span>
+                                            <span className="truncate min-w-0">{displayLabel}</span>
                                             {sizeLabel && !isMissing && (
                                                 <span className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums">
                                                     {sizeLabel}
@@ -505,7 +508,11 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
             <DialogContent
-                className="max-w-[calc(100%-2rem)] sm:max-w-2xl max-h-[85vh] overflow-y-auto overflow-x-hidden"
+                // Width is pinned to the viewport (vw), not the containing block,
+                // so the modal always fits the webview panel with a 1rem margin
+                // each side and caps at 2xl on wide panels. Using vw avoids the
+                // sm:max-w override silently dropping the responsive cap.
+                className="w-[calc(100vw-2rem)] max-w-2xl sm:max-w-2xl max-h-[85vh] overflow-y-auto overflow-x-hidden"
                 onEscapeKeyDown={(e) => {
                     // While the type-to-confirm removal panel is open, Escape should
                     // dismiss only that panel, not the whole modal. (Radix listens
@@ -524,9 +531,13 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                     </DialogTitle>
                 </DialogHeader>
                 
-                <div className="space-y-6">
+                {/* min-w-0 on this grid item (DialogContent is a CSS grid) lets the
+                    column shrink below its content's intrinsic width, so long
+                    unbreakable strings (e.g. a video URL) truncate instead of
+                    widening the whole modal. */}
+                <div className="space-y-6 min-w-0">
                     {/* User-Editable Fields */}
-                    <div className="space-y-4">
+                    <div className="space-y-4 min-w-0">
                         {Object.entries(USER_EDITABLE_FIELDS).map(([key, config]) => 
                             renderField(key, config)
                         )}
@@ -543,9 +554,9 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                     <span className="text-muted-foreground">ID:</span>
                                     <span className="ml-2 font-mono break-all">{metadata.id}</span>
                                 </div>
-                                <div>
+                                <div className="min-w-0">
                                     <span className="text-muted-foreground">Original Name:</span>
-                                    <span className="ml-2">{metadata.originalName}</span>
+                                    <span className="ml-2 break-all">{metadata.originalName}</span>
                                 </div>
                                 {metadata.sourceCreatedAt && (
                                     <div>

--- a/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
@@ -104,6 +104,11 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         fsPath: string;
         fileName: string;
     } | null>(null);
+    // Once the user clears/replaces the saved video in this session, keep the
+    // field editable even if they retype the exact same URL. Without this, the
+    // deferred removal leaves metadata.videoUrl unchanged, so retyping the old
+    // value would match it and re-lock the field mid-typing.
+    const [videoUnlocked, setVideoUnlocked] = useState(false);
 
     // Start the draft from the latest saved metadata each time the modal opens.
     useEffect(() => {
@@ -112,6 +117,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
             setHasChanges(false);
             setRemovalConfirmText(null);
             setPendingVideoFile(null);
+            setVideoUnlocked(false);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen]);
@@ -127,6 +133,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         setDraft((d) => ({ ...d, videoUrl: "" }) as CustomNotebookMetadata);
         setRemovalConfirmText(null);
         setHasChanges(true);
+        setVideoUnlocked(true);
         onPickedVideoConsumed?.();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pickedVideoFile, isOpen]);
@@ -166,6 +173,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         setHasChanges(true);
         setDraft((d) => ({ ...d, videoUrl: "" }) as CustomNotebookMetadata);
         setRemovalConfirmText(null);
+        setVideoUnlocked(true);
     };
 
     const handleSave = () => {
@@ -183,6 +191,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         setHasChanges(false);
         setRemovalConfirmText(null);
         setPendingVideoFile(null);
+        setVideoUnlocked(false);
         onClose();
     };
 
@@ -308,7 +317,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                         // requires an explicit Clear first (deferred — the file is
                         // only deleted and the JSON updated on Save). Once cleared,
                         // the field becomes editable for the next URL or picked file.
-                        if (reflectsSavedVideo) {
+                        if (reflectsSavedVideo && !videoUnlocked) {
                             return (
                                 <div className="space-y-3 min-w-0">
                                     <div className="flex flex-wrap items-center gap-2 min-w-0">
@@ -385,7 +394,21 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                                         To confirm, type or paste the{" "}
                                                         {isLocalFile ? "file name" : "URL"} below:
                                                     </Label>
-                                                    <code className="block select-all break-all rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+                                                    <code
+                                                        className="block cursor-pointer select-all break-all rounded bg-muted px-2 py-1 font-mono text-xs text-foreground"
+                                                        title="Click to select all"
+                                                        onClick={(e) => {
+                                                            // select-all alone is unreliable (a click
+                                                            // mid-text can collapse the selection), so
+                                                            // explicitly select the whole node on click.
+                                                            const selection = window.getSelection();
+                                                            if (!selection) return;
+                                                            const range = document.createRange();
+                                                            range.selectNodeContents(e.currentTarget);
+                                                            selection.removeAllRanges();
+                                                            selection.addRange(range);
+                                                        }}
+                                                    >
                                                         {expectedToken}
                                                     </code>
                                                     <Input

--- a/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../components/ui/tooltip";
 import { Separator } from "../components/ui/separator";
 import { Badge } from "../components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { formatBytes } from "../lib/utils";
 
@@ -79,18 +80,24 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     // removal — is persisted unless the user explicitly saves.
     const [draft, setDraft] = useState<CustomNotebookMetadata>(metadata);
     const [hasChanges, setHasChanges] = useState(false);
+    // Safety gate for removing a video: the user must type/paste the exact file
+    // name (local) or URL (remote) before the removal is allowed. `null` means
+    // the confirmation panel is closed.
+    const [removalConfirmText, setRemovalConfirmText] = useState<string | null>(null);
 
     // Start the draft from the latest saved metadata each time the modal opens.
     useEffect(() => {
         if (isOpen) {
             setDraft(metadata);
             setHasChanges(false);
+            setRemovalConfirmText(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen]);
 
     // Picking a file is an immediate host action that updates the saved videoUrl;
-    // mirror it into the draft so the field reflects the newly picked file.
+    // mirror it into the draft so the field reflects the newly picked file. Any
+    // in-progress removal confirmation no longer applies to the new reference.
     useEffect(() => {
         if (!isOpen) {
             return;
@@ -98,6 +105,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         setDraft((d) =>
             d.videoUrl === metadata.videoUrl ? d : { ...d, videoUrl: metadata.videoUrl }
         );
+        setRemovalConfirmText(null);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [metadata.videoUrl]);
 
@@ -106,12 +114,22 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
         setDraft((d) => ({ ...d, [key]: value }) as CustomNotebookMetadata);
     };
 
-    // Clear/remove is deferred: it only empties the draft field. The actual file
-    // deletion + JSON change happens on Save (the host removes the old local file
-    // when the saved videoUrl changes).
+    // Step 1 of removal: open the type-to-confirm panel. Nothing is changed yet.
     const handleClearVideo = () => {
+        setRemovalConfirmText("");
+    };
+
+    const cancelClearVideo = () => {
+        setRemovalConfirmText(null);
+    };
+
+    // Step 2 of removal (only reachable once the typed text matches): empty the
+    // draft field. The actual file deletion + JSON change is still deferred to
+    // Save (the host removes the old local file when the saved videoUrl changes).
+    const confirmClearVideo = () => {
         setHasChanges(true);
         setDraft((d) => ({ ...d, videoUrl: "" }) as CustomNotebookMetadata);
+        setRemovalConfirmText(null);
     };
 
     const handleSave = () => {
@@ -122,6 +140,7 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     const handleClose = () => {
         setDraft(metadata);
         setHasChanges(false);
+        setRemovalConfirmText(null);
         onClose();
     };
 
@@ -186,64 +205,161 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                 ? formatBytes(videoSizeBytes)
                                 : "";
 
+                        // The token the user must type/paste to confirm removal:
+                        // the file name for a local video, or the full URL for a
+                        // remote one. Matching is exact after trimming surrounding
+                        // whitespace (so a pasted value with stray spaces still
+                        // works) — a deliberate "are you sure" gate.
+                        const expectedToken = isLocalFile ? fileName : videoValue;
+                        const isConfirmingRemoval = removalConfirmText !== null;
+                        const trimmedExpected = expectedToken.trim();
+                        const removalMatches =
+                            isConfirmingRemoval &&
+                            trimmedExpected.length > 0 &&
+                            (removalConfirmText ?? "").trim() === trimmedExpected;
+
                         // When a video is set, lock the field. Changing it requires an
                         // explicit Clear first (deferred — the file is only deleted and
                         // the JSON updated on Save). Once cleared, the field becomes
                         // editable for the next URL or picked file.
                         if (hasVideo) {
                             return (
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <div
-                                        className={`flex-1 min-w-0 basis-0 flex items-center gap-2 rounded-md border px-3 py-2 text-sm overflow-hidden ${
-                                            isMissing
-                                                ? "border-destructive bg-destructive/10"
-                                                : "border-input bg-muted"
-                                        }`}
-                                        title={videoValue}
-                                    >
-                                        <i
-                                            className={`codicon shrink-0 ${
-                                                isLocalFile ? "codicon-device-camera-video" : "codicon-link"
-                                            } text-muted-foreground`}
-                                        />
-                                        <span className="truncate">{displayLabel}</span>
-                                        {sizeLabel && !isMissing && (
-                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums">
-                                                {sizeLabel}
-                                            </span>
+                                <div className="space-y-3">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <div
+                                            className={`flex-1 min-w-0 basis-0 flex items-center gap-2 rounded-md border px-3 py-2 text-sm overflow-hidden ${
+                                                isMissing
+                                                    ? "border-destructive bg-destructive/10"
+                                                    : "border-input bg-muted"
+                                            }`}
+                                            title={videoValue}
+                                        >
+                                            <i
+                                                className={`codicon shrink-0 ${
+                                                    isLocalFile ? "codicon-device-camera-video" : "codicon-link"
+                                                } text-muted-foreground`}
+                                            />
+                                            <span className="truncate">{displayLabel}</span>
+                                            {sizeLabel && !isMissing && (
+                                                <span className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums">
+                                                    {sizeLabel}
+                                                </span>
+                                            )}
+                                            {isMissing && (
+                                                <Badge variant="destructive" className="ml-auto shrink-0">
+                                                    File missing
+                                                </Badge>
+                                            )}
+                                        </div>
+                                        {showFreeSpace && !isConfirmingRemoval && (
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                className="shrink-0"
+                                                onClick={onFreeDiskSpace}
+                                                title="Remove the downloaded file to save space. It will stream again on demand."
+                                            >
+                                                <i className="codicon codicon-cloud-download mr-2" />
+                                                Free up space
+                                            </Button>
                                         )}
-                                        {isMissing && (
-                                            <Badge variant="destructive" className="ml-auto shrink-0">
-                                                File missing
-                                            </Badge>
+                                        {!isConfirmingRemoval && (
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                className="shrink-0"
+                                                onClick={handleClearVideo}
+                                                title={
+                                                    isLocalFile
+                                                        ? "Remove video (the local file is deleted when you save)"
+                                                        : "Remove video"
+                                                }
+                                            >
+                                                <i className="codicon codicon-trash mr-2" />
+                                                Clear
+                                            </Button>
                                         )}
                                     </div>
-                                    {showFreeSpace && (
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            className="shrink-0"
-                                            onClick={onFreeDiskSpace}
-                                            title="Remove the downloaded file to save space. It will stream again on demand."
-                                        >
-                                            <i className="codicon codicon-cloud-download mr-2" />
-                                            Free up space
-                                        </Button>
+
+                                    {isConfirmingRemoval && (
+                                        <Alert variant="destructive">
+                                            <i className="codicon codicon-warning" />
+                                            <AlertTitle>Remove this video?</AlertTitle>
+                                            <AlertDescription className="space-y-3">
+                                                <p>
+                                                    {isLocalFile
+                                                        ? "This removes the video reference and permanently deletes the local file when you save your changes."
+                                                        : "This removes the video URL from this chapter when you save your changes."}
+                                                </p>
+                                                <div className="space-y-1.5">
+                                                    <Label
+                                                        htmlFor="video-removal-confirm"
+                                                        className="text-xs font-medium text-foreground"
+                                                    >
+                                                        To confirm, type or paste the{" "}
+                                                        {isLocalFile ? "file name" : "URL"} below:
+                                                    </Label>
+                                                    <code className="block select-all break-all rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+                                                        {expectedToken}
+                                                    </code>
+                                                    <Input
+                                                        id="video-removal-confirm"
+                                                        autoFocus
+                                                        autoComplete="off"
+                                                        spellCheck={false}
+                                                        value={removalConfirmText ?? ""}
+                                                        onChange={(e) =>
+                                                            setRemovalConfirmText(e.target.value)
+                                                        }
+                                                        onKeyDown={(e) => {
+                                                            if (e.key === "Escape") {
+                                                                // Cancel only the confirmation,
+                                                                // don't let Radix close the modal.
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                cancelClearVideo();
+                                                            } else if (e.key === "Enter") {
+                                                                e.preventDefault();
+                                                                if (removalMatches) {
+                                                                    confirmClearVideo();
+                                                                }
+                                                            }
+                                                        }}
+                                                        placeholder={
+                                                            isLocalFile
+                                                                ? "Type the file name to confirm"
+                                                                : "Type the URL to confirm"
+                                                        }
+                                                        className="bg-background text-foreground"
+                                                    />
+                                                    {(removalConfirmText ?? "").length > 0 &&
+                                                        !removalMatches && (
+                                                            <p className="text-xs text-muted-foreground">
+                                                                The text doesn't match yet.
+                                                            </p>
+                                                        )}
+                                                </div>
+                                                <div className="flex flex-wrap justify-end gap-2">
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        onClick={cancelClearVideo}
+                                                    >
+                                                        Cancel
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="destructive"
+                                                        disabled={!removalMatches}
+                                                        onClick={confirmClearVideo}
+                                                    >
+                                                        <i className="codicon codicon-trash mr-2" />
+                                                        Remove video
+                                                    </Button>
+                                                </div>
+                                            </AlertDescription>
+                                        </Alert>
                                     )}
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        className="shrink-0"
-                                        onClick={handleClearVideo}
-                                        title={
-                                            isLocalFile
-                                                ? "Remove video (the local file is deleted when you save)"
-                                                : "Remove video"
-                                        }
-                                    >
-                                        <i className="codicon codicon-trash mr-2" />
-                                        Clear
-                                    </Button>
                                 </div>
                             );
                         }

--- a/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/NotebookMetadataModal.tsx
@@ -22,9 +22,20 @@ interface NotebookMetadataModalProps {
     isOpen: boolean;
     onClose: () => void;
     metadata: CustomNotebookMetadata;
-    /** Commit the edited metadata. Only called when the user clicks "Save Changes". */
-    onSave: (updated: CustomNotebookMetadata) => void;
+    /**
+     * Commit the edited metadata. Only called when the user clicks "Save Changes".
+     * `pendingVideoFilePath` is the absolute path of a staged video pick that the
+     * host should import into the project as part of this save.
+     */
+    onSave: (updated: CustomNotebookMetadata, pendingVideoFilePath?: string) => void;
     onPickFile: () => void;
+    /**
+     * A video the user picked in the OS dialog but hasn't committed. Shown as a
+     * pending video; only imported into the project on "Save Changes".
+     */
+    pickedVideoFile?: { fsPath: string; fileName: string; } | null;
+    /** Called once the modal has adopted a delivered `pickedVideoFile`. */
+    onPickedVideoConsumed?: () => void;
     /** Stream-and-save: a downloaded local copy can be reverted to a pointer to free space. */
     canFreeDiskSpace: boolean;
     onFreeDiskSpace: () => void;
@@ -70,6 +81,8 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     metadata,
     onSave,
     onPickFile,
+    pickedVideoFile,
+    onPickedVideoConsumed,
     canFreeDiskSpace,
     onFreeDiskSpace,
     videoReferenceStatus,
@@ -84,6 +97,13 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     // name (local) or URL (remote) before the removal is allowed. `null` means
     // the confirmation panel is closed.
     const [removalConfirmText, setRemovalConfirmText] = useState<string | null>(null);
+    // A video the user picked in the OS dialog but hasn't committed. It is only
+    // imported into the project (and the videoUrl updated) when the user clicks
+    // "Save Changes"; cancelling the modal discards it.
+    const [pendingVideoFile, setPendingVideoFile] = useState<{
+        fsPath: string;
+        fileName: string;
+    } | null>(null);
 
     // Start the draft from the latest saved metadata each time the modal opens.
     useEffect(() => {
@@ -91,9 +111,25 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
             setDraft(metadata);
             setHasChanges(false);
             setRemovalConfirmText(null);
+            setPendingVideoFile(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen]);
+
+    // Adopt a staged pick delivered from the host. Clearing the draft URL keeps
+    // any previously typed URL from lingering behind the pending chip, and the
+    // one-shot consume callback prevents re-adopting it if the modal reopens.
+    useEffect(() => {
+        if (!isOpen || !pickedVideoFile) {
+            return;
+        }
+        setPendingVideoFile(pickedVideoFile);
+        setDraft((d) => ({ ...d, videoUrl: "" }) as CustomNotebookMetadata);
+        setRemovalConfirmText(null);
+        setHasChanges(true);
+        onPickedVideoConsumed?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pickedVideoFile, isOpen]);
 
     // Picking a file is an immediate host action that updates the saved videoUrl;
     // mirror it into the draft so the field reflects the newly picked file. Any
@@ -133,14 +169,20 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
     };
 
     const handleSave = () => {
-        onSave(draft);
+        onSave(draft, pendingVideoFile?.fsPath);
         setHasChanges(false);
+        setPendingVideoFile(null);
+    };
+
+    const cancelPendingVideo = () => {
+        setPendingVideoFile(null);
     };
 
     const handleClose = () => {
         setDraft(metadata);
         setHasChanges(false);
         setRemovalConfirmText(null);
+        setPendingVideoFile(null);
         onClose();
     };
 
@@ -185,8 +227,49 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                     </Select>
                 ) : config.type === "url" && config.hasFilePicker ? (
                     (() => {
+                        // A staged pick takes precedence: show it as pending until
+                        // the user saves (which imports it) or clears it (discard).
+                        if (pendingVideoFile) {
+                            return (
+                                <div className="space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <div
+                                            className="flex-1 min-w-0 basis-0 flex items-center gap-2 rounded-md border border-input bg-muted px-3 py-2 text-sm overflow-hidden"
+                                            title={pendingVideoFile.fsPath}
+                                        >
+                                            <i className="codicon codicon-device-camera-video shrink-0 text-muted-foreground" />
+                                            <span className="truncate">{pendingVideoFile.fileName}</span>
+                                            <Badge variant="secondary" className="ml-auto shrink-0">
+                                                Pending
+                                            </Badge>
+                                        </div>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            className="shrink-0"
+                                            onClick={cancelPendingVideo}
+                                            title="Discard this pending video"
+                                        >
+                                            <i className="codicon codicon-close mr-2" />
+                                            Clear
+                                        </Button>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        This video will be added to the project when you save your
+                                        changes.
+                                    </p>
+                                </div>
+                            );
+                        }
+
                         const videoValue = String(currentValue);
                         const hasVideo = !!videoValue;
+                        // Lock the field (read-only chip + Clear) only while the
+                        // draft still points at the SAVED video. While composing a
+                        // new URL (draft differs from the saved value) the field
+                        // must stay an editable input — otherwise typing the first
+                        // character would flip it to the locked view immediately.
+                        const reflectsSavedVideo = hasVideo && draft.videoUrl === metadata.videoUrl;
                         const isLocalFile = hasVideo && !/^https?:\/\//i.test(videoValue);
                         // Only flag "missing" when the draft still reflects the saved
                         // reference (not a pending edit the host hasn't evaluated yet).
@@ -218,11 +301,11 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                             trimmedExpected.length > 0 &&
                             (removalConfirmText ?? "").trim() === trimmedExpected;
 
-                        // When a video is set, lock the field. Changing it requires an
-                        // explicit Clear first (deferred — the file is only deleted and
-                        // the JSON updated on Save). Once cleared, the field becomes
-                        // editable for the next URL or picked file.
-                        if (hasVideo) {
+                        // When the saved video is set, lock the field. Changing it
+                        // requires an explicit Clear first (deferred — the file is
+                        // only deleted and the JSON updated on Save). Once cleared,
+                        // the field becomes editable for the next URL or picked file.
+                        if (reflectsSavedVideo) {
                             return (
                                 <div className="space-y-3">
                                     <div className="flex flex-wrap items-center gap-2">
@@ -312,13 +395,10 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
                                                             setRemovalConfirmText(e.target.value)
                                                         }
                                                         onKeyDown={(e) => {
-                                                            if (e.key === "Escape") {
-                                                                // Cancel only the confirmation,
-                                                                // don't let Radix close the modal.
-                                                                e.preventDefault();
-                                                                e.stopPropagation();
-                                                                cancelClearVideo();
-                                                            } else if (e.key === "Enter") {
+                                                            // Escape is handled by the dialog's
+                                                            // onEscapeKeyDown (cancels just this
+                                                            // panel). Enter confirms when matched.
+                                                            if (e.key === "Enter") {
                                                                 e.preventDefault();
                                                                 if (removalMatches) {
                                                                     confirmClearVideo();
@@ -424,7 +504,19 @@ const NotebookMetadataModal: React.FC<NotebookMetadataModalProps> = ({
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-            <DialogContent className="max-w-[calc(100%-2rem)] sm:max-w-2xl max-h-[85vh] overflow-y-auto overflow-x-hidden">
+            <DialogContent
+                className="max-w-[calc(100%-2rem)] sm:max-w-2xl max-h-[85vh] overflow-y-auto overflow-x-hidden"
+                onEscapeKeyDown={(e) => {
+                    // While the type-to-confirm removal panel is open, Escape should
+                    // dismiss only that panel, not the whole modal. (Radix listens
+                    // for Escape at the document level, so a synthetic
+                    // stopPropagation on the input isn't enough — intercept here.)
+                    if (removalConfirmText !== null) {
+                        e.preventDefault();
+                        cancelClearVideo();
+                    }
+                }}
+            >
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <i className="codicon codicon-notebook" />

--- a/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
@@ -43,29 +43,23 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     // Check if the URL is a YouTube URL
     const isYouTubeUrl = videoUrl?.includes("youtube.com") || videoUrl?.includes("youtu.be");
 
-    // Guard so a persistently-failing URL doesn't trigger an infinite refresh loop.
-    const lastStreamRefreshRef = useRef<{ url: string; at: number; }>({ url: "", at: 0 });
-
     const handleError = (error: any) => {
         console.error("Video player error:", error);
 
-        // A streamed (presigned) URL may have expired mid-watch. Ask the host for
-        // a fresh URL once before showing an error. Only do this for genuine
-        // remote stream URLs — local webview-resource URLs won't benefit and
-        // would otherwise loop. A new URL changes the player key and remounts;
-        // the same URL is guarded by time + identity.
+        // A streamed (presigned) URL may have expired mid-watch, and an invalid
+        // user-entered URL simply won't load. Defer recovery to the parent via
+        // onRequestStreamUrl: it owns a guard that survives the player's
+        // unmount/remount cycle, so it re-resolves once and then surfaces an
+        // error instead of looping. (A guard here would reset on every remount.)
+        // Only delegate genuine remote URLs — local/webview-resource and YouTube
+        // errors are shown inline below and are not retried, so they can't loop.
         const isRemoteStreamUrl =
             /^https?:\/\//i.test(videoUrl) &&
             !/vscode-resource|vscode-cdn|vscode-webview/i.test(videoUrl) &&
             !isYouTubeUrl;
         if (onRequestStreamUrl && isRemoteStreamUrl) {
-            const now = Date.now();
-            const guard = lastStreamRefreshRef.current;
-            if (guard.url !== videoUrl || now - guard.at > 10000) {
-                lastStreamRefreshRef.current = { url: videoUrl, at: now };
-                onRequestStreamUrl();
-                return;
-            }
+            onRequestStreamUrl();
+            return;
         }
 
         // ReactPlayer onError receives an error object or event

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useVSCodeMessageHandler.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useVSCodeMessageHandler.ts
@@ -86,6 +86,7 @@ interface UseVSCodeMessageHandlerProps {
     updateTextDirection: (direction: "ltr" | "rtl") => void;
     updateNotebookMetadata: (metadata: CustomNotebookMetadata) => void;
     updateVideoUrl: (url: string) => void;
+    videoFilePicked?: (fsPath: string, fileName: string) => void;
     videoStreamResolving?: () => void;
     videoStreamUnavailable?: (reason: string, message?: string) => void;
     videoNeedsDownload?: (strategy: "auto-download" | "stream-and-save" | "stream-only") => void;
@@ -165,6 +166,7 @@ export const useVSCodeMessageHandler = ({
     updateTextDirection,
     updateNotebookMetadata,
     updateVideoUrl,
+    videoFilePicked,
     videoStreamResolving,
     videoStreamUnavailable,
     videoNeedsDownload,
@@ -261,6 +263,9 @@ export const useVSCodeMessageHandler = ({
                     break;
                 case "updateVideoUrlInWebview":
                     updateVideoUrl(message.content);
+                    break;
+                case "videoFilePicked":
+                    videoFilePicked?.(message.fsPath, message.fileName);
                     break;
                 case "videoStreamResolving":
                     videoStreamResolving?.();
@@ -456,6 +461,7 @@ export const useVSCodeMessageHandler = ({
         updateTextDirection,
         updateNotebookMetadata,
         updateVideoUrl,
+        videoFilePicked,
         videoStreamResolving,
         videoStreamUnavailable,
         videoNeedsDownload,


### PR DESCRIPTION
## 1031-Adding a delete confirmation for urls and video files
#1031 

Project: 1032-delete-video-safely

## Summary

Removing or replacing a chapter video previously took effect with only a single, easily-dismissed native confirmation — risky because removing a local video permanently deletes the file from the project on save. This PR adds a robust "type-to-confirm" safety gate in the Edit Metadata modal: to remove a video, the user must type or paste the exact file name (local) or URL (remote) before the removal is enabled. It also removes the now-redundant second confirmation that fired afterward, so the user confirms exactly once.

## Changes

These should match with the Acceptance Criteria

- Clicking **Clear** on a video in the Edit Metadata modal no longer removes it immediately; it opens a destructive confirmation panel.
- The user must type or paste the exact **file name** (local video) or **URL** (remote video) to enable the **Remove video** button; matching is exact (whitespace-trimmed) so a pasted value with stray spaces still works.
- The expected value is shown in a selectable/copyable field, with a "doesn't match yet" hint while typing a non-matching value.
- Confirming only empties the draft; the actual file deletion + metadata change still happens on **Save Changes** (and Cancel/X discards everything) — the existing deferred-save model is preserved.
- Keyboard support: `Enter` confirms when matched; `Escape` cancels just the confirmation without closing the modal; the input auto-focuses.
- The confirmation state resets when the modal opens, when the video reference changes (e.g. picking a new file), and on close.
- Removed the redundant host-side "Replace/Remove… will be deleted" prompt for modal-driven changes (a new `skipVideoConfirm` flag), since the modal now performs a stronger confirmation. The host still deletes the old file, and keeps the prompt as a fallback for any non-modal caller.

## Testing Checklist

- [x] **Local file – remove:** Clear a local video → confirmation panel appears showing the file name; **Remove video** is disabled until the typed/pasted name matches exactly.
- [x] Typing a wrong/partial name keeps **Remove video** disabled and shows "The text doesn't match yet."
- [x] Pasting the file name (with stray leading/trailing spaces) enables removal.
- [x] **URL – remove:** Clear a URL video → must type/paste the full URL to enable removal.
- [x] Confirm removal → field empties, but nothing is deleted until **Save Changes**.
- [x] **Save Changes** after a confirmed local removal → the local file is actually deleted from `files/` and `pointers/`; "Show Video" toggle disappears.
- [x] **Cancel/X** after confirming removal (before Save) → video intact; local file **not** deleted; player still works.
- [x] No redundant second native "Remove?/Replace?" dialog appears on Save after the in-modal confirmation.
- [x] **Replace flow:** Clear (type-to-confirm) → pick a new file → no extra "Replace?" prompt; the old local file is deleted and the new one is saved.
- [x] **Esc** inside the confirmation input cancels only the confirmation and does **not** close the modal.
- [x] **Enter** in the input removes the video only when the text matches.
- [x] Opening the modal / switching reference resets any in-progress confirmation (no stale panel).
- [x] Regression: editing non-video fields (font size / direction / corpus marker) and saving still works with no video prompts.