### PR TITLE
1048-Ciluba-project-episode-302-overlapping-subtitle-timestamps

### DIFF
--- a/sharedUtils/index.ts
+++ b/sharedUtils/index.ts
@@ -283,3 +283,4 @@ export const deriveTargetPathFromSource = (sourcePath: string): string => {
 // Re-export corpus utilities
 export * from "./corpusUtils";
 export * from "./exportOptionsEligibility";
+export * from "./timeUtils";

--- a/sharedUtils/timeUtils.ts
+++ b/sharedUtils/timeUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats a time in seconds as a VTT-style timecode: HH:MM:SS.mmm
+ *
+ * Computes from integer milliseconds so float artifacts don't truncate the
+ * final digit (e.g. 64.94 formats as "00:01:04.940", not "00:01:04.939").
+ */
+export const formatTimecode = (seconds: number): string => {
+    if (!isFinite(seconds) || isNaN(seconds) || seconds < 0) return "00:00:00.000";
+    const totalMs = Math.round(seconds * 1000);
+    const ms = totalMs % 1000;
+    const totalSec = Math.floor(totalMs / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    const pad2 = (n: number) => String(n).padStart(2, "0");
+    return `${pad2(h)}:${pad2(m)}:${pad2(s)}.${String(ms).padStart(3, "0")}`;
+};

--- a/src/exportHandler/vttUtils.ts
+++ b/src/exportHandler/vttUtils.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { CodexNotebookAsJSONData, QuillCellContent } from "@types";
 import { CodexCellTypes } from "../../types/enums";
 import { removeHtmlTags } from "./subtitleUtils";
+import { formatTimecode } from "../../sharedUtils/timeUtils";
 
 /**
  * Inserts line breaks for dialogue patterns when missing.
@@ -76,11 +77,6 @@ export const generateVttData = (
 ): string => {
     if (!cells.length) return "";
 
-    const formatTime = (seconds: number): string => {
-        const date = new Date(seconds * 1000);
-        return date.toISOString().substr(11, 12);
-    };
-
     const units: ProcessedUnit[] = cells
         .filter((unit) => {
             const metadata = unit.metadata;
@@ -112,12 +108,12 @@ export const generateVttData = (
 
     const cues =
         cueSplitting && units.length > 0
-            ? buildSplitCues(units, formatTime)
+            ? buildSplitCues(units)
             : units
                 .map(
                     (unit) =>
                         `${unit.id}
-${formatTime(unit.startTime)} --> ${formatTime(unit.endTime)}
+${formatTimecode(unit.startTime)} --> ${formatTimecode(unit.endTime)}
 ${unit.payload}
 
 `
@@ -165,7 +161,7 @@ export const hasOverlappingCues = (cells: CodexNotebookAsJSONData["cells"]): boo
  * emits one cue containing the concatenated text of all units active in that time range.
  * Cue is active in [tStart, tEnd) when unit.startTime < tEnd && unit.endTime > tStart.
  */
-function buildSplitCues(units: ProcessedUnit[], formatTime: (s: number) => string): string {
+function buildSplitCues(units: ProcessedUnit[]): string {
     const timestamps = new Set<number>();
     for (const unit of units) {
         timestamps.add(unit.startTime);
@@ -187,7 +183,7 @@ function buildSplitCues(units: ProcessedUnit[], formatTime: (s: number) => strin
         const text = active.map((unit) => unit.payload).join("\n");
         const cueId = `${active[0].id}-split`;
         parts.push(`${cueId}
-${formatTime(tStart)} --> ${formatTime(tEnd)}
+${formatTimecode(tStart)} --> ${formatTimecode(tEnd)}
 ${text}
 
 `);

--- a/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
@@ -7,7 +7,7 @@ import ScrollToContentContext from "./contextProviders/ScrollToContentContext";
 import { WebviewApi } from "vscode-webview";
 import ValidationButton from "./ValidationButton";
 import AudioValidationButton from "./AudioValidationButton";
-import { shouldDisableValidation } from "@sharedUtils";
+import { shouldDisableValidation, formatTimecode } from "@sharedUtils";
 import { Button } from "../components/ui/button";
 import { getTranslationStyle, CellTranslationState } from "./CellTranslationStyles";
 import { CELL_DISPLAY_MODES } from "../lib/types";
@@ -559,13 +559,13 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                             {cell.timestamps.startTime !== undefined &&
                             cell.timestamps.endTime !== undefined ? (
                                 <span>
-                                    {formatTime(cell.timestamps.startTime)} →{" "}
-                                    {formatTime(cell.timestamps.endTime)}
+                                    {formatTimecode(cell.timestamps.startTime)} →{" "}
+                                    {formatTimecode(cell.timestamps.endTime)}
                                 </span>
                             ) : cell.timestamps.startTime !== undefined ? (
-                                <span>Start: {formatTime(cell.timestamps.startTime)}</span>
+                                <span>Start: {formatTimecode(cell.timestamps.startTime)}</span>
                             ) : cell.timestamps.endTime !== undefined ? (
-                                <span>End: {formatTime(cell.timestamps.endTime)}</span>
+                                <span>End: {formatTimecode(cell.timestamps.endTime)}</span>
                             ) : null}
                         </div>
                     );
@@ -1156,15 +1156,5 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
         );
     }
 );
-
-// Helper function to format time in MM:SS.mmm format
-const formatTime = (timeInSeconds: number): string => {
-    const minutes = Math.floor(timeInSeconds / 60);
-    const seconds = Math.floor(timeInSeconds % 60);
-    const milliseconds = Math.floor((timeInSeconds % 1) * 1000);
-    return `${minutes.toString().padStart(2, "0")}:${seconds
-        .toString()
-        .padStart(2, "0")}.${milliseconds.toString().padStart(3, "0")}`;
-};
 
 export default CellContentDisplay;

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -10,6 +10,7 @@ import {
 import type { ReactPlayerRef } from "./types/reactPlayerTypes";
 import Editor, { EditorHandles } from "./Editor";
 import { getCleanedHtml } from "./utils";
+import { formatTimecode } from "@sharedUtils";
 import { CodexCellTypes } from "../../../../types/enums";
 import { AddParatextButton } from "./AddParatextButton";
 import ReactMarkdown from "react-markdown";
@@ -4103,8 +4104,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                     }}
                 />
                 <div className="flex justify-between text-xs text-muted-foreground mt-4">
-                    <span>Min: {formatTime(audioMinBound)}</span>
-                    <span>Max: {formatTime(audioMaxBound)}</span>
+                    <span>Min: {formatTimecode(audioMinBound)}</span>
+                    <span>Max: {formatTimecode(audioMaxBound)}</span>
                 </div>
             </>
         );
