### PR TITLE
InDesign import export update

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,2 @@
+[0617/150301.373:ERROR:third_party\crashpad\crashpad\util\win\registration_protocol_win.cc:108] CreateFile: The system cannot find the file specified. (0x2)
+[0617/150302.820:ERROR:third_party\crashpad\crashpad\util\win\registration_protocol_win.cc:108] CreateFile: The system cannot find the file specified. (0x2)

--- a/sharedUtils/exportOptionsEligibility.ts
+++ b/sharedUtils/exportOptionsEligibility.ts
@@ -7,7 +7,6 @@ export const EXPORT_OPTIONS_BY_FILE_TYPE: Record<string, string[]> = {
         "docx",
         "indesign",
         "biblica",
-        "reach4life",
         "pdf",
         "obs",
         "markdown",

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -276,7 +276,6 @@ async function exportCodexContentAsIdmlRoundtrip(
     // Import exporters
     const { exportIdmlRoundtrip } = await import("../../webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter");
     const { exportIdmlRoundtrip: exportBiblicaIdml } = await import("../../webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter");
-    // const { exportIdmlRoundtrip: exportReach4LifeIdml } = await import("../../webviews/codex-webviews/src/NewSourceUploader/importers/reach4life/reach4lifeExporter");
 
     // For each selected codex file, find its original attachment and create a translated copy in export folder
     for (const [index, filePath] of filesToExport.entries()) {
@@ -305,11 +304,6 @@ async function exportCodexContentAsIdmlRoundtrip(
                 fileType === 'biblica' ||
                 importerType === 'biblica-experimental' ||
                 fileType === 'biblica-experimental';
-            // const isReach4LifeFile =
-            //     corpusMarker === 'reach4life' ||
-            //     corpusMarker === 'reach4life-idml' ||
-            //     importerType === 'reach4life' ||
-            //     fileType === 'reach4life';
             const exporterType = isBiblicaFile ? 'Biblica' : 'Standard';
 
             console.log(`[IDML Export] Processing ${fileName} (corpusMarker: ${corpusMarker}) using ${exporterType} exporter`);
@@ -1544,18 +1538,16 @@ async function exportCodexContentAsRebuild(
             } else if (
                 corpusMarker === 'biblica' ||
                 corpusMarker === 'biblica-idml' ||
-                corpusMarker === 'reach4life' ||
-                corpusMarker === 'reach4life-idml' ||
                 corpusMarker === 'idml-roundtrip' ||
+                corpusMarker === 'indesign' ||
                 (corpusMarker && corpusMarker.startsWith('idml-')) ||
                 importerType === 'biblica' ||
                 fileType === 'biblica' ||
-                importerType === 'reach4life' ||
-                fileType === 'reach4life' ||
+                importerType === 'indesign' ||
                 importerType === 'biblica-experimental' || // Backward compatibility
                 fileType === 'biblica-experimental' // Backward compatibility
             ) {
-                // Biblica/Reach4Life files and IDML files both use the IDML exporter
+                // Biblica and InDesign files both use the IDML exporter
                 filesByType['idml'] = filesByType['idml'] || [];
                 filesByType['idml'].push(filePath);
             } else if (
@@ -1694,7 +1686,7 @@ async function exportCodexContentAsRebuild(
         messages.push(`Skipped ${unsupportedFiles.length} unsupported file(s).`);
         console.warn("[Rebuild Export] Unsupported files:", unsupportedFiles);
     }
-    messages.push("Supported types: DOCX, IDML, Biblica, Reach4Life, PDF, OBS, Markdown, TMS, USFM, CSV/TSV.");
+    messages.push("Supported types: DOCX, InDesign, Biblica, PDF, OBS, Markdown, TMS, USFM, CSV/TSV.");
 
     reporter.complete({
         exportPath: userSelectedPath,

--- a/src/projectManager/debug.log
+++ b/src/projectManager/debug.log
@@ -1,0 +1,2 @@
+[0617/150302.872:ERROR:third_party\crashpad\crashpad\util\win\registration_protocol_win.cc:108] CreateFile: The system cannot find the file specified. (0x2)
+[0617/155238.939:ERROR:third_party\crashpad\crashpad\util\win\registration_protocol_win.cc:108] CreateFile: The system cannot find the file specified. (0x2)

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1228,7 +1228,6 @@ function getWebviewContent(
                                                 <span class="format-tag format-tag-roundtrip">CSV/TSV</span>
                                                 <span class="format-tag format-tag-roundtrip">IDML</span>
                                                 <span class="format-tag format-tag-roundtrip">Biblica Study Notes</span>
-                                                <!--<span class="format-tag format-tag-roundtrip">Reach4Life</span>-->
                                             </div>
                                         </div>
                                     </div>

--- a/src/projectManager/utils/exportViewUtils.ts
+++ b/src/projectManager/utils/exportViewUtils.ts
@@ -271,16 +271,6 @@ function getGroupKeyFromMetadata(metadata: Record<string, unknown>): string {
         return "docx";
     }
 
-    // Reach4Life (idml) - check before Biblica and generic InDesign
-    if (
-        corpusMarker === "reach4life" ||
-        corpusMarker === "reach4life-idml" ||
-        importerType === "reach4life" ||
-        fileType === "reach4life"
-    ) {
-        return "reach4life";
-    }
-
     // Biblica Study Notes (idml) - check before generic InDesign
     if (
         corpusMarker === "biblica" ||
@@ -429,8 +419,7 @@ export async function groupCodexFilesByImporterType(
         maculabible: 9,
         obs: 10,
         biblica: 11,
-        reach4life: 12,
-        spreadsheet: 13,
+        spreadsheet: 12,
         unknown: 99,
     };
 

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -1465,6 +1465,9 @@ function standardizeImporterType(importerType: string | undefined): string | und
     if (normalized === "obs-story") {
         return "obs";
     }
+    if (normalized === "reach4life") {
+        return "indesign";
+    }
 
     // Valid FileImporterType values (must match the FileImporterType union in types/index.d.ts)
     const validTypes: string[] = [
@@ -1487,7 +1490,6 @@ function standardizeImporterType(importerType: string | undefined): string | und
         "ebibleCorpus",
         "macula",
         "biblica",
-        "reach4life",
         "obs",
     ];
 
@@ -1520,6 +1522,7 @@ function inferImporterTypeFromCorpusMarker(corpusMarker: string | undefined): st
         "subtitle": "subtitles",
         "spreadsheet": "spreadsheet",
         "indesign": "indesign",
+        "reach4life": "indesign",
         "usfm": "usfm",
         "usfm-experimental": "usfm-experimental",
         "paratext": "paratext",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -912,7 +912,6 @@ type FileImporterType =
     | "ebibleCorpus"
     | "macula"
     | "biblica"
-    | "reach4life"
     | "obs";
 
 /**

--- a/webviews/codex-webviews/src/NewSourceUploader/components/PluginSelection.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/components/PluginSelection.tsx
@@ -45,7 +45,6 @@ const PluginCard: React.FC<{
     const isBetaPlugin =
         plugin.id === "indesign-importer" ||
         plugin.id === "biblica-importer" ||
-        plugin.id === "reach4life-importer" ||
         plugin.id === "spreadsheet";
 
     return (

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/BiblicaImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/BiblicaImporterForm.tsx
@@ -19,32 +19,20 @@ import {
 } from "../../utils/workflowHelpers";
 import { extractImagesFromHtml } from "../../utils/imageProcessor";
 import { createNoteCellMetadata } from "./cellMetadata";
-
-function escapeHtml(text: string): string {
-    const div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML.replace(/\n/g, "<br>");
-}
-
-function buildInlineHTMLFromRanges(
-    ranges: { appliedCharacterStyle?: string; content?: string }[]
-): string {
-    if (!Array.isArray(ranges) || ranges.length === 0) return "";
-
-    return ranges
-        .map((r) => {
-            const style = (r?.appliedCharacterStyle || "").toString();
-            const content = (r?.content || "").toString();
-            const text = content.replace(/\n/g, "<br />");
-            const safeStyle = escapeHtml(style);
-            const safeText = text
-                .split("<br />")
-                .map((part: string) => escapeHtml(part))
-                .join("<br />");
-            return `<span class="idml-char" data-character-style="${safeStyle}">${safeText}</span>`;
-        })
-        .join("");
-}
+import type { IDMLStory } from "./types";
+import {
+    buildSegmentedParagraphHtml,
+    extractContentSegmentStructureFromParagraph,
+    getSegmentCharacterStylesForParagraph,
+    joinContentSegments,
+} from "../common/contentSegmentUtils";
+import {
+    isBiblicaNoteSectionStyle,
+    isStructuralOnlyContent,
+    splitSegmentsAtLineBreaks,
+    getStructuralApostropheSegmentIndexes,
+    stripStructuralApostropheSegments,
+} from "./biblicaImportUtils";
 
 /**
  * Create cells from Study Bible stories (source notes only; verses inform globalReferences).
@@ -66,7 +54,7 @@ function computeChapterRangeLabel(
 }
 
 async function createCellsFromStories(
-    stories: unknown[],
+    stories: IDMLStory[],
     htmlRepresentation: { stories?: { id: string }[]; originalHash?: string },
     sourceFileName: string
 ): Promise<CustomNotebookCellData[]> {
@@ -91,19 +79,7 @@ async function createCellsFromStories(
         lastChapterInRange = chapter;
     };
 
-    for (const story of stories as Array<{
-        id: string;
-        paragraphs: Array<{
-            id: string;
-            metadata?: Record<string, unknown>;
-            paragraphStyleRange: {
-                appliedParagraphStyle: string;
-                content: string;
-                dataAfter?: string;
-            };
-            characterStyleRanges?: Array<{ appliedCharacterStyle?: string; content?: string }>;
-        }>;
-    }>) {
+    for (const story of stories) {
         for (let i = 0; i < story.paragraphs.length; i++) {
             const paragraph = story.paragraphs[i];
             const paragraphStyle = paragraph.paragraphStyleRange.appliedParagraphStyle;
@@ -236,23 +212,43 @@ async function createCellsFromStories(
                 continue;
             }
 
-            // --- From here on, this is a non-verse paragraph (note / intro / meta) ---
+            // --- From here on, this is a non-verse paragraph ---
 
-            const content = paragraph.paragraphStyleRange.content;
-            const ranges = paragraph.characterStyleRanges || [];
-            let combinedContent = content;
-            if (ranges.length > 0) {
-                combinedContent = ranges.map((r) => r.content || "").join("");
+            // Only intro/* note styles become editable cells; skip meta running headers, TOC, etc.
+            if (!isBiblicaNoteSectionStyle(paragraphStyle)) {
+                continue;
             }
 
-            const contentWithoutBreaks = combinedContent
+            const { segments: contentSegments, breakBefore: contentSegmentBreakBefore } =
+                extractContentSegmentStructureFromParagraph(paragraph);
+
+            if (isStructuralOnlyContent(contentSegments)) {
+                continue;
+            }
+
+            const allSegmentStyles =
+                paragraph.contentSegmentStyles?.length === contentSegments.length
+                    ? paragraph.contentSegmentStyles
+                    : getSegmentCharacterStylesForParagraph(paragraph, contentSegments.length);
+            const structuralApostropheIndexes = getStructuralApostropheSegmentIndexes(
+                contentSegments,
+                allSegmentStyles
+            );
+            const visibleContentSegments = stripStructuralApostropheSegments(
+                contentSegments,
+                structuralApostropheIndexes
+            );
+
+            const hasText = visibleContentSegments.some((segment) => segment.trim().length > 0);
+            if (!hasText) {
+                continue;
+            }
+
+            const contentWithoutBreaks = visibleContentSegments
+                .join("")
                 .replace(/[\r\n]+/g, "")
                 .replace(/\s+/g, " ")
                 .trim();
-
-            if (!contentWithoutBreaks || contentWithoutBreaks.length === 0) {
-                continue;
-            }
 
             // Chapter label headings (head:cl) like "Psalm 2" introduce a new
             // chapter. Force a new milestone so the heading and any following
@@ -284,95 +280,66 @@ async function createCellsFromStories(
                 currentVerseArray = [];
             }
 
-            const contentWithBreaks = combinedContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-            const segments = contentWithBreaks.split("\n");
-            let rangeSegments: Array<{ ranges: typeof ranges; content: string }> = [];
+            const noteGlobalReferences: string[] = currentBook ? [currentBook] : [];
+            const lineGroups = splitSegmentsAtLineBreaks(
+                contentSegments,
+                contentSegmentBreakBefore
+            );
+            const totalLineGroups = lineGroups.length;
 
-            if (ranges.length > 0) {
-                let currentSegment: { ranges: typeof ranges; content: string } = {
-                    ranges: [],
-                    content: "",
-                };
-
-                for (const range of ranges) {
-                    const rangeContent = range.content || "";
-                    if (rangeContent.includes("\n")) {
-                        const rangeParts = rangeContent.split("\n");
-                        for (let j = 0; j < rangeParts.length; j++) {
-                            const part = rangeParts[j];
-                            if (part) {
-                                currentSegment.ranges.push({ ...range, content: part });
-                                currentSegment.content += part;
-                            }
-                            if (j < rangeParts.length - 1) {
-                                rangeSegments.push({ ...currentSegment });
-                                currentSegment = { ranges: [], content: "" };
-                            }
-                        }
-                    } else {
-                        currentSegment.ranges.push(range);
-                        currentSegment.content += rangeContent;
-                    }
-                }
-
-                if (currentSegment.content || currentSegment.ranges.length > 0) {
-                    rangeSegments.push(currentSegment);
-                }
-                if (rangeSegments.length === 0) {
-                    rangeSegments = [{ ranges, content: contentWithBreaks }];
-                }
-            } else {
-                rangeSegments = segments.map((seg: string) => ({ ranges: [], content: seg }));
-            }
-
-            const finalSegments: Array<{ ranges: typeof ranges; content: string }> =
-                rangeSegments.length > 0
-                    ? rangeSegments
-                    : segments.map((seg: string) => ({ ranges: [], content: seg }));
-
-            for (let segmentIndex = 0; segmentIndex < finalSegments.length; segmentIndex++) {
-                const segment = finalSegments[segmentIndex];
-                const cleanText = segment.content
-                    .replace(/[\r\n]+/g, " ")
-                    .replace(/\s+/g, " ")
-                    .trim();
-
-                if (!cleanText && segmentIndex > 0 && segment.ranges.length === 0) {
+            for (let segmentIndex = 0; segmentIndex < lineGroups.length; segmentIndex++) {
+                const group = lineGroups[segmentIndex];
+                const groupStyles = allSegmentStyles.slice(
+                    group.startIndex,
+                    group.startIndex + group.segments.length
+                );
+                const isLastSegment = segmentIndex === totalLineGroups - 1;
+                const visibleSegments = stripStructuralApostropheSegments(
+                    group.segments,
+                    structuralApostropheIndexes
+                        .filter(
+                            (idx) =>
+                                idx >= group.startIndex &&
+                                idx < group.startIndex + group.segments.length
+                        )
+                        .map((idx) => idx - group.startIndex)
+                );
+                if (!visibleSegments.some((segment) => segment.trim().length > 0)) {
                     continue;
                 }
-
-                let inlineHTML: string;
-                if (segment.ranges.length > 0) {
-                    inlineHTML = buildInlineHTMLFromRanges(segment.ranges);
-                } else {
-                    inlineHTML = escapeHtml(segment.content);
-                }
-
-                const isLastSegment = segmentIndex === finalSegments.length - 1;
-                const htmlContent = `<p class="biblica-paragraph" data-paragraph-style="${paragraphStyle}" data-story-id="${story.id}" data-segment-index="${segmentIndex}" data-is-last-segment="${isLastSegment}">${inlineHTML}</p>`;
-
-                let noteGlobalReferences: string[] = [];
-                if (currentBook) {
-                    noteGlobalReferences = [currentBook];
-                }
+                const cellOriginalContent = joinContentSegments(visibleSegments);
 
                 const { cellId, metadata: cellMetadata } = createNoteCellMetadata({
                     cellLabel: undefined,
                     storyId: story.id,
                     paragraphId: paragraph.id,
                     appliedParagraphStyle: paragraphStyle,
-                    originalText: cleanText || segment.content,
+                    paragraph,
                     globalReferences: noteGlobalReferences,
                     sourceFileName,
-                    originalHash: htmlRepresentation.originalHash,
-                    paragraphDataAfter: paragraph.paragraphStyleRange.dataAfter,
-                    storyOrder: stories.indexOf(story),
+                    originalHash: htmlRepresentation.originalHash ?? "",
+                    stories,
                     paragraphOrder: i,
-                    segmentIndex,
-                    totalSegments: finalSegments.length,
-                    isLastSegment,
                     chapterNumber: currentMilestoneLabel ?? undefined,
+                    segmentIndex,
+                    totalSegments: totalLineGroups,
+                    isLastSegment,
+                    cellOriginalContent,
+                    structuralApostropheSegmentIndexes: structuralApostropheIndexes,
                 });
+
+                const htmlContent = buildSegmentedParagraphHtml(
+                    group.segments,
+                    paragraphStyle,
+                    story.id ?? "",
+                    groupStyles,
+                    group.breakBefore,
+                    {
+                        segmentIndexOffset: group.startIndex,
+                        totalSegmentCount: contentSegments.length,
+                        skipSegmentIndexes: structuralApostropheIndexes,
+                    }
+                );
 
                 const cell = createProcessedCell(
                     cellId,

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { applySegmentTranslationToParagraphBlock, mergeSplitCellTranslations } from '../common/contentSegmentUtils';
+
+describe('Biblica surgical export', () => {
+    const paragraphBlock = `<ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/intro%3aipi">
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/bold%3astyle">
+        <Content>Original bold</Content>
+    </CharacterStyleRange>
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]">
+        <Content>Original plain</Content>
+    </CharacterStyleRange>
+</ParagraphStyleRange>`;
+
+    it('should replace only changed Content inner text and preserve character styles', () => {
+        const html =
+            '<p class="indesign-paragraph">' +
+            '<span class="idml-segment" data-segment-index="0">Translated bold</span>' +
+            '<span class="idml-eoc" data-eoc="1"></span>' +
+            '<span class="idml-segment" data-segment-index="1">Original plain</span>' +
+            '</p>';
+
+        const result = applySegmentTranslationToParagraphBlock(
+            paragraphBlock,
+            html,
+            ['Original bold', 'Original plain']
+        );
+
+        expect(result).toContain('<Content>Translated bold</Content>');
+        expect(result).toContain('<Content>Original plain</Content>');
+        expect(result).toContain('bold%3astyle');
+        expect(result).not.toContain('Original bold');
+    });
+
+    it('should leave paragraph XML unchanged when translation matches originals', () => {
+        const html =
+            '<p class="indesign-paragraph">' +
+            '<span class="idml-segment" data-segment-index="0">Original bold</span>' +
+            '<span class="idml-eoc" data-eoc="1"></span>' +
+            '<span class="idml-segment" data-segment-index="1">Original plain</span>' +
+            '</p>';
+
+        const result = applySegmentTranslationToParagraphBlock(
+            paragraphBlock,
+            html,
+            ['Original bold', 'Original plain']
+        );
+
+        expect(result).toBe(paragraphBlock);
+    });
+
+    it('merges split cell translations back onto one paragraph', () => {
+        const originalSegments = ['First line', 'Second line'];
+        const cellOne =
+            '<p><span class="idml-segment" data-segment-index="0">Edited first</span></p>';
+        const cellTwo =
+            '<p><span class="idml-segment" data-segment-index="1">Edited second</span></p>';
+
+        const mergedHtml = mergeSplitCellTranslations(
+            [cellOne, cellTwo],
+            originalSegments,
+            [false, true]
+        );
+
+        const paragraphBlock = `<ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/intro%3aipi">
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]">
+        <Content>First line</Content>
+        <Br />
+        <Content>Second line</Content>
+    </CharacterStyleRange>
+</ParagraphStyleRange>`;
+
+        const result = applySegmentTranslationToParagraphBlock(
+            paragraphBlock,
+            mergedHtml,
+            originalSegments
+        );
+
+        expect(result).toContain('<Content>Edited first</Content>');
+        expect(result).toContain('<Content>Edited second</Content>');
+        expect(result).toContain('<Br');
+    });
+
+    it('clears structural apostrophe Content slots on export', () => {
+        const apostropheParagraph = `<ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/intro%3aipi">
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/bold%3astyle">
+        <Content>Israel</Content>
+    </CharacterStyleRange>
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/source%20serif">
+        <Content>ʼ</Content>
+    </CharacterStyleRange>
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/bold%3astyle">
+        <Content>s covenant history</Content>
+    </CharacterStyleRange>
+</ParagraphStyleRange>`;
+
+        const originalSegments = ['Israel', 'ʼ', 's covenant history'];
+        const html =
+            '<p class="indesign-paragraph">' +
+            '<span class="idml-segment" data-segment-index="0">Zmluvné</span>' +
+            '<span class="idml-eoc" data-eoc="1"></span>' +
+            '<span class="idml-segment" data-segment-index="2">dejiny Izraela</span>' +
+            '</p>';
+
+        const result = applySegmentTranslationToParagraphBlock(
+            apostropheParagraph,
+            html,
+            originalSegments,
+            undefined,
+            [1]
+        );
+
+        expect(result).toContain('<Content>Zmluvné</Content>');
+        expect(result).toContain('<Content>dejiny Izraela</Content>');
+        expect(result).toContain('<Content></Content>');
+        expect(result).not.toContain('<Content>ʼ</Content>');
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.ts
@@ -20,6 +20,11 @@ import {
     IDMLExportError,
     IDMLExportConfig
 } from './types';
+import {
+    applySegmentTranslationToParagraphBlock,
+    findParagraphBlockInStoryXml,
+    mergeSplitCellTranslations,
+} from '../common/contentSegmentUtils';
 
 // Import JSZip for Node.js environment
 import JSZip from 'jszip';
@@ -527,9 +532,17 @@ export interface ParagraphUpdate {
     paragraphOrder?: number;
     appliedParagraphStyle?: string;
     translated: string;
+    translatedHtml?: string;
+    contentSegments?: string[];
+    contentSegmentCount?: number;
+    contentSegmentBreakBefore?: boolean[];
     dataAfter?: string[];
-    segmentIndex?: number; // Index of this segment within the paragraph (0-based)
-    totalSegments?: number; // Total number of segments for this paragraph
+    /** Legacy multi-cell imports: index of segment within paragraph */
+    segmentIndex?: number;
+    /** Legacy multi-cell imports: total segments for paragraph */
+    totalSegments?: number;
+    /** Indexes of structural apostrophe slots to clear on export */
+    structuralApostropheSegmentIndexes?: number[];
 }
 
 /**
@@ -617,13 +630,100 @@ export async function exportIdmlRoundtrip(
         return "";
     };
 
-    // Helper to remove HTML tags while preserving line breaks
+    // Helper to remove HTML tags while preserving line breaks (legacy fallback)
     const removeHtmlTags = (html: string): string => {
-        // First convert <br>, <br/>, <br /> tags to newlines
         let text = html.replace(/<br\s*\/?>/gi, '\n');
-        // Then remove all other HTML tags
         text = text.replace(/<[^>]*>/g, '');
         return text.trim();
+    };
+
+    const applySegmentParagraphUpdate = (storyXml: string, update: ParagraphUpdate): string => {
+        const located = findParagraphBlockInStoryXml(storyXml, {
+            paragraphId: update.paragraphId,
+            paragraphOrder: update.paragraphOrder,
+        });
+
+        if (!located) {
+            return storyXml;
+        }
+
+        const translatedHtml = update.translatedHtml || update.translated;
+        if (!translatedHtml?.trim()) {
+            return storyXml;
+        }
+
+        const updatedBlock = applySegmentTranslationToParagraphBlock(
+            located.block,
+            translatedHtml,
+            update.contentSegments,
+            xmlEscape,
+            update.structuralApostropheSegmentIndexes
+        );
+
+        if (updatedBlock === located.block) {
+            return storyXml;
+        }
+
+        return (
+            storyXml.slice(0, located.start) +
+            updatedBlock +
+            storyXml.slice(located.end)
+        );
+    };
+
+    const coalesceSplitSurgicalUpdates = (updates: ParagraphUpdate[]): ParagraphUpdate[] => {
+        const byParagraph = new Map<string, ParagraphUpdate[]>();
+        const standalone: ParagraphUpdate[] = [];
+
+        for (const update of updates) {
+            if (!Array.isArray(update.contentSegments) || update.contentSegments.length === 0) {
+                standalone.push(update);
+                continue;
+            }
+
+            const key =
+                update.paragraphId ??
+                (typeof update.paragraphOrder === "number"
+                    ? `order:${update.paragraphOrder}`
+                    : `unknown:${byParagraph.size}`);
+
+            const group = byParagraph.get(key) ?? [];
+            group.push(update);
+            byParagraph.set(key, group);
+        }
+
+        const coalesced: ParagraphUpdate[] = [...standalone];
+
+        for (const group of byParagraph.values()) {
+            if (group.length === 1) {
+                coalesced.push(group[0]);
+                continue;
+            }
+
+            const hasSplitCells = group.some((item) => typeof item.segmentIndex === "number");
+            if (!hasSplitCells) {
+                coalesced.push(...group);
+                continue;
+            }
+
+            const sorted = [...group].sort(
+                (a, b) => (a.segmentIndex ?? 0) - (b.segmentIndex ?? 0)
+            );
+            const base = sorted[0];
+            const mergedHtml = mergeSplitCellTranslations(
+                sorted.map((item) => item.translatedHtml ?? item.translated),
+                base.contentSegments ?? [],
+                base.contentSegmentBreakBefore
+            );
+
+            coalesced.push({
+                ...base,
+                translatedHtml: mergedHtml,
+                translated: removeHtmlTags(mergedHtml),
+            });
+        }
+
+        return coalesced;
     };
 
     // Track story order counters for fallback
@@ -635,7 +735,8 @@ export async function exportIdmlRoundtrip(
         const isText = cell.kind === 2 && meta?.type === "text";
         if (!isText) continue;
 
-        const translated = removeHtmlTags(getTranslatedHtml(cell)).trim();
+        const translatedHtml = getTranslatedHtml(cell);
+        const translated = removeHtmlTags(translatedHtml).trim();
         if (!translated) continue;
 
         // Check if this is a Biblica verse-based cell
@@ -709,6 +810,15 @@ export async function exportIdmlRoundtrip(
 
         const paragraphId: string | undefined = structure?.paragraphId || meta?.paragraphId;
         const dataAfterRuns: string[] | undefined = structure?.paragraphStyleRange?.dataAfter;
+        const contentSegments: string[] | undefined = structure?.contentSegments;
+        const contentSegmentCount: number | undefined =
+            typeof structure?.contentSegmentCount === "number"
+                ? structure.contentSegmentCount
+                : contentSegments?.length;
+        const contentSegmentBreakBefore: boolean[] | undefined =
+            structure?.contentSegmentBreakBefore;
+        const structuralApostropheSegmentIndexes: number[] | undefined =
+            structure?.structuralApostropheSegmentIndexes;
         const appliedParagraphStyle: string | undefined =
             structure?.paragraphStyleRange?.appliedParagraphStyle ||
             meta?.appliedParagraphStyle;
@@ -740,9 +850,14 @@ export async function exportIdmlRoundtrip(
                 paragraphOrder,
                 appliedParagraphStyle,
                 translated,
+                translatedHtml,
+                contentSegments,
+                contentSegmentCount,
+                contentSegmentBreakBefore,
                 dataAfter: dataAfterRuns,
                 segmentIndex,
-                totalSegments
+                totalSegments,
+                structuralApostropheSegmentIndexes,
             });
             storyIdToUpdates.set(storyId, updates);
         } else if (storyOrder !== undefined) {
@@ -751,9 +866,14 @@ export async function exportIdmlRoundtrip(
                 paragraphOrder,
                 appliedParagraphStyle,
                 translated,
+                translatedHtml,
+                contentSegments,
+                contentSegmentCount,
+                contentSegmentBreakBefore,
                 dataAfter: dataAfterRuns,
                 segmentIndex,
-                totalSegments
+                totalSegments,
+                structuralApostropheSegmentIndexes,
             });
             storyIndexToUpdates.set(storyOrder, updates);
         }
@@ -1189,78 +1309,67 @@ ${footnoteString.split('\n').map(line => `                    ${line}`).join('\n
         const xmlText = await zip.file(storyKey)!.async("string");
         let updated = xmlText;
 
-        // Group updates by paragraphOrder to merge segmented paragraphs
-        const updatesByParagraph = new Map<number, ParagraphUpdate[]>();
-        const standaloneUpdates: ParagraphUpdate[] = [];
+        const surgicalUpdates: ParagraphUpdate[] = [];
+        const legacyUpdates: ParagraphUpdate[] = [];
 
         for (const u of updates) {
+            if (Array.isArray(u.contentSegments) && u.contentSegments.length > 0) {
+                surgicalUpdates.push(u);
+            } else {
+                legacyUpdates.push(u);
+            }
+        }
+
+        for (const u of coalesceSplitSurgicalUpdates(surgicalUpdates)) {
+            updated = applySegmentParagraphUpdate(updated, u);
+        }
+
+        // Legacy fallback for pre-migration multi-cell imports (no contentSegments metadata)
+        const updatesByParagraph = new Map<number, ParagraphUpdate[]>();
+        const standaloneLegacyUpdates: ParagraphUpdate[] = [];
+
+        for (const u of legacyUpdates) {
             if (typeof u.paragraphOrder === 'number' && typeof u.segmentIndex === 'number') {
-                // This is a segmented paragraph - group by paragraphOrder
                 const group = updatesByParagraph.get(u.paragraphOrder) || [];
                 group.push(u);
                 updatesByParagraph.set(u.paragraphOrder, group);
             } else {
-                // Standalone update (not segmented)
-                standaloneUpdates.push(u);
+                standaloneLegacyUpdates.push(u);
             }
         }
 
-        // Merge segmented paragraphs: combine segments with \n between them
-        const mergedUpdates: ParagraphUpdate[] = [];
-        for (const [paragraphOrder, segments] of updatesByParagraph.entries()) {
-            // Sort segments by segmentIndex
-            segments.sort((a, b) => {
-                const aIdx = a.segmentIndex ?? 0;
-                const bIdx = b.segmentIndex ?? 0;
-                return aIdx - bIdx;
-            });
-
-            // Merge segments with \n between them
-            const mergedText = segments.map(s => s.translated).join('\n');
-
-            // Use dataAfter from the last segment only
+        const mergedLegacyUpdates: ParagraphUpdate[] = [];
+        for (const [, segments] of updatesByParagraph.entries()) {
+            segments.sort((a, b) => (a.segmentIndex ?? 0) - (b.segmentIndex ?? 0));
+            const mergedText = segments.map((s) => s.translated).join('\n');
             const lastSegment = segments[segments.length - 1];
-            const dataAfter = lastSegment?.dataAfter;
-
-            // Use other properties from first segment
             const firstSegment = segments[0];
-            mergedUpdates.push({
+            mergedLegacyUpdates.push({
                 paragraphId: firstSegment.paragraphId,
                 paragraphOrder: firstSegment.paragraphOrder,
                 appliedParagraphStyle: firstSegment.appliedParagraphStyle,
                 translated: mergedText,
-                dataAfter
+                dataAfter: lastSegment?.dataAfter,
             });
         }
 
-        // Combine merged updates with standalone updates
-        const allUpdates = [...mergedUpdates, ...standaloneUpdates];
-
-        // Sort updates by paragraphOrder (descending) to process from end to start
-        // This avoids index shifting issues when replacing paragraphs
-        const sortedUpdates = allUpdates.sort((a, b) => {
-            // If both have paragraphOrder, sort by that (descending)
+        const allLegacyUpdates = [...mergedLegacyUpdates, ...standaloneLegacyUpdates];
+        const sortedLegacyUpdates = allLegacyUpdates.sort((a, b) => {
             if (typeof a.paragraphOrder === 'number' && typeof b.paragraphOrder === 'number') {
                 return b.paragraphOrder - a.paragraphOrder;
             }
-            // If only one has paragraphOrder, prioritize it
             if (typeof a.paragraphOrder === 'number') return -1;
             if (typeof b.paragraphOrder === 'number') return 1;
-            // If both have paragraphId, keep original order
             if (a.paragraphId && b.paragraphId) return 0;
-            // ParagraphId-based updates come first (processed after order-based)
             if (a.paragraphId) return 1;
             if (b.paragraphId) return -1;
             return 0;
         });
 
-        // Process updates from end to start (highest paragraphOrder first)
-        // Prefer id-based replacement, but fallback to order if ID doesn't exist in XML
-        for (const u of sortedUpdates) {
+        for (const u of sortedLegacyUpdates) {
             if (u.paragraphId) {
                 const beforeIdReplace = updated;
                 updated = replaceParagraphById(updated, u.paragraphId, u.translated, u.dataAfter);
-                // If ID-based replacement didn't change anything, fallback to order-based
                 if (updated === beforeIdReplace && typeof u.paragraphOrder === 'number') {
                     console.log(`[Export] Paragraph ID ${u.paragraphId} not found, falling back to order-based replacement at index ${u.paragraphOrder}${u.appliedParagraphStyle ? ` (style: ${u.appliedParagraphStyle})` : ''}`);
                     updated = replaceNthParagraph(updated, u.paragraphOrder, u.translated, u.dataAfter, u.appliedParagraphStyle);
@@ -1309,17 +1418,25 @@ ${footnoteString.split('\n').map(line => `                    ${line}`).join('\n
                     const xmlText = await storyFile.async("string");
                     let updated = xmlText;
 
-                    // Sort updates by paragraphOrder (descending) to process from end to start
-                    // This avoids index shifting issues when replacing paragraphs
-                    const sortedUpdates = [...updates].sort((a, b) => {
+                    const surgicalUpdates = updates.filter(
+                        (u) => Array.isArray(u.contentSegments) && u.contentSegments.length > 0
+                    );
+                    const legacyUpdates = updates.filter(
+                        (u) => !Array.isArray(u.contentSegments) || u.contentSegments.length === 0
+                    );
+
+                    for (const u of coalesceSplitSurgicalUpdates(surgicalUpdates)) {
+                        updated = applySegmentParagraphUpdate(updated, u);
+                    }
+
+                    const sortedLegacyUpdates = [...legacyUpdates].sort((a, b) => {
                         if (typeof a.paragraphOrder === 'number' && typeof b.paragraphOrder === 'number') {
                             return b.paragraphOrder - a.paragraphOrder;
                         }
                         return 0;
                     });
 
-                    // Process updates from end to start (highest paragraphOrder first)
-                    for (const u of sortedUpdates) {
+                    for (const u of sortedLegacyUpdates) {
                         if (typeof u.paragraphOrder === 'number') {
                             console.log(`[Export] Replacing paragraph at index ${u.paragraphOrder}${u.appliedParagraphStyle ? ` (style: ${u.appliedParagraphStyle})` : ''}`);
                             updated = replaceNthParagraph(updated, u.paragraphOrder, u.translated, u.dataAfter, u.appliedParagraphStyle);

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaImportUtils.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaImportUtils.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isBiblicaNoteSectionStyle,
+    isStructuralOnlyContent,
+    splitSegmentsAtLineBreaks,
+    getStructuralApostropheSegmentIndexes,
+    isStructuralApostropheSegment,
+    stripStructuralApostropheSegments,
+} from './biblicaImportUtils';
+import { buildSegmentedParagraphHtml } from '../common/contentSegmentUtils';
+
+describe('biblicaImportUtils', () => {
+    it('detects intro note styles', () => {
+        expect(isBiblicaNoteSectionStyle('ParagraphStyle/intro%3aipi')).toBe(true);
+        expect(isBiblicaNoteSectionStyle('ParagraphStyle/meta%3arh')).toBe(false);
+    });
+
+    it('treats ACE-only content as structural', () => {
+        expect(isStructuralOnlyContent(['\t<?ACE 18?><?ACE 8?>'])).toBe(true);
+        expect(isStructuralOnlyContent(['Genesis'])).toBe(false);
+    });
+
+    it('splits segments at line breaks and preserves start indices', () => {
+        const groups = splitSegmentsAtLineBreaks(
+            ['Line one', 'Line two', 'Line three'],
+            [false, true, true]
+        );
+
+        expect(groups).toHaveLength(3);
+        expect(groups[0].startIndex).toBe(0);
+        expect(groups[0].segments).toEqual(['Line one']);
+        expect(groups[1].startIndex).toBe(1);
+        expect(groups[1].segments).toEqual(['Line two']);
+        expect(groups[2].startIndex).toBe(2);
+        expect(groups[2].segments).toEqual(['Line three']);
+    });
+
+    it('detects structural apostrophe segments by style or content', () => {
+        expect(
+            isStructuralApostropheSegment('ʼ', 'CharacterStyle/source%20serif')
+        ).toBe(true);
+        expect(isStructuralApostropheSegment("'", 'CharacterStyle/$ID/[No character style]')).toBe(
+            true
+        );
+        expect(isStructuralApostropheSegment('covenant', 'CharacterStyle/bold')).toBe(false);
+    });
+
+    it('collects apostrophe slot indexes and strips them from visible text', () => {
+        const segments = ["Israel", "ʼ", "s covenant history"];
+        const styles = [
+            'CharacterStyle/$ID/[No character style]',
+            'CharacterStyle/source%20serif',
+            'CharacterStyle/$ID/[No character style]',
+        ];
+        const indexes = getStructuralApostropheSegmentIndexes(segments, styles);
+        expect(indexes).toEqual([1]);
+        expect(stripStructuralApostropheSegments(segments, indexes)).toEqual([
+            'Israel',
+            's covenant history',
+        ]);
+    });
+
+    it('omits apostrophe segments from editor HTML while preserving indices', () => {
+        const segments = ['Zmluvné', 'ʼ', 'dejiny'];
+        const styles = [
+            'CharacterStyle/bold',
+            'CharacterStyle/source%20serif',
+            'CharacterStyle/bold',
+        ];
+        const skipIndexes = getStructuralApostropheSegmentIndexes(segments, styles);
+        const html = buildSegmentedParagraphHtml(segments, 'ParagraphStyle/intro%3aipi', 'u123', styles, [false, false, false], {
+            skipSegmentIndexes: skipIndexes,
+        });
+
+        expect(html).toContain('data-segment-index="0"');
+        expect(html).toContain('data-segment-index="2"');
+        expect(html).not.toContain('data-segment-index="1"');
+        expect(html).not.toContain('ʼ');
+        expect(html).toContain('data-segment-count="3"');
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaImportUtils.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaImportUtils.ts
@@ -1,0 +1,121 @@
+/**
+ * Biblica-specific import helpers for note paragraph filtering and line-break splitting.
+ */
+
+/** InDesign ACE placeholder markers in running headers / structural paragraphs. */
+const ACE_MARKER_PATTERN = /<\?ACE\s+\d+\?>/gi;
+
+/** Apostrophe characters used as structural glue in English Biblica IDML (source serif). */
+const STRUCTURAL_APOSTROPHE_PATTERN = /^['\u02BC\u2019\u2032\u00B4]+$/;
+
+/**
+ * Note styles use the intro prefix (e.g. intro%3aipi, intro%3aili1).
+ */
+export function isBiblicaNoteSectionStyle(paragraphStyle: string): boolean {
+    return paragraphStyle.includes("intro%3a") || paragraphStyle.includes("intro:");
+}
+
+/**
+ * True when visible text is empty after stripping ACE markers and whitespace.
+ */
+export function isStructuralOnlyContent(segments: string[]): boolean {
+    const visible = segments
+        .join("")
+        .replace(ACE_MARKER_PATTERN, "")
+        .replace(/\s+/g, "")
+        .trim();
+    return visible.length === 0;
+}
+
+/**
+ * True for InDesign "source serif" apostrophe glue or apostrophe-only segment text.
+ */
+export function isSourceSerifCharacterStyle(characterStyle: string): boolean {
+    return characterStyle.toLowerCase().includes("source serif");
+}
+
+export function isStructuralApostropheContent(text: string): boolean {
+    const trimmed = text.trim();
+    return trimmed.length > 0 && STRUCTURAL_APOSTROPHE_PATTERN.test(trimmed);
+}
+
+export function isStructuralApostropheSegment(text: string, characterStyle?: string): boolean {
+    if (characterStyle && isSourceSerifCharacterStyle(characterStyle)) {
+        return true;
+    }
+    return isStructuralApostropheContent(text);
+}
+
+/**
+ * Indexes of <Content> slots that carry structural apostrophes only (not translated).
+ */
+export function getStructuralApostropheSegmentIndexes(
+    segments: string[],
+    segmentStyles?: string[]
+): number[] {
+    const indexes: number[] = [];
+    for (let i = 0; i < segments.length; i++) {
+        if (isStructuralApostropheSegment(segments[i] ?? "", segmentStyles?.[i])) {
+            indexes.push(i);
+        }
+    }
+    return indexes;
+}
+
+export function stripStructuralApostropheSegments(
+    segments: string[],
+    structuralIndexes: number[]
+): string[] {
+    const skip = new Set(structuralIndexes);
+    return segments.filter((_, index) => !skip.has(index));
+}
+
+export interface LineBreakSegmentGroup {
+    /** Index of the first segment in the parent paragraph. */
+    startIndex: number;
+    segments: string[];
+    /** breakBefore flags relative to this group (index 0 is always false). */
+    breakBefore: boolean[];
+}
+
+/**
+ * Split content segments at IDML line breaks (breakBefore[i] === true).
+ * Each group becomes one editor cell, preserving original segment indices for export.
+ */
+export function splitSegmentsAtLineBreaks(
+    segments: string[],
+    breakBefore: boolean[]
+): LineBreakSegmentGroup[] {
+    if (segments.length === 0) {
+        return [];
+    }
+
+    const groups: LineBreakSegmentGroup[] = [];
+    let currentStart = 0;
+    let currentSegments: string[] = [segments[0] ?? ""];
+    let currentBreakBefore: boolean[] = [false];
+
+    for (let i = 1; i < segments.length; i++) {
+        if (breakBefore[i]) {
+            groups.push({
+                startIndex: currentStart,
+                segments: currentSegments,
+                breakBefore: currentBreakBefore,
+            });
+            currentStart = i;
+            currentSegments = [segments[i] ?? ""];
+            currentBreakBefore = [false];
+        } else {
+            currentSegments.push(segments[i] ?? "");
+            currentBreakBefore.push(false);
+        }
+    }
+
+    groups.push({
+        startIndex: currentStart,
+        segments: currentSegments,
+        breakBefore: currentBreakBefore,
+    });
+
+    return groups.filter((group) => !isStructuralOnlyContent(group.segments));
+}

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaParser.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaParser.test.ts
@@ -466,3 +466,51 @@ describe('BiblicaParser – chapter-range milestone metadata', () => {
         }
     });
 });
+
+describe('BiblicaParser – content segments', () => {
+    let parser: IDMLParser;
+
+    beforeEach(() => {
+        parser = new IDMLParser({
+            preserveAllFormatting: true,
+            preserveObjectIds: true,
+            validateRoundTrip: false,
+            strictMode: false,
+        });
+    });
+
+    it('should extract contentSegments from note paragraphs matching Content nodes', async () => {
+        const xml = wrapInStory(`
+<ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/intro%3aipi">
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/bold%3astyle">
+        <Content>First</Content>
+    </CharacterStyleRange>
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]">
+        <Content>Second</Content>
+    </CharacterStyleRange>
+</ParagraphStyleRange>`);
+
+        const doc = await parser.parseIDML(xml);
+        const para = doc.stories[0].paragraphs[0];
+
+        expect(para.contentSegments).toEqual(['First', 'Second']);
+        expect(para.contentSegmentBreakBefore).toEqual([false, false]);
+    });
+
+    it('should track breakBefore when Br separates Content nodes', async () => {
+        const xml = wrapInStory(`
+<ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/intro%3aipi">
+    <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]">
+        <Content>Line one</Content>
+        <Br />
+        <Content>Line two</Content>
+    </CharacterStyleRange>
+</ParagraphStyleRange>`);
+
+        const doc = await parser.parseIDML(xml);
+        const para = doc.stories[0].paragraphs[0];
+
+        expect(para.contentSegments).toEqual(['Line one', 'Line two']);
+        expect(para.contentSegmentBreakBefore).toEqual([false, true]);
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaParser.ts
@@ -19,6 +19,7 @@ import {
     IDMLParseError,
     IDMLImportConfig
 } from './types';
+import { extractContentSegmentStructureFromParagraphXml, findParagraphBlockInStoryXml, extractSegmentStylesFromParagraphXml } from '../common/contentSegmentUtils';
 
 // Local hashing helpers to avoid test-only imports
 function toArrayBufferForHash(input: string | ArrayBuffer): ArrayBuffer {
@@ -218,6 +219,9 @@ export class IDMLParser {
             const idMatch = fullMatch.match(/id="([^"]*)"/);
             const originalId = idMatch ? idMatch[1] : undefined;
 
+            const segmentStructure = extractContentSegmentStructureFromParagraphXml(paragraphContent);
+            const contentSegmentStyles = extractSegmentStylesFromParagraphXml(paragraphContent);
+
             const paragraph: IDMLParagraph = {
                 id: originalId, // Only         use ID if it existed in original
                 paragraphStyleRange: {
@@ -227,6 +231,9 @@ export class IDMLParser {
                     content: this.extractTextContentFromString(paragraphContent)
                 },
                 characterStyleRanges: this.extractCharacterRangesFromParagraph(paragraphContent),
+                contentSegments: segmentStructure.segments,
+                contentSegmentBreakBefore: segmentStructure.breakBefore,
+                contentSegmentStyles,
                 metadata: {}
             };
 
@@ -774,6 +781,48 @@ export class IDMLParser {
     }
 
     /**
+     * Extract content segments from paragraph XML (prefer raw story slice for accuracy).
+     */
+    private extractContentSegmentsForParagraph(
+        paragraphElement: Element,
+        storyXml: string,
+        paragraphIndex: number
+    ): { segments: string[]; breakBefore: boolean[] } {
+        if (storyXml && paragraphIndex >= 0) {
+            const located = findParagraphBlockInStoryXml(storyXml, { paragraphOrder: paragraphIndex });
+            if (located) {
+                return extractContentSegmentStructureFromParagraphXml(located.block);
+            }
+        }
+        return extractContentSegmentStructureFromParagraphXml(paragraphElement.outerHTML);
+    }
+
+    /**
+     * Attach content segment fields to a paragraph result.
+     */
+    private withContentSegments(
+        paragraph: IDMLParagraph,
+        paragraphElement: Element,
+        storyXml: string,
+        paragraphIndex: number
+    ): IDMLParagraph {
+        const located =
+            storyXml && paragraphIndex >= 0
+                ? findParagraphBlockInStoryXml(storyXml, { paragraphOrder: paragraphIndex })
+                : null;
+        const paragraphXml = located?.block ?? paragraphElement.outerHTML;
+        const segmentStructure = extractContentSegmentStructureFromParagraphXml(paragraphXml);
+        const contentSegmentStyles = extractSegmentStylesFromParagraphXml(paragraphXml);
+
+        return {
+            ...paragraph,
+            contentSegments: segmentStructure.segments,
+            contentSegmentBreakBefore: segmentStructure.breakBefore,
+            contentSegmentStyles,
+        };
+    }
+
+    /**
      * Extract individual paragraph
      */
     private async extractParagraph(paragraphElement: Element, currentBook: string = '', currentChapter: string = '1', storyXml: string = '', paragraphIndex: number = -1): Promise<IDMLParagraph> {
@@ -809,12 +858,17 @@ export class IDMLParser {
                 this.debugLog(`Found book abbreviation: ${bookAbbrev}`);
                 const metadata = this.extractElementMetadata(paragraphElement) || {};
                 (metadata as any).bookAbbreviation = bookAbbrev;
-                return {
-                    id: paragraphId,
-                    paragraphStyleRange,
-                    characterStyleRanges,
-                    metadata
-                };
+                return this.withContentSegments(
+                    {
+                        id: paragraphId,
+                        paragraphStyleRange,
+                        characterStyleRanges,
+                        metadata,
+                    },
+                    paragraphElement,
+                    storyXml,
+                    paragraphIndex
+                );
             }
         }
 
@@ -1320,21 +1374,31 @@ export class IDMLParser {
                 (metadata as any).lastChapterNumber = lastChapterSeen;
             }
 
-            return {
-                id: paragraphId,
-                paragraphStyleRange,
-                characterStyleRanges,
-                metadata
-            };
+            return this.withContentSegments(
+                {
+                    id: paragraphId,
+                    paragraphStyleRange,
+                    characterStyleRanges,
+                    metadata,
+                },
+                paragraphElement,
+                storyXml,
+                paragraphIndex
+            );
         } catch (err) {
             // Fallback to default behavior
             this.debugLog(`Verse segment parsing failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
-            return {
-                id: paragraphId,
-                paragraphStyleRange,
-                characterStyleRanges,
-                metadata: this.extractElementMetadata(paragraphElement)
-            };
+            return this.withContentSegments(
+                {
+                    id: paragraphId,
+                    paragraphStyleRange,
+                    characterStyleRanges,
+                    metadata: this.extractElementMetadata(paragraphElement),
+                },
+                paragraphElement,
+                storyXml,
+                paragraphIndex
+            );
         }
     }
 

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/cellMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/cellMetadata.ts
@@ -1,15 +1,20 @@
 /**
  * Cell Metadata Builder for Biblica Importer
- * 
+ *
  * This file centralizes all cell metadata structure creation for Biblica imports.
  * Makes it easy to find and modify metadata fields in one place.
- * 
+ *
  * Note: Verse cells are not created - verses are detected and tracked for globalReferences
  * assignment to notes, but only note cells are actually created.
  */
 
 import { CodexCellTypes } from 'types/enums';
 import { v4 as uuidv4 } from 'uuid';
+import { IDMLParagraph, IDMLStory } from './types';
+import {
+    extractContentSegmentStructureFromParagraph,
+    joinContentSegments,
+} from '../common/contentSegmentUtils';
 
 /**
  * Parameters for creating note/paragraph cell metadata
@@ -19,17 +24,21 @@ export interface NoteCellMetadataParams {
     storyId?: string;
     paragraphId?: string;
     appliedParagraphStyle: string;
-    originalText: string;
+    paragraph: IDMLParagraph;
     globalReferences: string[];
     sourceFileName: string;
     originalHash: string;
-    paragraphDataAfter?: string[];
-    storyOrder: number;
+    stories: IDMLStory[];
     paragraphOrder: number;
-    segmentIndex: number;
-    totalSegments: number;
-    isLastSegment: boolean;
-    chapterNumber?: string; // Chapter number for milestone detection
+    chapterNumber?: string;
+    /** When a paragraph is split at line breaks, which slice this cell represents. */
+    segmentIndex?: number;
+    totalSegments?: number;
+    isLastSegment?: boolean;
+    /** Plain text for this cell slice (joined segment group). */
+    cellOriginalContent?: string;
+    /** Indexes of structural apostrophe <Content> slots (omitted from editor HTML). */
+    structuralApostropheSegmentIndexes?: number[];
 }
 
 /**
@@ -37,8 +46,13 @@ export interface NoteCellMetadataParams {
  * Generates a UUID for the cell ID
  */
 export function createNoteCellMetadata(params: NoteCellMetadataParams): { metadata: any; cellId: string; } {
-    // Generate UUID for cell ID
     const cellId = uuidv4();
+    const contentSegments = extractContentSegmentStructureFromParagraph(params.paragraph).segments;
+    const { breakBefore: contentSegmentBreakBefore } =
+        extractContentSegmentStructureFromParagraph(params.paragraph);
+    const storyId = params.storyId ?? "";
+    const cellOriginalContent =
+        params.cellOriginalContent ?? joinContentSegments(contentSegments);
 
     return {
         cellId,
@@ -46,33 +60,48 @@ export function createNoteCellMetadata(params: NoteCellMetadataParams): { metada
             id: cellId,
             type: CodexCellTypes.TEXT,
             edits: [],
-            cellLabel: params.cellLabel, // Use sequential number as label
+            cellLabel: params.cellLabel,
             storyId: params.storyId,
             paragraphId: params.paragraphId,
             appliedParagraphStyle: params.appliedParagraphStyle,
-            chapterNumber: params.chapterNumber, // Chapter number for milestone detection
+            chapterNumber: params.chapterNumber,
             data: {
-                originalText: params.originalText,
+                originalContent: cellOriginalContent,
+                originalText: cellOriginalContent,
                 globalReferences: params.globalReferences,
-                // Minimal structure needed for export
                 idmlStructure: {
                     storyId: params.storyId,
                     paragraphId: params.paragraphId,
+                    contentSegments,
+                    contentSegmentCount: contentSegments.length,
+                    contentSegmentBreakBefore,
+                    ...(params.structuralApostropheSegmentIndexes?.length
+                        ? {
+                              structuralApostropheSegmentIndexes:
+                                  params.structuralApostropheSegmentIndexes,
+                          }
+                        : {}),
                     paragraphStyleRange: {
                         appliedParagraphStyle: params.appliedParagraphStyle,
-                        // Only keep dataAfter if present and this is the last segment
-                        dataAfter: (params.isLastSegment ? params.paragraphDataAfter : undefined)
-                    }
+                        ...((params.isLastSegment !== false &&
+                            (params.paragraph.paragraphStyleRange as { dataAfter?: string[] }).dataAfter)
+                            ? { dataAfter: (params.paragraph.paragraphStyleRange as { dataAfter?: string[] }).dataAfter }
+                            : {}),
+                    },
+                    characterStyleRanges: params.paragraph.characterStyleRanges,
                 },
-                // Minimal relationships needed for export
                 relationships: {
                     parentStory: params.storyId,
-                    storyOrder: params.storyOrder,
+                    storyOrder: params.stories.findIndex((s) => s.id === storyId),
                     paragraphOrder: params.paragraphOrder,
-                    segmentIndex: params.segmentIndex, // Track which segment this is within the paragraph
-                    totalSegments: params.totalSegments, // Track total segments for this paragraph
+                    ...(typeof params.segmentIndex === "number"
+                        ? { segmentIndex: params.segmentIndex }
+                        : {}),
+                    ...(typeof params.totalSegments === "number"
+                        ? { totalSegments: params.totalSegments }
+                        : {}),
                 },
-            }
-        }
+            },
+        },
     };
 }

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/types.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/types.ts
@@ -27,6 +27,12 @@ export interface IDMLParagraph {
     id?: string;
     paragraphStyleRange: IDMLParagraphStyleRange;
     characterStyleRanges: IDMLCharacterStyleRange[];
+    /** One entry per <Content> node in document order (round-trip text slots). */
+    contentSegments?: string[];
+    /** When true, segment i starts after an IDML line break (<Br />). */
+    contentSegmentBreakBefore?: boolean[];
+    /** One character style per <Content> node (document order). */
+    contentSegmentStyles?: string[];
     metadata?: Record<string, any>;
 }
 

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/common/contentSegmentUtils.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/common/contentSegmentUtils.ts
@@ -7,7 +7,7 @@
  * without rebuilding CharacterStyleRange XML.
  */
 
-import type { IDMLCharacterStyleRange, IDMLParagraph } from "./types";
+import type { IDMLParagraph } from "../indesign/types";
 
 /** Plain-text/metadata delimiter (stored in metadata only, not in editor HTML). */
 export const END_OF_CONTENT = "\u001E";
@@ -107,6 +107,26 @@ export function extractContentSegmentsFromParagraph(paragraph: IDMLParagraph): s
 }
 
 /**
+ * Extract one character style per <Content> node from paragraph XML (document order).
+ */
+export function extractSegmentStylesFromParagraphXml(paragraphBlock: string): string[] {
+    const styles: string[] = [];
+    const csrRegex =
+        /<CharacterStyleRange\b[^>]*AppliedCharacterStyle="([^"]*)"[^>]*>([\s\S]*?)<\/CharacterStyleRange>/gi;
+    let csrMatch: RegExpExecArray | null;
+    while ((csrMatch = csrRegex.exec(paragraphBlock)) !== null) {
+        const style = csrMatch[1] ?? "";
+        const inner = csrMatch[2] ?? "";
+        const contentRegex = /<Content>([\s\S]*?)<\/Content>/gi;
+        let contentMatch: RegExpExecArray | null;
+        while ((contentMatch = contentRegex.exec(inner)) !== null) {
+            styles.push(style);
+        }
+    }
+    return styles;
+}
+
+/**
  * Replace only inner text of <Content> nodes; leave Br, style ranges, and all
  * other markup byte-identical unless the translated slot explicitly changed.
  */
@@ -114,13 +134,15 @@ export function replaceParagraphContentBySegments(
     paragraphBlock: string,
     segments: string[],
     xmlEscape: (value: string) => string,
-    originalSegments?: string[]
+    originalSegments?: string[],
+    forceClearSegmentIndexes?: number[]
 ): string {
     const xmlOriginals = extractContentSegmentsFromParagraphXml(paragraphBlock);
     const originals =
         originalSegments && originalSegments.length > 0
             ? padSegmentArray(originalSegments, xmlOriginals.length, xmlOriginals)
             : xmlOriginals;
+    const forceClear = new Set(forceClearSegmentIndexes ?? []);
 
     let segmentIndex = 0;
     return paragraphBlock.replace(/<Content>([\s\S]*?)<\/Content>/g, (match, oldInner: string) => {
@@ -128,10 +150,18 @@ export function replaceParagraphContentBySegments(
         const slotOriginal = originals[segmentIndex] ?? xmlOriginal;
         const translated =
             segmentIndex < segments.length ? segments[segmentIndex] : undefined;
+        const currentIndex = segmentIndex;
         segmentIndex += 1;
 
         if (translated === undefined) {
             return match;
+        }
+
+        if (forceClear.has(currentIndex)) {
+            if (translated === "" && xmlOriginal === "") {
+                return match;
+            }
+            return `<Content>${xmlEscape("")}</Content>`;
         }
 
         // Empty slot with original text usually means a mapping failure — keep XML as-is.
@@ -197,7 +227,8 @@ export function applySegmentTranslationToParagraphBlock(
     paragraphBlock: string,
     translatedHtml: string,
     originalSegments?: string[],
-    xmlEscape?: (value: string) => string
+    xmlEscape?: (value: string) => string,
+    forceClearSegmentIndexes?: number[]
 ): string {
     const escape = xmlEscape ?? defaultXmlEscape;
     const xmlSegments = extractContentSegmentsFromParagraphXml(paragraphBlock);
@@ -216,11 +247,17 @@ export function applySegmentTranslationToParagraphBlock(
         originals
     );
 
+    const forceClear = new Set(forceClearSegmentIndexes ?? []);
+    const clearedSegments = translatedSegments.map((text, index) =>
+        forceClear.has(index) ? "" : text
+    );
+
     return replaceParagraphContentBySegments(
         paragraphBlock,
-        translatedSegments,
+        clearedSegments,
         escape,
-        originals
+        originals,
+        forceClearSegmentIndexes
     );
 }
 
@@ -401,19 +438,34 @@ export function buildSegmentedParagraphHtml(
     paragraphStyle: string,
     storyId: string,
     segmentStyles?: string[],
-    breakBefore?: boolean[]
+    breakBefore?: boolean[],
+    options?: {
+        segmentIndexOffset?: number;
+        totalSegmentCount?: number;
+        /** Original segment indexes to omit from editor HTML (structural apostrophes). */
+        skipSegmentIndexes?: number[];
+    }
 ): string {
     if (segments.length === 0) {
         return "";
     }
 
+    const segmentIndexOffset = options?.segmentIndexOffset ?? 0;
+    const totalSegmentCount = options?.totalSegmentCount ?? segments.length;
+    const skipIndexes = new Set(options?.skipSegmentIndexes ?? []);
     const defaultStyle = "CharacterStyle/$ID/[No character style]";
     const spanParts: string[] = [];
+    let previousVisibleIndex = -1;
+
     for (let i = 0; i < segments.length; i++) {
+        if (skipIndexes.has(segmentIndexOffset + i)) {
+            continue;
+        }
+
         const segmentText = segments[i] ?? "";
         const charStyle = segmentStyles?.[i] ?? defaultStyle;
 
-        if (i > 0) {
+        if (previousVisibleIndex >= 0) {
             const isLineBreak = breakBefore?.[i] ?? false;
             if (isLineBreak) {
                 spanParts.push(`<br class="idml-eoc" data-eoc="1" />`);
@@ -423,11 +475,16 @@ export function buildSegmentedParagraphHtml(
         }
 
         spanParts.push(
-            `<span class="idml-segment" data-segment-index="${i}" data-character-style="${escapeHtml(charStyle)}">${escapeHtml(segmentText)}</span>`
+            `<span class="idml-segment" data-segment-index="${segmentIndexOffset + i}" data-character-style="${escapeHtml(charStyle)}">${escapeHtml(segmentText)}</span>`
         );
+        previousVisibleIndex = i;
     }
 
-    return `<p class="indesign-paragraph" data-paragraph-style="${escapeHtml(paragraphStyle)}" data-story-id="${escapeHtml(storyId)}" data-segment-count="${segments.length}">${spanParts.join("")}</p>`;
+    if (spanParts.length === 0) {
+        return "";
+    }
+
+    return `<p class="indesign-paragraph" data-paragraph-style="${escapeHtml(paragraphStyle)}" data-story-id="${escapeHtml(storyId)}" data-segment-count="${totalSegmentCount}">${spanParts.join("")}</p>`;
 }
 
 /**
@@ -521,6 +578,35 @@ export function resolveTranslatedSegments(
     return mergeTranslatedSegments([trimmed], expectedSegmentCount, originalSegments);
 }
 
+/**
+ * Merge translated HTML from multiple cells that split one paragraph at line breaks.
+ * Preserves original segment indices for surgical export.
+ */
+export function mergeSplitCellTranslations(
+    cellHtmlList: string[],
+    originalSegments: string[],
+    breakBefore?: boolean[]
+): string {
+    const merged = [...originalSegments];
+
+    for (const html of cellHtmlList) {
+        const parsed = parseSegmentsFromCellHtml(html);
+        if (!parsed) {
+            continue;
+        }
+        for (let i = 0; i < parsed.length; i++) {
+            const text = parsed[i];
+            if (typeof text === "string" && text.trim().length > 0) {
+                merged[i] = text;
+            }
+        }
+    }
+
+    return buildSegmentedParagraphHtml(merged, "", "", undefined, breakBefore, {
+        totalSegmentCount: originalSegments.length,
+    });
+}
+
 function stripCellHtmlToPlainText(html: string): string {
     return html
         .replace(/<span[^>]*\bdata-eoc=["']1["'][^>]*>[\s\S]*?<\/span>/gi, END_OF_CONTENT)
@@ -569,4 +655,3 @@ function mergeTranslatedSegments(
         return candidate ?? "";
     });
 }
-

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/InDesignImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/InDesignImporterForm.tsx
@@ -26,7 +26,7 @@ import {
     extractContentSegmentStructureFromParagraph,
     getSegmentCharacterStylesForParagraph,
     joinContentSegments,
-} from "./contentSegmentUtils";
+} from "../common/contentSegmentUtils";
 import type {
     IDMLCharacterStyleRange,
     IDMLDocument,

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/InDesignImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/InDesignImporterForm.tsx
@@ -21,6 +21,12 @@ import {
     createIndesignVerseCellMetadata,
     createIndesignParagraphCellMetadata,
 } from "./cellMetadata";
+import {
+    buildSegmentedParagraphHtml,
+    extractContentSegmentStructureFromParagraph,
+    getSegmentCharacterStylesForParagraph,
+    joinContentSegments,
+} from "./contentSegmentUtils";
 import type {
     IDMLCharacterStyleRange,
     IDMLDocument,
@@ -74,15 +80,12 @@ async function createCellsFromStories(
     for (const story of stories) {
         for (let i = 0; i < story.paragraphs.length; i++) {
             const paragraph = story.paragraphs[i];
-            const content = paragraph.paragraphStyleRange.content;
             const paragraphStyle = paragraph.paragraphStyleRange.appliedParagraphStyle;
+            const { segments: contentSegments, breakBefore: contentSegmentBreakBefore } =
+                extractContentSegmentStructureFromParagraph(paragraph);
+            const hasText = contentSegments.some((segment) => segment.trim().length > 0);
 
-            const cleanText = content
-                .replace(/[\r\n]+/g, " ")
-                .replace(/\s+/g, " ")
-                .trim();
-
-            if (!cleanText) {
+            if (!hasText) {
                 continue;
             }
 
@@ -108,6 +111,7 @@ async function createCellsFromStories(
                             paragraphId: paragraph.id || "",
                             appliedParagraphStyle: paragraphStyle,
                             paragraph,
+                            paragraphIndex: i,
                             fileName,
                             originalHash: htmlRepresentation.originalHash,
                         });
@@ -124,7 +128,7 @@ async function createCellsFromStories(
 
             const { cellId, metadata: cellMetadata } = createIndesignParagraphCellMetadata({
                 cellLabel: undefined,
-                originalContent: cleanText,
+                originalContent: joinContentSegments(contentSegments),
                 storyId: story.id || "",
                 paragraphId: paragraph.id || "",
                 appliedParagraphStyle: paragraphStyle,
@@ -134,9 +138,13 @@ async function createCellsFromStories(
                 fileName,
                 originalHash: htmlRepresentation.originalHash,
             });
-            const inlineHTML =
-                ranges.length > 0 ? buildInlineHTMLFromRanges(ranges) : escapeHtml(cleanText);
-            const htmlContent = `<p class="indesign-paragraph" data-paragraph-style="${paragraphStyle}" data-story-id="${story.id}">${inlineHTML}</p>`;
+            const htmlContent = buildSegmentedParagraphHtml(
+                contentSegments,
+                paragraphStyle,
+                story.id || "",
+                getSegmentCharacterStylesForParagraph(paragraph, contentSegments.length),
+                contentSegmentBreakBefore
+            );
             const cell = createProcessedCell(cellId, htmlContent, cellMetadata);
             const images = await extractImagesFromHtml(htmlContent);
             cell.images = images;

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/cellMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/cellMetadata.ts
@@ -12,7 +12,7 @@ import {
     extractContentSegmentsFromParagraph,
     extractContentSegmentStructureFromParagraph,
     joinContentSegments,
-} from './contentSegmentUtils';
+} from '../common/contentSegmentUtils';
 
 /**
  * Parameters for creating InDesign verse cell metadata

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/cellMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/cellMetadata.ts
@@ -8,6 +8,11 @@
 import { CodexCellTypes } from 'types/enums';
 import { v4 as uuidv4 } from 'uuid';
 import { IDMLParagraph, IDMLStory } from './types';
+import {
+    extractContentSegmentsFromParagraph,
+    extractContentSegmentStructureFromParagraph,
+    joinContentSegments,
+} from './contentSegmentUtils';
 
 /**
  * Parameters for creating InDesign verse cell metadata
@@ -21,6 +26,7 @@ export interface IndesignVerseCellMetadataParams {
     paragraphId: string;
     appliedParagraphStyle: string;
     paragraph: IDMLParagraph;
+    paragraphIndex: number;
     fileName: string;
     originalHash: string;
 }
@@ -46,7 +52,9 @@ export interface IndesignParagraphCellMetadataParams {
  * Generates a UUID for the cell ID
  */
 export function createIndesignVerseCellMetadata(params: IndesignVerseCellMetadataParams): { metadata: any; cellId: string; } {
-    const { bookCode, chapter, verseNumber, originalContent, storyId, paragraphId, appliedParagraphStyle, paragraph, fileName, originalHash } = params;
+    const { bookCode, chapter, verseNumber, originalContent, storyId, paragraphId, appliedParagraphStyle, paragraph, paragraphIndex, fileName, originalHash } = params;
+    const contentSegments = extractContentSegmentsFromParagraph(paragraph);
+    const { breakBefore: contentSegmentBreakBefore } = extractContentSegmentStructureFromParagraph(paragraph);
 
     // Generate UUID for cell ID
     const cellId = uuidv4();
@@ -73,6 +81,9 @@ export function createIndesignVerseCellMetadata(params: IndesignVerseCellMetadat
                 idmlStructure: {
                     storyId,
                     paragraphId,
+                    contentSegments,
+                    contentSegmentCount: contentSegments.length,
+                    contentSegmentBreakBefore,
                     paragraphStyleRange: {
                         appliedParagraphStyle,
                         // Only keep dataAfter if present (for paragraph breaks)
@@ -83,7 +94,7 @@ export function createIndesignVerseCellMetadata(params: IndesignVerseCellMetadat
                 // Minimal relationships needed for export
                 relationships: {
                     parentStory: storyId,
-                    paragraphOrder: 0, // Will be set by importer if needed
+                    paragraphOrder: paragraphIndex,
                 },
             }
         }
@@ -96,6 +107,8 @@ export function createIndesignVerseCellMetadata(params: IndesignVerseCellMetadat
  */
 export function createIndesignParagraphCellMetadata(params: IndesignParagraphCellMetadataParams): { metadata: any; cellId: string; } {
     const { cellLabel, originalContent, storyId, paragraphId, appliedParagraphStyle, paragraph, stories, paragraphIndex, fileName, originalHash } = params;
+    const contentSegments = extractContentSegmentsFromParagraph(paragraph);
+    const { breakBefore: contentSegmentBreakBefore } = extractContentSegmentStructureFromParagraph(paragraph);
 
     // Generate UUID for cell ID
     const cellId = uuidv4();
@@ -111,12 +124,15 @@ export function createIndesignParagraphCellMetadata(params: IndesignParagraphCel
             paragraphId,
             appliedParagraphStyle,
             data: {
-                originalContent,
+                originalContent: joinContentSegments(contentSegments),
                 globalReferences: [], // Empty for InDesign files (no verse references)
                 // Minimal structure needed for export
                 idmlStructure: {
                     storyId,
                     paragraphId,
+                    contentSegments,
+                    contentSegmentCount: contentSegments.length,
+                    contentSegmentBreakBefore,
                     paragraphStyleRange: {
                         appliedParagraphStyle,
                         // Only keep dataAfter if present (for paragraph breaks)

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/contentSegmentUtils.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/contentSegmentUtils.ts
@@ -1,0 +1,572 @@
+/**
+ * IDML content-segment round-trip utilities.
+ *
+ * Each <Content> node in a ParagraphStyleRange is one editable text slot.
+ * Segments are joined with END_OF_CONTENT in stored plain text, and rendered
+ * as indexed spans in HTML so export can map 1:1 back onto <Content> nodes
+ * without rebuilding CharacterStyleRange XML.
+ */
+
+import type { IDMLCharacterStyleRange, IDMLParagraph } from "./types";
+
+/** Plain-text/metadata delimiter (stored in metadata only, not in editor HTML). */
+export const END_OF_CONTENT = "\u001E";
+
+export function joinContentSegments(segments: string[]): string {
+    return segments.join(END_OF_CONTENT);
+}
+
+export function splitContentSegments(markedText: string): string[] {
+    if (!markedText.includes(END_OF_CONTENT)) {
+        return [markedText];
+    }
+    return markedText.split(END_OF_CONTENT);
+}
+
+/**
+ * Extract every <Content> text value inside a ParagraphStyleRange block, in document order.
+ */
+export function extractContentSegmentsFromParagraphXml(paragraphBlock: string): string[] {
+    const segments: string[] = [];
+    const contentRegex = /<Content>([\s\S]*?)<\/Content>/gi;
+    let match: RegExpExecArray | null;
+    while ((match = contentRegex.exec(paragraphBlock)) !== null) {
+        segments.push(decodeXmlEntities(match[1] ?? ""));
+    }
+    return segments;
+}
+
+/**
+ * Extract segments from parsed paragraph metadata (fallback when XML is unavailable).
+ */
+export interface ContentSegmentStructure {
+    segments: string[];
+    breakBefore: boolean[];
+}
+
+/**
+ * Walk paragraph XML and collect each <Content> text plus whether a <Br /> precedes it.
+ */
+export function extractContentSegmentStructureFromParagraphXml(
+    paragraphBlock: string
+): ContentSegmentStructure {
+    const segments: string[] = [];
+    const breakBefore: boolean[] = [];
+    let pendingBreak = false;
+
+    const tokenRegex = /(<Content>[\s\S]*?<\/Content>)|(<Br\s*\/?>)/gi;
+    let match: RegExpExecArray | null;
+    while ((match = tokenRegex.exec(paragraphBlock)) !== null) {
+        if (match[1]) {
+            const contentInner = /<Content>([\s\S]*?)<\/Content>/i.exec(match[1]);
+            segments.push(decodeXmlEntities(contentInner?.[1] ?? ""));
+            breakBefore.push(pendingBreak);
+            pendingBreak = false;
+        } else if (match[2]) {
+            pendingBreak = true;
+        }
+    }
+
+    return { segments, breakBefore };
+}
+
+export function extractContentSegmentStructureFromParagraph(
+    paragraph: IDMLParagraph
+): ContentSegmentStructure {
+    if (Array.isArray(paragraph.contentSegments) && paragraph.contentSegments.length > 0) {
+        const breakBefore = paragraph.contentSegmentBreakBefore ?? [];
+        return {
+            segments: [...paragraph.contentSegments],
+            breakBefore: paragraph.contentSegments.map((_, index) => breakBefore[index] ?? false),
+        };
+    }
+
+    const segments: string[] = [];
+    const breakBefore: boolean[] = [];
+    for (const range of paragraph.characterStyleRanges || []) {
+        const content = range.content ?? "";
+        if (!content) {
+            continue;
+        }
+        const parts = content.split("\n");
+        const endsWithBreak = content.endsWith("\n");
+        const sliceEnd =
+            endsWithBreak && parts.length > 0 && parts[parts.length - 1] === ""
+                ? parts.length - 1
+                : parts.length;
+        for (let i = 0; i < sliceEnd; i++) {
+            segments.push(parts[i] ?? "");
+            breakBefore.push(i > 0);
+        }
+    }
+    return { segments, breakBefore };
+}
+
+export function extractContentSegmentsFromParagraph(paragraph: IDMLParagraph): string[] {
+    return extractContentSegmentStructureFromParagraph(paragraph).segments;
+}
+
+/**
+ * Replace only inner text of <Content> nodes; leave Br, style ranges, and all
+ * other markup byte-identical unless the translated slot explicitly changed.
+ */
+export function replaceParagraphContentBySegments(
+    paragraphBlock: string,
+    segments: string[],
+    xmlEscape: (value: string) => string,
+    originalSegments?: string[]
+): string {
+    const xmlOriginals = extractContentSegmentsFromParagraphXml(paragraphBlock);
+    const originals =
+        originalSegments && originalSegments.length > 0
+            ? padSegmentArray(originalSegments, xmlOriginals.length, xmlOriginals)
+            : xmlOriginals;
+
+    let segmentIndex = 0;
+    return paragraphBlock.replace(/<Content>([\s\S]*?)<\/Content>/g, (match, oldInner: string) => {
+        const xmlOriginal = decodeXmlEntities(oldInner ?? "");
+        const slotOriginal = originals[segmentIndex] ?? xmlOriginal;
+        const translated =
+            segmentIndex < segments.length ? segments[segmentIndex] : undefined;
+        segmentIndex += 1;
+
+        if (translated === undefined) {
+            return match;
+        }
+
+        // Empty slot with original text usually means a mapping failure — keep XML as-is.
+        if (translated.trim() === "" && slotOriginal.trim() !== "") {
+            return match;
+        }
+
+        if (translated === slotOriginal || translated === xmlOriginal) {
+            return match;
+        }
+
+        return `<Content>${xmlEscape(translated)}</Content>`;
+    });
+}
+
+function padSegmentArray(
+    segments: string[],
+    expectedCount: number,
+    fallback: string[]
+): string[] {
+    return Array.from({ length: expectedCount }, (_, index) => {
+        if (index < segments.length) {
+            return segments[index];
+        }
+        return fallback[index] ?? "";
+    });
+}
+
+/**
+ * Locate a top-level ParagraphStyleRange block by Self/id or by story order index.
+ */
+export function findParagraphBlockInStoryXml(
+    storyXml: string,
+    options: { paragraphId?: string; paragraphOrder?: number }
+): { block: string; start: number; end: number } | null {
+    const blocks = listTopLevelParagraphBlocks(storyXml);
+    if (options.paragraphId) {
+        const escapedId = escapeRegExp(options.paragraphId);
+        const idPattern = new RegExp(
+            `\\b(?:Self|id)=["']${escapedId}["']`,
+            "i"
+        );
+        const byId = blocks.find(({ openTag }) => idPattern.test(openTag));
+        if (byId) {
+            return byId;
+        }
+    }
+
+    if (typeof options.paragraphOrder === "number") {
+        const byOrder = blocks[options.paragraphOrder];
+        if (byOrder) {
+            return byOrder;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Apply translated segments to one paragraph block without touching any other XML.
+ */
+export function applySegmentTranslationToParagraphBlock(
+    paragraphBlock: string,
+    translatedHtml: string,
+    originalSegments?: string[],
+    xmlEscape?: (value: string) => string
+): string {
+    const escape = xmlEscape ?? defaultXmlEscape;
+    const xmlSegments = extractContentSegmentsFromParagraphXml(paragraphBlock);
+    if (xmlSegments.length === 0) {
+        return paragraphBlock;
+    }
+
+    const originals =
+        originalSegments && originalSegments.length > 0
+            ? padSegmentArray(originalSegments, xmlSegments.length, xmlSegments)
+            : xmlSegments;
+
+    const translatedSegments = resolveTranslatedSegments(
+        translatedHtml,
+        xmlSegments.length,
+        originals
+    );
+
+    return replaceParagraphContentBySegments(
+        paragraphBlock,
+        translatedSegments,
+        escape,
+        originals
+    );
+}
+
+function listTopLevelParagraphBlocks(
+    storyXml: string
+): Array<{ block: string; start: number; end: number; openTag: string }> {
+    const blocks: Array<{ block: string; start: number; end: number; openTag: string }> = [];
+    let depth = 0;
+    let currentStart = -1;
+    let currentOpenTag = "";
+    let inStory = false;
+    let storyDepth = 0;
+
+    const tagRegex = /<\/?(?:Story|ParagraphStyleRange)\b[^>]*>/gi;
+    let match: RegExpExecArray | null;
+
+    while ((match = tagRegex.exec(storyXml)) !== null) {
+        const tag = match[0];
+        const tagName = tag.match(/<\/?(\w+)/)?.[1];
+        const isClosing = tag.startsWith("</");
+        const pos = match.index;
+
+        if (tagName === "Story") {
+            if (isClosing) {
+                storyDepth--;
+                if (storyDepth === 0) {
+                    inStory = false;
+                }
+            } else {
+                storyDepth++;
+                if (storyDepth === 1) {
+                    inStory = true;
+                    depth = 0;
+                }
+            }
+            continue;
+        }
+
+        if (!inStory || tagName !== "ParagraphStyleRange") {
+            continue;
+        }
+
+        if (isClosing) {
+            depth--;
+            if (depth === 0 && currentStart >= 0) {
+                const end = pos + tag.length;
+                blocks.push({
+                    block: storyXml.slice(currentStart, end),
+                    start: currentStart,
+                    end,
+                    openTag: currentOpenTag,
+                });
+                currentStart = -1;
+                currentOpenTag = "";
+            }
+        } else if (depth === 0) {
+            currentStart = pos;
+            currentOpenTag = tag;
+            depth++;
+        } else {
+            depth++;
+        }
+    }
+
+    if (blocks.length > 0) {
+        return blocks;
+    }
+
+    // Fallback when Story wrapper tags are absent from the XML fragment.
+    const flatRegex = /<ParagraphStyleRange\b[^>]*>[\s\S]*?<\/ParagraphStyleRange>/gi;
+    let flatMatch: RegExpExecArray | null;
+    while ((flatMatch = flatRegex.exec(storyXml)) !== null) {
+        const block = flatMatch[0];
+        const start = flatMatch.index;
+        blocks.push({
+            block,
+            start,
+            end: start + block.length,
+            openTag: block.match(/^<ParagraphStyleRange\b[^>]*>/i)?.[0] ?? "",
+        });
+    }
+
+    return blocks;
+}
+
+function defaultXmlEscape(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True when a paragraph has no text but contains Br runs (spacing / break paragraphs).
+ */
+export function isStructuralBreakParagraph(paragraph: IDMLParagraph): boolean {
+    const segments = paragraph.contentSegments ?? extractContentSegmentsFromParagraph(paragraph);
+    const hasText = segments.some((segment) => segment.trim().length > 0);
+    if (hasText) {
+        return false;
+    }
+    const combined = paragraph.paragraphStyleRange?.content ?? "";
+    if (combined.includes("\n")) {
+        return true;
+    }
+    const dataAfter = (paragraph.paragraphStyleRange as { dataAfter?: string[] })?.dataAfter;
+    return Array.isArray(dataAfter) && dataAfter.length > 0;
+}
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
+
+function decodeXmlEntities(text: string): string {
+    return text
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'");
+}
+
+/**
+ * Derive one character style per content segment from parsed ranges.
+ */
+export function getSegmentCharacterStylesForParagraph(
+    paragraph: IDMLParagraph,
+    segmentCount: number
+): string[] {
+    const styles: string[] = [];
+    const defaultStyle = "CharacterStyle/$ID/[No character style]";
+
+    for (const range of paragraph.characterStyleRanges || []) {
+        const content = range.content ?? "";
+        if (!content && styles.length >= segmentCount) {
+            continue;
+        }
+
+        const parts = content.split("\n");
+        const endsWithBreak = content.endsWith("\n");
+        const sliceEnd =
+            endsWithBreak && parts.length > 0 && parts[parts.length - 1] === ""
+                ? parts.length - 1
+                : parts.length;
+
+        for (let i = 0; i < sliceEnd; i++) {
+            styles.push(range.appliedCharacterStyle || defaultStyle);
+        }
+    }
+
+    if (styles.length === 0) {
+        return Array.from({ length: segmentCount }, () => defaultStyle);
+    }
+
+    while (styles.length < segmentCount) {
+        styles.push(styles[styles.length - 1] || defaultStyle);
+    }
+
+    return styles.slice(0, segmentCount);
+}
+
+/**
+ * Build editor HTML with one span per content segment.
+ * Segment boundaries are invisible in the UI; line breaks only where IDML had <Br />.
+ */
+export function buildSegmentedParagraphHtml(
+    segments: string[],
+    paragraphStyle: string,
+    storyId: string,
+    segmentStyles?: string[],
+    breakBefore?: boolean[]
+): string {
+    if (segments.length === 0) {
+        return "";
+    }
+
+    const defaultStyle = "CharacterStyle/$ID/[No character style]";
+    const spanParts: string[] = [];
+    for (let i = 0; i < segments.length; i++) {
+        const segmentText = segments[i] ?? "";
+        const charStyle = segmentStyles?.[i] ?? defaultStyle;
+
+        if (i > 0) {
+            const isLineBreak = breakBefore?.[i] ?? false;
+            if (isLineBreak) {
+                spanParts.push(`<br class="idml-eoc" data-eoc="1" />`);
+            } else {
+                spanParts.push(`<span class="idml-eoc" data-eoc="1" aria-hidden="true"></span>`);
+            }
+        }
+
+        spanParts.push(
+            `<span class="idml-segment" data-segment-index="${i}" data-character-style="${escapeHtml(charStyle)}">${escapeHtml(segmentText)}</span>`
+        );
+    }
+
+    return `<p class="indesign-paragraph" data-paragraph-style="${escapeHtml(paragraphStyle)}" data-story-id="${escapeHtml(storyId)}" data-segment-count="${segments.length}">${spanParts.join("")}</p>`;
+}
+
+/**
+ * Parse translated cell HTML back into content segments (preferred export path).
+ */
+export function parseSegmentsFromCellHtml(html: string): string[] | null {
+    if (!html || !html.includes("data-segment-index")) {
+        return null;
+    }
+
+    const spanRegex =
+        /<span[^>]*\bdata-segment-index=["'](\d+)["'][^>]*>([\s\S]*?)<\/span>/gi;
+    const indexed: { index: number; text: string }[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = spanRegex.exec(html)) !== null) {
+        const index = Number.parseInt(match[1], 10);
+        if (Number.isNaN(index)) {
+            continue;
+        }
+        const inner = (match[2] ?? "")
+            .replace(/<span[^>]*\bdata-eoc=["']1["'][^>]*>[\s\S]*?<\/span>/gi, END_OF_CONTENT)
+            .replace(/<br[^>]*\bdata-eoc=["']1["'][^>]*\/?>/gi, END_OF_CONTENT)
+            .replace(/<br\s*\/?>/gi, END_OF_CONTENT)
+            .replace(/<[^>]*>/g, "");
+        indexed.push({ index, text: decodeXmlEntities(inner) });
+    }
+
+    if (indexed.length === 0) {
+        return null;
+    }
+
+    indexed.sort((a, b) => a.index - b.index);
+    const maxIndex = indexed[indexed.length - 1].index;
+    const segments = Array.from({ length: maxIndex + 1 }, () => "");
+    for (const item of indexed) {
+        segments[item.index] = item.text;
+    }
+    return segments;
+}
+
+/**
+ * Resolve translated segments using HTML spans, EOC markers, or safe fallbacks.
+ */
+export function resolveTranslatedSegments(
+    translatedHtml: string,
+    expectedSegmentCount: number,
+    originalSegments?: string[]
+): string[] {
+    const fromHtml = parseSegmentsFromCellHtml(translatedHtml);
+    if (fromHtml && fromHtml.length > 0) {
+        return mergeTranslatedSegments(fromHtml, expectedSegmentCount, originalSegments);
+    }
+
+    const plain = stripCellHtmlToPlainText(translatedHtml);
+
+    if (plain.includes(END_OF_CONTENT)) {
+        return mergeTranslatedSegments(
+            splitContentSegments(plain),
+            expectedSegmentCount,
+            originalSegments
+        );
+    }
+
+    const trimmed = plain.trim();
+    if (expectedSegmentCount <= 1) {
+        return [trimmed];
+    }
+
+    const byNewline = trimmed.split("\n");
+    if (byNewline.length === expectedSegmentCount) {
+        return byNewline;
+    }
+
+    // Single edited blob for a multi-segment paragraph: update only text-bearing slots.
+    if (originalSegments && originalSegments.length === expectedSegmentCount) {
+        const textSlotIndexes = originalSegments
+            .map((segment, index) => (segment.trim().length > 0 ? index : -1))
+            .filter((index) => index >= 0);
+
+        if (textSlotIndexes.length === 1) {
+            const result = [...originalSegments];
+            result[textSlotIndexes[0]] = trimmed;
+            return result;
+        }
+
+        if (textSlotIndexes.length > 1) {
+            return mergeTranslatedSegments([trimmed], expectedSegmentCount, originalSegments);
+        }
+    }
+
+    return mergeTranslatedSegments([trimmed], expectedSegmentCount, originalSegments);
+}
+
+function stripCellHtmlToPlainText(html: string): string {
+    return html
+        .replace(/<span[^>]*\bdata-eoc=["']1["'][^>]*>[\s\S]*?<\/span>/gi, END_OF_CONTENT)
+        .replace(/<br[^>]*\bdata-eoc=["']1["'][^>]*\/?>/gi, END_OF_CONTENT)
+        .replace(/<br\s*\/?>/gi, END_OF_CONTENT)
+        .replace(/<[^>]*>/g, "")
+        .replace(/&nbsp;/g, " ")
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"');
+}
+
+/**
+ * Merge parsed translation onto the original segment scaffold.
+ * Unmapped or empty slots keep the original text so Br/Content structure stays intact.
+ */
+function mergeTranslatedSegments(
+    translated: string[],
+    expectedCount: number,
+    originalSegments?: string[]
+): string[] {
+    if (expectedCount <= 0) {
+        return translated;
+    }
+
+    if (translated.length > expectedCount) {
+        const head = translated.slice(0, expectedCount - 1);
+        const tail = translated.slice(expectedCount - 1).join("");
+        translated = [...head, tail];
+    }
+
+    return Array.from({ length: expectedCount }, (_, index) => {
+        const candidate = translated[index];
+        const hasTranslation =
+            typeof candidate === "string" && candidate.trim().length > 0;
+
+        if (hasTranslation) {
+            return candidate;
+        }
+
+        if (originalSegments && index < originalSegments.length) {
+            return originalSegments[index];
+        }
+
+        return candidate ?? "";
+    });
+}
+

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
@@ -21,7 +21,7 @@ import {
 import {
     applySegmentTranslationToParagraphBlock,
     findParagraphBlockInStoryXml,
-} from './contentSegmentUtils';
+} from '../common/contentSegmentUtils';
 
 // Import JSZip for Node.js environment
 import JSZip from 'jszip';

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
@@ -18,6 +18,10 @@ import {
     IDMLExportError,
     IDMLExportConfig
 } from './types';
+import {
+    applySegmentTranslationToParagraphBlock,
+    findParagraphBlockInStoryXml,
+} from './contentSegmentUtils';
 
 // Import JSZip for Node.js environment
 import JSZip from 'jszip';
@@ -521,6 +525,9 @@ export interface ParagraphUpdate {
     paragraphId?: string;
     paragraphOrder?: number;
     translated: string;
+    translatedHtml?: string;
+    contentSegments?: string[];
+    contentSegmentCount?: number;
     dataAfter?: string[];
 }
 
@@ -598,9 +605,42 @@ export async function exportIdmlRoundtrip(
         return "";
     };
 
-    // Helper to remove HTML tags
+    // Helper to remove HTML tags (for plain text fallback)
     const removeHtmlTags = (html: string): string => {
         return html.replace(/<[^>]*>/g, '').trim();
+    };
+
+    const applyParagraphUpdate = (storyXml: string, update: ParagraphUpdate): string => {
+        const located = findParagraphBlockInStoryXml(storyXml, {
+            paragraphId: update.paragraphId,
+            paragraphOrder: update.paragraphOrder,
+        });
+
+        if (!located) {
+            return storyXml;
+        }
+
+        const translatedHtml = update.translatedHtml || update.translated;
+        if (!translatedHtml?.trim()) {
+            return storyXml;
+        }
+
+        const updatedBlock = applySegmentTranslationToParagraphBlock(
+            located.block,
+            translatedHtml,
+            update.contentSegments,
+            xmlEscape
+        );
+
+        if (updatedBlock === located.block) {
+            return storyXml;
+        }
+
+        return (
+            storyXml.slice(0, located.start) +
+            updatedBlock +
+            storyXml.slice(located.end)
+        );
     };
 
     // Track story order counters for fallback
@@ -612,7 +652,8 @@ export async function exportIdmlRoundtrip(
         const isText = cell.kind === 2 && meta?.type === "text";
         if (!isText) continue;
 
-        const translated = removeHtmlTags(getTranslatedHtml(cell)).trim();
+        const translatedHtml = getTranslatedHtml(cell);
+        const translated = removeHtmlTags(translatedHtml).trim();
         if (!translated) continue;
 
         const structure = meta?.data?.idmlStructure;
@@ -633,6 +674,11 @@ export async function exportIdmlRoundtrip(
 
         const paragraphId: string | undefined = structure?.paragraphId || meta?.paragraphId;
         const dataAfterRuns: string[] | undefined = structure?.paragraphStyleRange?.dataAfter;
+        const contentSegments: string[] | undefined = structure?.contentSegments;
+        const contentSegmentCount: number | undefined =
+            typeof structure?.contentSegmentCount === "number"
+                ? structure.contentSegmentCount
+                : contentSegments?.length;
 
         let paragraphOrder: number | undefined = typeof relationships?.paragraphOrder === 'number'
             ? relationships.paragraphOrder
@@ -648,52 +694,33 @@ export async function exportIdmlRoundtrip(
         // Add to appropriate map
         if (storyId) {
             const updates = storyIdToUpdates.get(storyId) || [];
-            updates.push({ paragraphId, paragraphOrder, translated, dataAfter: dataAfterRuns });
+            updates.push({
+                paragraphId,
+                paragraphOrder,
+                translated,
+                translatedHtml,
+                contentSegments,
+                contentSegmentCount,
+                dataAfter: dataAfterRuns,
+            });
             storyIdToUpdates.set(storyId, updates);
         } else if (storyOrder !== undefined) {
             const updates = storyIndexToUpdates.get(storyOrder) || [];
-            updates.push({ paragraphOrder, translated, dataAfter: dataAfterRuns });
+            updates.push({
+                paragraphOrder,
+                translated,
+                translatedHtml,
+                contentSegments,
+                contentSegmentCount,
+                dataAfter: dataAfterRuns,
+            });
             storyIndexToUpdates.set(storyOrder, updates);
         }
     }
 
-    // Helper to build replacement content
-    const buildReplacementInner = (newText: string, dataAfter?: string[]): string => {
-        const hasBreakInDataAfter = Array.isArray(dataAfter) && dataAfter.some(s => /<Br\b/i.test(s));
-        const br = hasBreakInDataAfter ? '' : '<Br/>';
-        const after = Array.isArray(dataAfter) ? dataAfter.join('') : '';
-        return `<CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]"><Content>${xmlEscape(newText)}</Content>${br}</CharacterStyleRange>${after}`;
-    };
-
-    // Helper to replace paragraph by ID
-    const replaceParagraphById = (xml: string, pid: string, newText: string, dataAfter?: string[]): string => {
-        const escapedPid = escapeRegExp(pid);
-        const blockRe = new RegExp(`(<ParagraphStyleRange[^>]*\\bid=["']${escapedPid}["'][^>]*>)([\\s\\S]*?)(<\\/ParagraphStyleRange>)`, 'i');
-        const replacementInner = buildReplacementInner(newText, dataAfter);
-        return xml.replace(blockRe, (_m, openTag, _inner, closeTag) => `${openTag}${replacementInner}${closeTag}`);
-    };
-
-    // Helper to replace paragraph by order index
-    const replaceNthParagraph = (xml: string, index: number, newText: string, dataAfter?: string[]): string => {
-        const reBlock = /<ParagraphStyleRange\b[^>]*>[\s\S]*?<\/ParagraphStyleRange>/gi;
-        const blocks: { start: number; end: number; }[] = [];
-        let match: RegExpExecArray | null;
-        while ((match = reBlock.exec(xml)) !== null) {
-            blocks.push({ start: match.index, end: reBlock.lastIndex });
-        }
-        if (index < 0 || index >= blocks.length) return xml;
-
-        const target = blocks[index];
-        const before = xml.slice(0, target.start);
-        const block = xml.slice(target.start, target.end);
-        const after = xml.slice(target.end);
-
-        const updatedBlock = block.replace(/^(<ParagraphStyleRange\b[^>]*>)[\s\S]*?(<\/ParagraphStyleRange>)$/i, (_m, openTag, closeTag) => {
-            const replacementInner = buildReplacementInner(newText, dataAfter);
-            return `${openTag}${replacementInner}${closeTag}`;
-        });
-
-        return before + updatedBlock + after;
+    // Helper to replace one paragraph — only inner <Content> text changes
+    const applyParagraphUpdateToStory = (xml: string, update: ParagraphUpdate): string => {
+        return applyParagraphUpdate(xml, update);
     };
 
     // Apply updates per story
@@ -713,13 +740,9 @@ export async function exportIdmlRoundtrip(
         const xmlText = await zip.file(storyKey)!.async("string");
         let updated = xmlText;
 
-        // Prefer id-based replacement, otherwise fallback to order
+        // Prefer Self/id match, then fall back to paragraph order index
         for (const u of updates) {
-            if (u.paragraphId) {
-                updated = replaceParagraphById(updated, u.paragraphId, u.translated, u.dataAfter);
-            } else if (typeof u.paragraphOrder === 'number') {
-                updated = replaceNthParagraph(updated, u.paragraphOrder, u.translated, u.dataAfter);
-            }
+            updated = applyParagraphUpdateToStory(updated, u);
         }
 
         if (updated !== xmlText) {
@@ -753,9 +776,7 @@ export async function exportIdmlRoundtrip(
                     let updated = xmlText;
 
                     for (const u of updates) {
-                        if (typeof u.paragraphOrder === 'number') {
-                            updated = replaceNthParagraph(updated, u.paragraphOrder, u.translated, u.dataAfter);
-                        }
+                        updated = applyParagraphUpdateToStory(updated, u);
                     }
 
                     if (updated !== xmlText) {

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlParser.ts
@@ -19,7 +19,7 @@ import {
     IDMLParseError,
     IDMLImportConfig
 } from './types';
-import { extractContentSegmentStructureFromParagraphXml } from './contentSegmentUtils';
+import { extractContentSegmentStructureFromParagraphXml } from '../common/contentSegmentUtils';
 
 // Local hashing helpers to avoid test-only imports
 function toArrayBufferForHash(input: string | ArrayBuffer): ArrayBuffer {

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlParser.ts
@@ -19,6 +19,7 @@ import {
     IDMLParseError,
     IDMLImportConfig
 } from './types';
+import { extractContentSegmentStructureFromParagraphXml } from './contentSegmentUtils';
 
 // Local hashing helpers to avoid test-only imports
 function toArrayBufferForHash(input: string | ArrayBuffer): ArrayBuffer {
@@ -214,9 +215,13 @@ export class IDMLParser {
             const paragraphContent = match[2];
             const fullMatch = match[0];
 
-            // Extract ID from original XML if it exists
-            const idMatch = fullMatch.match(/id="([^"]*)"/);
+            // Extract ID from original XML (IDML uses Self; some files also have id)
+            const idMatch =
+                fullMatch.match(/\bSelf="([^"]*)"/i) ||
+                fullMatch.match(/\bid="([^"]*)"/i);
             const originalId = idMatch ? idMatch[1] : undefined;
+
+            const segmentStructure = extractContentSegmentStructureFromParagraphXml(paragraphContent);
 
             const paragraph: IDMLParagraph = {
                 id: originalId, // Only         use ID if it existed in original
@@ -227,6 +232,8 @@ export class IDMLParser {
                     content: this.extractTextContentFromString(paragraphContent)
                 },
                 characterStyleRanges: this.extractCharacterRangesFromParagraph(paragraphContent),
+                contentSegments: segmentStructure.segments,
+                contentSegmentBreakBefore: segmentStructure.breakBefore,
                 metadata: {}
             };
 
@@ -412,12 +419,47 @@ export class IDMLParser {
             (paragraphStyleRange as any).dataAfter = trailingRuns;
         }
 
+        const segmentStructure = this.extractContentSegmentStructureFromElement(paragraphElement);
+
         return {
             id: paragraphId, // undefined if no ID in original
             paragraphStyleRange,
             characterStyleRanges,
+            contentSegments: segmentStructure.segments,
+            contentSegmentBreakBefore: segmentStructure.breakBefore,
             metadata: this.extractElementMetadata(paragraphElement)
         };
+    }
+
+    /**
+     * Extract each <Content> text and whether a preceding <Br /> started this segment.
+     */
+    private extractContentSegmentStructureFromElement(paragraphElement: Element): {
+        segments: string[];
+        breakBefore: boolean[];
+    } {
+        const segments: string[] = [];
+        const breakBefore: boolean[] = [];
+        let pendingBreak = false;
+
+        const walk = (element: Element) => {
+            for (let i = 0; i < element.children.length; i++) {
+                const child = element.children[i] as Element;
+                const tag = child.tagName;
+                if (tag === "Content") {
+                    segments.push(child.textContent || "");
+                    breakBefore.push(pendingBreak);
+                    pendingBreak = false;
+                } else if (tag === "Br") {
+                    pendingBreak = true;
+                } else if (tag === "CharacterStyleRange" || tag === "Properties") {
+                    walk(child);
+                }
+            }
+        };
+
+        walk(paragraphElement);
+        return { segments, breakBefore };
     }
 
     /**

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/types.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/types.ts
@@ -27,6 +27,10 @@ export interface IDMLParagraph {
     id?: string;
     paragraphStyleRange: IDMLParagraphStyleRange;
     characterStyleRanges: IDMLCharacterStyleRange[];
+    /** One entry per <Content> node in document order (round-trip text slots). */
+    contentSegments?: string[];
+    /** When true, segment i starts after an IDML line break (<Br />). */
+    contentSegmentBreakBefore?: boolean[];
     metadata?: Record<string, any>;
 }
 

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/registry.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/registry.tsx
@@ -25,7 +25,6 @@ import { paratextImporterPlugin } from "./paratext/index.tsx";
 import { spreadsheetImporterPlugin } from "./bibleSpredSheet/index.tsx";
 import { audioImporterPlugin } from "./audio/index.tsx";
 import { biblicaImporterPlugin } from "./biblica/index.tsx";
-// import { reach4lifeImporterPlugin } from "./reach4life/index.tsx";
 import { tmsImporterPlugin } from "./tms/index.tsx";
 // import { pdfImporterPlugin } from "./pdf/index.tsx";
 import { indesignImporterPlugin } from "./indesign/index.tsx";
@@ -147,12 +146,6 @@ export const importerPlugins: ImporterPlugin[] = [
         description: "Biblica IDML importer with Study Bible notes",
         tags: ["Specialized", "Bible", "Biblica", "Round-trip"],
     },
-    // {
-    //     ...reach4lifeImporterPlugin,
-    //     name: "Reach4Life",
-    //     description: "Reach4Life IDML importer",
-    //     tags: ["Specialized", "Bible", "Reach4Life", "Round-trip"],
-    // },
     {
         ...spreadsheetImporterPlugin,
         name: "Bible Spreadsheet with Audio data",

--- a/webviews/codex-webviews/src/NewSourceUploader/types/processedNotebookMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/types/processedNotebookMetadata.ts
@@ -217,17 +217,6 @@ export interface BiblicaNotebookMetadata extends ProcessedNotebookMetadataBase {
     contentType?: "notes";
 }
 
-export interface Reach4LifeNotebookMetadata extends ProcessedNotebookMetadataBase {
-    importerType: "reach4life";
-    originalFileData?: ArrayBuffer;
-    documentId?: string;
-    storyCount?: number;
-    originalHash?: string;
-    totalCells?: number;
-    fileType?: "reach4life" | string;
-    contentType?: "notes";
-}
-
 export interface MaculaNotebookMetadata extends ProcessedNotebookMetadataBase {
     importerType: "macula";
     corpusMarker?: string;
@@ -251,7 +240,6 @@ export type ProcessedNotebookMetadata =
     | DocxNotebookMetadata
     | IndesignNotebookMetadata
     | BiblicaNotebookMetadata
-    | Reach4LifeNotebookMetadata
     | MaculaNotebookMetadata;
 
 export type ProcessedNotebookMetadataByImporter = {
@@ -273,7 +261,6 @@ export type ProcessedNotebookMetadataByImporter = {
     docx: DocxNotebookMetadata;
     indesign: IndesignNotebookMetadata;
     biblica: BiblicaNotebookMetadata;
-    reach4life: Reach4LifeNotebookMetadata;
     macula: MaculaNotebookMetadata;
 };
 


### PR DESCRIPTION
Developed a new way for regular InDesign importer exporter to maintain the correct strucutre and surgically replace the correct textual content in between all the styles and tags. Work more reliable than the older version. Now it just saves you could say "end-of-content" or "style-block" with no further explanation and preserving them as sort of "text splitters". When the exporter will be replacing the content and it will hit this splitter, it will then skip all the styling in the original document until it finds new text it starts replacing until it hits new splitter and so on.

## PR Title
Format:
[Issue Number]-[Issue Name]

## Summary

Closes #716 
This might not completely close the issue, but it's a great step towards that, I will still have to run more tests with files they will provide me later.

## Testing Checklist
- [x] import regular indesign file
- [x] translate cells also with html enforcement necessary
- [x] export the file and see if it was exported correctly with preserved locations, styles etc.