### PR TITLE
1036 feature play video button needs to be available when there is no recorded audio

### DIFF
--- a/src/projectManager/utils/versionChecks.ts
+++ b/src/projectManager/utils/versionChecks.ts
@@ -8,7 +8,7 @@ interface VSCodeVersionStatus {
 }
 
 // Required version of Frontier Authentication extension for all syncing operations (based on codex minimum requirements)
-export const REQUIRED_FRONTIER_VERSION = "0.6.0"; // Prevent concurrent metadata.json changes by Frontier Authentication
+export const REQUIRED_FRONTIER_VERSION = "0.7.0"; // Prevent concurrent metadata.json changes by Frontier Authentication
 
 // Required VS Code version for Codex Editor
 export const REQUIRED_VSCODE_VERSION = "1.99.0"; // Try really hard not to bump this up

--- a/src/projectManager/utils/versionChecks.ts
+++ b/src/projectManager/utils/versionChecks.ts
@@ -8,7 +8,7 @@ interface VSCodeVersionStatus {
 }
 
 // Required version of Frontier Authentication extension for all syncing operations (based on codex minimum requirements)
-export const REQUIRED_FRONTIER_VERSION = "0.7.0"; // Prevent concurrent metadata.json changes by Frontier Authentication
+export const REQUIRED_FRONTIER_VERSION = "0.6.0"; // Prevent concurrent metadata.json changes by Frontier Authentication
 
 // Required VS Code version for Codex Editor
 export const REQUIRED_VSCODE_VERSION = "1.99.0"; // Try really hard not to bump this up

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -1643,25 +1643,23 @@ const CellEditor: React.FC<CellEditorProps> = ({
         const startTime = effectiveTimestamps?.startTime;
         const endTime = effectiveTimestamps?.endTime;
 
-        console.log("[PlayVideo] clicked", {
-            startTime,
-            endTime,
-            hasAudioBlob: !!audioBlob,
-            shouldShowVideoPlayer,
-            videoUrl,
-        });
-
         if (startTime === undefined || endTime === undefined) {
-            console.warn("[PlayVideo] Timestamps are not available");
+            console.warn("Timestamps are not available");
             return;
         }
 
         if (endTime <= startTime) {
-            console.warn("[PlayVideo] Invalid timestamps: endTime must be greater than startTime");
+            console.warn("Invalid timestamps: endTime must be greater than startTime");
             return;
         }
 
         setIsPlayAudioLoading(true);
+        // This cell-scoped preview owns the shared video for [startTime, endTime];
+        // suppress the multi-cell audio overlay so it can't play other cells'
+        // recorded audio over (or past) this section. Cleared when the video
+        // stops (isVideoPlaying → false in useMultiCellAudioPlayback), or in the
+        // finally below if nothing ends up playing.
+        globalAudioController.setVideoPreviewActive(true);
         try {
             // Clean up any existing playback
             if (audioElementRef.current) {
@@ -1924,16 +1922,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }
 
             // Handle video playback if available
-            console.log("[PlayVideo] video gate", {
-                shouldShowVideoPlayer,
-                videoUrl,
-                hasPlayerRef: !!playerRef?.current,
-                playerRefType: playerRef?.current
-                    ? Object.prototype.toString.call(playerRef.current)
-                    : null,
-                startTime,
-                endTime,
-            });
             if (
                 shouldShowVideoPlayer &&
                 videoUrl &&
@@ -2004,11 +1992,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         videoElement = asMediaElement(document.querySelector("video"));
                     }
 
-                    console.log("[PlayVideo] discovery result", {
-                        foundVideoElement: !!videoElement,
-                        seeked,
-                    });
-
                     // Seek to the subtitle start unless an API seek already did
                     if (videoElement && !seeked) {
                         videoElement.currentTime = startTime;
@@ -2024,14 +2007,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         // recorded audio, play the video's own track so the
                         // section isn't silent.
                         videoElement.muted = combinedBlob ? muteVideoAudioDuringPlayback : false;
-
-                        console.log("[PlayVideo] ready to play", {
-                            currentTime: videoElement.currentTime,
-                            endTime,
-                            muted: videoElement.muted,
-                            paused: videoElement.paused,
-                            readyState: videoElement.readyState,
-                        });
 
                         // Check if we're already past the end time (shouldn't happen, but be safe)
                         if (videoElement.currentTime >= endTime) {
@@ -2059,17 +2034,12 @@ const CellEditor: React.FC<CellEditorProps> = ({
                             // This prevents the handler from firing and pausing before play() resolves
                             try {
                                 await videoElement.play();
-                                console.log("[PlayVideo] play() resolved", {
-                                    paused: videoElement.paused,
-                                    currentTime: videoElement.currentTime,
-                                });
 
                                 // Only set up the handler after play() succeeds
                                 // This prevents race conditions where pause() interrupts play()
                                 videoTimeUpdateHandlerRef.current = timeUpdateHandler;
                                 videoElement.addEventListener("timeupdate", timeUpdateHandler);
                             } catch (playError) {
-                                console.warn("[PlayVideo] play() rejected", playError);
                                 // Suppress AbortError warnings - these are expected when pause() interrupts play()
                                 // This can happen if cleanup is called while play() is pending
                                 if (
@@ -2107,6 +2077,16 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }
         } finally {
             setIsPlayAudioLoading(false);
+            // Normally the flag is cleared when the video stops (isVideoPlaying
+            // → false in useMultiCellAudioPlayback). But if nothing actually
+            // started here — no audio and the video isn't playing (not found, or
+            // play() was rejected) — that transition never happens, so clear it
+            // now to avoid leaving the overlay suppressed.
+            const videoPlaying =
+                !!videoElementRef.current && !videoElementRef.current.paused;
+            if (!videoPlaying && !audioElementRef.current) {
+                globalAudioController.setVideoPreviewActive(false);
+            }
         }
     }, [
         audioBlob,
@@ -2177,6 +2157,10 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 }
                 videoElementRef.current = null;
             }
+
+            // Clear the preview flag in case the cell changed mid-preview, so the
+            // multi-cell overlay isn't left suppressed.
+            globalAudioController.setVideoPreviewActive(false);
         };
     }, [cellMarkers]);
 

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -1338,8 +1338,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
             audioAttachments?.[nextCellId] === "available-local" ||
             audioAttachments?.[nextCellId] === "available-pointer" ||
             audioAttachments?.[nextCellId] === "available-cached");
-    const canPlayAudioWithVideo =
-        Boolean(audioBlob) || hasPrevAudioAvailable || hasNextAudioAvailable;
 
     // Helper function to request audio blob for a cell
     const requestAudioBlob = useCallback((cellId: string): Promise<Blob | null> => {
@@ -1645,13 +1643,21 @@ const CellEditor: React.FC<CellEditorProps> = ({
         const startTime = effectiveTimestamps?.startTime;
         const endTime = effectiveTimestamps?.endTime;
 
+        console.log("[PlayVideo] clicked", {
+            startTime,
+            endTime,
+            hasAudioBlob: !!audioBlob,
+            shouldShowVideoPlayer,
+            videoUrl,
+        });
+
         if (startTime === undefined || endTime === undefined) {
-            console.warn("Timestamps are not available");
+            console.warn("[PlayVideo] Timestamps are not available");
             return;
         }
 
         if (endTime <= startTime) {
-            console.warn("Invalid timestamps: endTime must be greater than startTime");
+            console.warn("[PlayVideo] Invalid timestamps: endTime must be greater than startTime");
             return;
         }
 
@@ -1796,14 +1802,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         combinedBlob = null;
                     }
                 } else {
-                    setAudioWarning("No audio available in the current video timestamp range");
-                    return;
+                    // No recorded audio overlaps this range — fall through and
+                    // play the video alone from the subtitle start time. Clear
+                    // any stale cached blob so we don't replay another cell's
+                    // audio over this video-only section.
+                    combinedBlob = null;
+                    setAudioWarning(null);
                 }
-            }
-
-            if (!combinedBlob) {
-                console.warn("No combined audio blob available");
-                return;
             }
 
             // Helper function to clean up all audio and video
@@ -1848,135 +1853,185 @@ const CellEditor: React.FC<CellEditorProps> = ({
                 }
             };
 
-            // Create single audio element from combined blob
-            const audioUrl = URL.createObjectURL(combinedBlob);
-            overlappingAudioUrlsRef.current.set("combined", audioUrl);
-            const audio = new Audio(audioUrl);
-            audioElementRef.current = audio;
+            // Create single audio element from combined blob. Skipped when no
+            // recorded audio overlaps this range — the video then plays alone.
+            if (combinedBlob) {
+                const audioUrl = URL.createObjectURL(combinedBlob);
+                overlappingAudioUrlsRef.current.set("combined", audioUrl);
+                const audio = new Audio(audioUrl);
+                audioElementRef.current = audio;
 
-            // Set up audio event handlers
-            audio.onended = () => {
-                if (!videoElementRef.current) {
-                    cleanupAll();
-                }
-            };
-            audio.onerror = () => {
-                const error = audio.error;
-                // Only log if it's a real error (not just unsupported format - code 4)
-                // MediaError codes: 1=ABORTED, 2=NETWORK, 3=DECODE, 4=SRC_NOT_SUPPORTED
-                if (error && error.code !== 4) {
-                    const errorMessage = error.message
-                        ? `Error loading combined audio: ${error.message}`
-                        : "Error loading combined audio";
-                    console.warn(errorMessage);
-                }
-            };
-
-            // Set up timeupdate listener to stop at endTime
-            const audioTimeUpdateHandler = (e: Event) => {
-                const target = e.target as HTMLAudioElement;
-                if (target.currentTime >= totalDuration) {
-                    target.pause();
-                    if (audioTimeUpdateHandlerRef.current) {
-                        target.removeEventListener("timeupdate", audioTimeUpdateHandlerRef.current);
-                        audioTimeUpdateHandlerRef.current = null;
+                // Set up audio event handlers
+                audio.onended = () => {
+                    if (!videoElementRef.current) {
+                        cleanupAll();
                     }
-                    cleanupAll();
-                }
-            };
-
-            audioTimeUpdateHandlerRef.current = audioTimeUpdateHandler;
-            audio.addEventListener("timeupdate", audioTimeUpdateHandler);
-
-            // Wait for audio to be ready
-            await new Promise<void>((resolve, reject) => {
-                const handleLoadedMetadata = () => {
-                    audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
-                    audio.removeEventListener("error", handleError);
-                    resolve();
                 };
-
-                const handleError = () => {
-                    audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
-                    audio.removeEventListener("error", handleError);
+                audio.onerror = () => {
                     const error = audio.error;
-                    const errorMessage = error?.message || "Error loading combined audio";
-                    reject(new Error(errorMessage));
+                    // Only log if it's a real error (not just unsupported format - code 4)
+                    // MediaError codes: 1=ABORTED, 2=NETWORK, 3=DECODE, 4=SRC_NOT_SUPPORTED
+                    if (error && error.code !== 4) {
+                        const errorMessage = error.message
+                            ? `Error loading combined audio: ${error.message}`
+                            : "Error loading combined audio";
+                        console.warn(errorMessage);
+                    }
                 };
 
-                if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) {
-                    handleLoadedMetadata();
-                } else {
-                    audio.addEventListener("loadedmetadata", handleLoadedMetadata);
-                    audio.addEventListener("error", handleError);
-                }
-            });
+                // Set up timeupdate listener to stop at endTime
+                const audioTimeUpdateHandler = (e: Event) => {
+                    const target = e.target as HTMLAudioElement;
+                    if (target.currentTime >= totalDuration) {
+                        target.pause();
+                        if (audioTimeUpdateHandlerRef.current) {
+                            target.removeEventListener(
+                                "timeupdate",
+                                audioTimeUpdateHandlerRef.current
+                            );
+                            audioTimeUpdateHandlerRef.current = null;
+                        }
+                        cleanupAll();
+                    }
+                };
+
+                audioTimeUpdateHandlerRef.current = audioTimeUpdateHandler;
+                audio.addEventListener("timeupdate", audioTimeUpdateHandler);
+
+                // Wait for audio to be ready
+                await new Promise<void>((resolve, reject) => {
+                    const handleLoadedMetadata = () => {
+                        audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
+                        audio.removeEventListener("error", handleError);
+                        resolve();
+                    };
+
+                    const handleError = () => {
+                        audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
+                        audio.removeEventListener("error", handleError);
+                        const error = audio.error;
+                        const errorMessage = error?.message || "Error loading combined audio";
+                        reject(new Error(errorMessage));
+                    };
+
+                    if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) {
+                        handleLoadedMetadata();
+                    } else {
+                        audio.addEventListener("loadedmetadata", handleLoadedMetadata);
+                        audio.addEventListener("error", handleError);
+                    }
+                });
+            }
 
             // Handle video playback if available
+            console.log("[PlayVideo] video gate", {
+                shouldShowVideoPlayer,
+                videoUrl,
+                hasPlayerRef: !!playerRef?.current,
+                playerRefType: playerRef?.current
+                    ? Object.prototype.toString.call(playerRef.current)
+                    : null,
+                startTime,
+                endTime,
+            });
             if (
                 shouldShowVideoPlayer &&
                 videoUrl &&
-                playerRef?.current &&
                 startTime !== undefined &&
                 endTime !== undefined
             ) {
                 try {
                     let videoElement: HTMLVideoElement | null = null;
                     let seeked = false;
+                    const player = playerRef?.current;
 
-                    // First try seekTo method if available
-                    if (typeof playerRef.current.seekTo === "function") {
-                        playerRef.current.seekTo(startTime, "seconds");
+                    // Duck-type a media element. For HLS/streaming sources
+                    // react-player v3 renders a custom element (e.g.
+                    // <hls-video>) whose real <video> lives in shadow DOM.
+                    // These elements are drop-in <video> replacements: they
+                    // expose play()/currentTime/muted/etc and proxy to the
+                    // inner video, so we can drive them directly without
+                    // reaching into the shadow root. A plain <video> matches
+                    // this too, covering the non-HLS case.
+                    const asMediaElement = (el: unknown): HTMLVideoElement | null => {
+                        const candidate = el as any;
+                        if (
+                            candidate &&
+                            typeof candidate === "object" &&
+                            typeof candidate.play === "function" &&
+                            typeof candidate.pause === "function" &&
+                            typeof candidate.addEventListener === "function" &&
+                            "currentTime" in candidate &&
+                            "paused" in candidate
+                        ) {
+                            return candidate as HTMLVideoElement;
+                        }
+                        return null;
+                    };
+
+                    // 1. The ref itself is the media element (native <video>
+                    //    or a media-compatible custom element like <hls-video>).
+                    videoElement = asMediaElement(player);
+
+                    // 2. Older API: seekTo method if available.
+                    if (!videoElement && typeof player?.seekTo === "function") {
+                        player.seekTo(startTime, "seconds");
                         seeked = true;
                     }
 
-                    // Try to find the video element
-                    const internalPlayer = playerRef.current.getInternalPlayer?.();
-
-                    if (internalPlayer instanceof HTMLVideoElement) {
-                        videoElement = internalPlayer;
-                        if (!seeked) {
-                            videoElement.currentTime = startTime;
-                            seeked = true;
-                        }
-                    } else if (internalPlayer && typeof internalPlayer === "object") {
-                        // Try different ways to access the video element
-                        const foundVideo =
-                            (internalPlayer as any).querySelector?.("video") ||
-                            (internalPlayer as any).video ||
-                            internalPlayer;
-
-                        if (foundVideo instanceof HTMLVideoElement) {
-                            videoElement = foundVideo;
-                            if (!seeked) {
-                                videoElement.currentTime = startTime;
-                                seeked = true;
-                            }
-                        }
+                    // 3. getInternalPlayer (react-player v2 style).
+                    if (!videoElement && player) {
+                        const internalPlayer = player.getInternalPlayer?.();
+                        videoElement =
+                            asMediaElement(internalPlayer) ||
+                            asMediaElement((internalPlayer as any)?.querySelector?.("video")) ||
+                            asMediaElement((internalPlayer as any)?.video);
                     }
 
-                    // Last resort: Try to find video element in the DOM
-                    if (!videoElement && playerRef.current) {
-                        const wrapper = playerRef.current as any;
-                        const foundVideo =
-                            wrapper.querySelector?.("video") ||
-                            wrapper.parentElement?.querySelector?.("video");
+                    // 4. Look for a <video> in light DOM near the ref, then in
+                    //    its shadow root (custom elements keep it there).
+                    if (!videoElement && player) {
+                        const wrapper = player as any;
+                        videoElement =
+                            asMediaElement(wrapper.querySelector?.("video")) ||
+                            asMediaElement(wrapper.parentElement?.querySelector?.("video")) ||
+                            asMediaElement(wrapper.shadowRoot?.querySelector?.("video"));
+                    }
 
-                        if (foundVideo instanceof HTMLVideoElement) {
-                            videoElement = foundVideo;
-                            if (!seeked) {
-                                videoElement.currentTime = startTime;
-                                seeked = true;
-                            }
-                        }
+                    // 5. Last resort: the editor renders a single player, so
+                    //    fall back to the only <video> in the document.
+                    if (!videoElement) {
+                        videoElement = asMediaElement(document.querySelector("video"));
+                    }
+
+                    console.log("[PlayVideo] discovery result", {
+                        foundVideoElement: !!videoElement,
+                        seeked,
+                    });
+
+                    // Seek to the subtitle start unless an API seek already did
+                    if (videoElement && !seeked) {
+                        videoElement.currentTime = startTime;
+                        seeked = true;
                     }
 
                     // If we found the video element, mute it and set up playback
                     if (videoElement) {
                         videoElementRef.current = videoElement;
                         previousVideoMuteStateRef.current = videoElement.muted;
-                        // Only mute if checkbox is checked
-                        videoElement.muted = muteVideoAudioDuringPlayback;
+                        // Mute only when recorded audio is overlaying the video
+                        // (the checkbox exists to avoid double audio). With no
+                        // recorded audio, play the video's own track so the
+                        // section isn't silent.
+                        videoElement.muted = combinedBlob ? muteVideoAudioDuringPlayback : false;
+
+                        console.log("[PlayVideo] ready to play", {
+                            currentTime: videoElement.currentTime,
+                            endTime,
+                            muted: videoElement.muted,
+                            paused: videoElement.paused,
+                            readyState: videoElement.readyState,
+                        });
 
                         // Check if we're already past the end time (shouldn't happen, but be safe)
                         if (videoElement.currentTime >= endTime) {
@@ -2004,12 +2059,17 @@ const CellEditor: React.FC<CellEditorProps> = ({
                             // This prevents the handler from firing and pausing before play() resolves
                             try {
                                 await videoElement.play();
+                                console.log("[PlayVideo] play() resolved", {
+                                    paused: videoElement.paused,
+                                    currentTime: videoElement.currentTime,
+                                });
 
                                 // Only set up the handler after play() succeeds
                                 // This prevents race conditions where pause() interrupts play()
                                 videoTimeUpdateHandlerRef.current = timeUpdateHandler;
                                 videoElement.addEventListener("timeupdate", timeUpdateHandler);
                             } catch (playError) {
+                                console.warn("[PlayVideo] play() rejected", playError);
                                 // Suppress AbortError warnings - these are expected when pause() interrupts play()
                                 // This can happen if cleanup is called while play() is pending
                                 if (
@@ -2028,17 +2088,21 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }
 
             // Play the combined audio using globalAudioController to prevent duplicate playback
-            // This ensures useMultiCellAudioPlayback knows audio is already playing
-            try {
-                await globalAudioController.playExclusive(audio);
-            } catch (playError) {
-                if (
-                    playError instanceof Error &&
-                    playError.name !== "AbortError" &&
-                    playError.name !== "NotAllowedError"
-                ) {
-                    console.error("Error playing combined audio:", playError);
-                    cleanupAll();
+            // This ensures useMultiCellAudioPlayback knows audio is already playing.
+            // Skipped for video-only playback where no audio element was created.
+            const audioToPlay = audioElementRef.current;
+            if (audioToPlay) {
+                try {
+                    await globalAudioController.playExclusive(audioToPlay);
+                } catch (playError) {
+                    if (
+                        playError instanceof Error &&
+                        playError.name !== "AbortError" &&
+                        playError.name !== "NotAllowedError"
+                    ) {
+                        console.error("Error playing combined audio:", playError);
+                        cleanupAll();
+                    }
                 }
             }
         } finally {
@@ -5300,7 +5364,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                         variant="default"
                                                         size="sm"
                                                         disabled={
-                                                            !canPlayAudioWithVideo ||
                                                             (effectiveTimestamps?.endTime ?? 0) -
                                                                 (effectiveTimestamps?.startTime ??
                                                                     0) <=

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useMultiCellAudioPlayback.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useMultiCellAudioPlayback.ts
@@ -474,6 +474,25 @@ export function useMultiCellAudioPlayback({
             return;
         }
 
+        // A cell-scoped "Play Video" preview owns playback for a single cell's
+        // range; don't overlay other cells' recorded audio while it runs. Stop
+        // any element that may have already started (e.g. a debounced check that
+        // raced the preview start) so it can't linger past the video stop.
+        if (globalAudioController.isVideoPreviewActive()) {
+            audioElementsRef.current.forEach((data) => {
+                if (!data.audioElement.paused || data.isPlaying) {
+                    try {
+                        data.audioElement.pause();
+                        data.audioElement.currentTime = 0;
+                        data.isPlaying = false;
+                    } catch (error) {
+                        console.error(`Error stopping audio for cell ${data.cellId}:`, error);
+                    }
+                }
+            });
+            return;
+        }
+
         const currentTime = currentVideoTime;
         const tolerance = 0.1; // 100ms tolerance for starting audio
 
@@ -662,6 +681,12 @@ export function useMultiCellAudioPlayback({
                 }
             });
             restoreVideoMuteState();
+            // The video has stopped, so any cell-scoped "Play Video" preview is
+            // over. Clear the suppression flag here (rather than at the preview's
+            // endTime) so it stays set until the video is confirmed stopped —
+            // closing the race where a debounced check could start overlay audio
+            // in the gap between the flag clearing and isVideoPlaying flipping.
+            globalAudioController.setVideoPreviewActive(false);
         }
     }, [isVideoPlaying, restoreVideoMuteState]);
 

--- a/webviews/codex-webviews/src/lib/audioController.ts
+++ b/webviews/codex-webviews/src/lib/audioController.ts
@@ -3,6 +3,7 @@ export type AudioControllerEvent = { type: "stopped"; audio: HTMLAudioElement; }
 export class GlobalAudioController {
     private currentAudio: HTMLAudioElement | null = null;
     private listeners: Set<(e: AudioControllerEvent) => void> = new Set();
+    private videoPreviewActive = false;
 
     addListener(listener: (e: AudioControllerEvent) => void): void {
         this.listeners.add(listener);
@@ -67,6 +68,21 @@ export class GlobalAudioController {
             this.currentAudio = null;
             this.notifyStopped(audio);
         }
+    }
+
+    /**
+     * Marks that a cell-scoped "Play Video" preview is driving the shared video
+     * element. While active, the multi-cell audio overlay must not start other
+     * cells' recorded audio — the preview owns playback for a single cell's
+     * range. Without this, a no-audio cell's preview lets the overlay play an
+     * overlapping cell's audio (which can also linger past the video stop).
+     */
+    setVideoPreviewActive(active: boolean): void {
+        this.videoPreviewActive = active;
+    }
+
+    isVideoPreviewActive(): boolean {
+        return this.videoPreviewActive;
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1036

The **Play Video** button in the Timeline tab of the cell editor was disabled whenever a cell had no recorded audio, so subtitle/video cells without a dub couldn't be previewed against the video. This makes the button available regardless of recorded audio: it now seeks to the start of the cell's subtitle timestamp and plays that section, working for both local files and streamed videos (depends on the domain). It also fixes a related issue where previewing a no-audio cell could bleed in another cell's recorded audio created by these changes.

## Changes

- **Play Video is enabled when there is no recorded audio.** Removed the `!canPlayAudioWithVideo` gate from the button's `disabled` condition. The button is still hidden when no video is showing (it remains gated on `isSubtitlesType && shouldShowVideoPlayer && videoUrl`).
- **Plays the subtitle section regardless of audio.** `handlePlayAudioWithVideo` no longer bails out when there are no audio segments — it seeks the video to the subtitle start time and plays through to the end time. Audio-element creation is skipped when there's nothing to combine, and the video plays its own audio track (the "Mute video" checkbox is only honored when recorded audio is actually overlaying the video).
- **Works for streamed videos (HLS URLs).** For `.m3u8` sources, react-player v3 renders the `<hls-video>` custom element (the real `<video>` lives in shadow DOM), so the previous discovery that required `instanceof HTMLVideoElement` / `querySelector("video")` failed. Discovery now duck-types the media element and drives the custom element directly, with shadow-DOM and document fallbacks.
- **Audio no longer plays another cell's audio when clicking "Play Video" on the first time after reloading.** Added a `videoPreviewActive` flag to the shared audio controller. While a cell-scoped Play Video preview is driving the shared video element, the multi-cell audio overlay (`useMultiCellAudioPlayback`) is suppressed, so it can't start (or let linger past the video stop) a neighboring cell's recorded audio. The flag is cleared when the video stops, closing the previous timing race.

## Testing Checklist

### Play Video availability
- [x] On a subtitle/video cell **with** recorded audio, the Play Video button is enabled and visible.
- [x] On a subtitle/video cell **without** recorded audio, the Play Video button is now enabled and visible.
- [x] When no video is showing, the Play Video button is hidden.
- [x] The button is disabled only when the timestamp range is empty/invalid or while loading.

### Playback behavior
- [x] Clicking Play Video seeks the video to the start of the cell's subtitle timestamp.
- [x] The video plays from the subtitle start time through to the end time, then stops.
- [x] On a cell **with** recorded audio, the cell's audio plays in sync with the video (mute-video behavior unchanged).
- [x] On a cell **without** recorded audio, the video section plays with its own audio (not silent).

### Streamed (HLS) video
- [x] Play Video seeks and plays correctly for a streamed `.m3u8` video URL.
- [x] Play Video still seeks and plays correctly for a local/non-streamed video file.

### No-audio audio bleed
- [x] Play a cell that has recorded audio, then switch to a cell with no recorded audio and click Play Video — no audio from the previous/other cell plays (verified on the first attempt after loading the views, where the bug previously occurred).
- [x] Repeated previews across audio and no-audio cells never leak another cell's audio.

### Regressions
- [x] Full-timeline video playback via the native video controls still overlays each cell's recorded audio as before.
- [x] Navigating away mid-preview leaves the multi-cell overlay working normally (not stuck suppressed).
- [x] Webview unit tests pass (`pnpm run test`).