@@ -4210,8 +4211,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         }}
                     />
                     <div className="flex justify-between text-xs text-muted-foreground mt-2">
-                        <span>Min: {formatTime(Math.max(0, previousEndBound))}</span>
-                        <span>Max: {formatTime(computedMaxBound)}</span>
+                        <span>Min: {formatTimecode(Math.max(0, previousEndBound))}</span>
+                        <span>Max: {formatTimecode(computedMaxBound)}</span>
                     </div>
                 </>
             );
@@ -5092,7 +5093,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             />
                                                             <div className="flex min-w-max text-xs text-muted-foreground">
                                                                 <span>
-                                                                    End: {formatTime(prevEndTime)}
+                                                                    End: {formatTimecode(prevEndTime)}
                                                                 </span>
                                                             </div>
                                                         </div>
@@ -5136,7 +5137,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             <div className="flex min-w-max text-xs text-muted-foreground">
                                                                 <span>
                                                                     End:{" "}
-                                                                    {formatTime(
+                                                                    {formatTimecode(
                                                                         prevAudioTimestamps.endTime
                                                                     )}
                                                                 </span>
@@ -5189,9 +5190,9 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                         undefined &&
                                                                     (effectiveTimestamps.endTime as number) >
                                                                         (effectiveTimestamps.startTime as number)
-                                                                        ? `${formatTime(
+                                                                        ? `${formatTimecode(
                                                                               effectiveTimestamps.startTime as number
-                                                                          )} → ${formatTime(
+                                                                          )} → ${formatTimecode(
                                                                               effectiveTimestamps.endTime as number
                                                                           )}`
                                                                         : ""}
@@ -5226,9 +5227,9 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                         undefined &&
                                                                     (effectiveAudioTimestamps.endTime as number) >
                                                                         (effectiveAudioTimestamps.startTime as number)
-                                                                        ? `${formatTime(
+                                                                        ? `${formatTimecode(
                                                                               effectiveAudioTimestamps.startTime as number
-                                                                          )} → ${formatTime(
+                                                                          )} → ${formatTimecode(
                                                                               effectiveAudioTimestamps.endTime as number
                                                                           )}`
                                                                         : ""}
@@ -5281,7 +5282,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             <div className="flex min-w-max text-xs text-muted-foreground">
                                                                 <span>
                                                                     Start:{" "}
-                                                                    {formatTime(nextStartTime)}
+                                                                    {formatTimecode(nextStartTime)}
                                                                 </span>
                                                             </div>
                                                         </div>
@@ -5330,7 +5331,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             <div className="flex min-w-max text-xs text-muted-foreground">
                                                                 <span>
                                                                     Start:{" "}
-                                                                    {formatTime(
+                                                                    {formatTimecode(
                                                                         nextAudioTimestamps.startTime
                                                                     )}
                                                                 </span>
@@ -5930,16 +5931,6 @@ const CellEditor: React.FC<CellEditorProps> = ({
             )}
         </Card>
     );
-};
-
-// Helper function to format time in MM:SS.mmm format
-const formatTime = (timeInSeconds: number): string => {
-    const minutes = Math.floor(timeInSeconds / 60);
-    const seconds = Math.floor(timeInSeconds % 60);
-    const milliseconds = Math.floor((timeInSeconds % 1) * 1000);
-    return `${minutes.toString().padStart(2, "0")}:${seconds
-        .toString()
-        .padStart(2, "0")}.${milliseconds.toString().padStart(3, "0")}`;
 };
 
 export default CellEditor;

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.buttonOrder.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.buttonOrder.test.tsx
@@ -21,7 +21,8 @@ Object.defineProperty(window, "vscodeApi", {
 global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
 
 // Mock @sharedUtils
-vi.mock("@sharedUtils", () => ({
+vi.mock("@sharedUtils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@sharedUtils")>()),
     shouldDisableValidation: vi.fn().mockReturnValue(false),
 }));
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.lockUnlock.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellContentDisplay.lockUnlock.test.tsx
@@ -21,7 +21,8 @@ Object.defineProperty(window, "vscodeApi", {
 global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
 
 // Mock @sharedUtils
-vi.mock("@sharedUtils", () => ({
+vi.mock("@sharedUtils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@sharedUtils")>()),
     shouldDisableValidation: vi.fn().mockReturnValue(false),
 }));
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellLineNumbers.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellLineNumbers.test.tsx
@@ -21,7 +21,8 @@ Object.defineProperty(window, "vscodeApi", {
 global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
 
 // Mock @sharedUtils
-vi.mock("@sharedUtils", () => ({
+vi.mock("@sharedUtils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@sharedUtils")>()),
     shouldDisableValidation: vi.fn().mockReturnValue(false),
 }));
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellList.footnoteOffset.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CellList.footnoteOffset.test.tsx
@@ -21,7 +21,8 @@ Object.defineProperty(window, "vscodeApi", {
 global.acquireVsCodeApi = vi.fn().mockReturnValue(mockVscode);
 
 // Mock @sharedUtils
-vi.mock("@sharedUtils", () => ({
+vi.mock("@sharedUtils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@sharedUtils")>()),
     shouldDisableValidation: vi.fn().mockReturnValue(false),
 }));
 

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/CodexCellEditor.saveWorkflow.integration.test.tsx
@@ -144,7 +144,8 @@ beforeAll(() => {
 });
 
 // Mock @sharedUtils
-vi.mock("@sharedUtils", () => ({
+vi.mock("@sharedUtils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@sharedUtils")>()),
     shouldDisableValidation: vi.fn().mockReturnValue(false),
     getCellValueData: vi.fn(),
 }));

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/vttUtils.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/vttUtils.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { QuillCellContent } from "../../../../../types";
-import { removeHtmlTags } from "@sharedUtils";
+import { removeHtmlTags, formatTimecode } from "@sharedUtils";
 
 export const useSubtitleData = (translationUnits: QuillCellContent[]) => {
     const subtitleData = useMemo(() => {
@@ -28,11 +28,6 @@ export const generateVttData = (
 ): string => {
     if (!translationUnits.length) return "";
 
-    const formatTime = (seconds: number): string => {
-        const date = new Date(seconds * 1000);
-        return date.toISOString().substr(11, 12);
-    };
-
     const cues = translationUnits
         .filter((unit) => !!unit.timestamps)
         .map((unit, index) => {
@@ -44,7 +39,7 @@ export const generateVttData = (
                 ? `<v ${escapeVoiceName(rawLabel)}>${body}</v>`
                 : body;
             return `${unit.cellMarkers[0]}
-${formatTime(Number(startTime))} --> ${formatTime(Number(endTime))}
+${formatTimecode(Number(startTime))} --> ${formatTimecode(Number(endTime))}
 ${payload}
 
 `;

--- a/webviews/codex-webviews/src/timeUtils.test.ts
+++ b/webviews/codex-webviews/src/timeUtils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { formatTimecode } from "../../../sharedUtils/timeUtils";
+
+describe("formatTimecode", () => {
+    it("formats zero", () => {
+        expect(formatTimecode(0)).toBe("00:00:00.000");
+    });
+
+    it("formats sub-minute times", () => {
+        expect(formatTimecode(41.875)).toBe("00:00:41.875");
+        expect(formatTimecode(51.51)).toBe("00:00:51.510");
+    });
+
+    it("rounds float artifacts instead of truncating", () => {
+        // 64.94 % 1 === 0.9399999..., which Math.floor-based formatting
+        // renders as .939 — the VTT export and display must both say .940
+        expect(formatTimecode(64.94)).toBe("00:01:04.940");
+    });
+
+    it("includes the hours place past one hour", () => {
+        expect(formatTimecode(4026.485)).toBe("01:07:06.485");
+    });
+
+    it("carries rounding across unit boundaries", () => {
+        expect(formatTimecode(59.9996)).toBe("00:01:00.000");
+        expect(formatTimecode(3599.9999)).toBe("01:00:00.000");
+    });
+
+    it("guards against invalid input", () => {
+        expect(formatTimecode(NaN)).toBe("00:00:00.000");
+        expect(formatTimecode(Infinity)).toBe("00:00:00.000");
+        expect(formatTimecode(-1)).toBe("00:00:00.000");
+    });
+});


### PR DESCRIPTION
## Summary

Closes #1048

Timestamps in the editor webview were displayed as total-minutes (`MM:SS.mmm`) with no hours place, causing cells past the 1-hour mark to look completely different from the VTT export (e.g. `67:06.485` in the editor vs `01:07:06.485` in the VTT). A secondary float-truncation bug also caused 21 timestamps across the project to be off by 1ms in both the display and the export. This PR consolidates all four time formatters onto a single shared `formatTimecode` utility that always emits `HH:MM:SS.mmm` and rounds via integer milliseconds to avoid float artifacts.

## Changes

- Added `sharedUtils/timeUtils.ts` — new `formatTimecode(seconds)` utility shared across extension host and webviews
- `src/exportHandler/vttUtils.ts` — replaced inline `Date`-based formatter with `formatTimecode`; removed `formatTime` parameter threading through `buildSplitCues`
- `webviews/codex-webviews/src/CodexCellEditor/utils/vttUtils.ts` — same, unifying the in-editor VTT preview with the export
- `CellContentDisplay.tsx` — replaced local `formatTime` (MM:SS.mmm, no hours) with `formatTimecode`
- `TextCellEditor.tsx` — same for the Timestamps tab and audio bounds display
- Updated 5 test files to use vitest `importOriginal` partial-mock pattern so the new `formatTimecode` export is visible in existing `@sharedUtils` mocks

## Testing Checklist

### Editor timestamp display
- [x] Cell **under 1 hour** (e.g. first cue at ~41s) — header shows `00:00:41.875`, not `00:41.875`
- [x] Cell **over 1 hour** (scroll near end, ~4026s) — header shows `01:07:06.485`, not `67:06.485`
- [x] Timestamps tab for any cell also uses `HH:MM:SS.mmm` format
- [x] Cell with known float case (stored `64.940`) — editor shows `00:01:04.940`, not `00:01:04.939`

### VTT export
- [x] Export project as "subtitles-vtt-with-styles"
- [x] Exported `.vtt` timestamps match what the editor displays (same `HH:MM:SS.mmm` format)
- [x] Spot-check 3–5 cues against raw `.codex` `metadata.data.startTime` — values match to the millisecond
- [x] Previously-off timestamps now correct (e.g. `00:08:32.387` not `00:08:32.386`)

### In-editor VTT preview
- [x] Subtitle overlay still syncs correctly to video playback position

### Regression: audio duration display
- [x] Waveform canvas time labels still show short `M:SS` format (audio formatters were intentionally left unchanged)