### PR TITLE
Cancel export and media download strategy improvement

### DIFF
--- a/src/exportHandler/audioAttachmentUtils.ts
+++ b/src/exportHandler/audioAttachmentUtils.ts
@@ -127,6 +127,62 @@ export function getCellAudioState(cell: unknown): CellAudioState {
 }
 
 /**
+ * Counts a cell's *other* usable audio takes — non-deleted, not flagged
+ * `isMissing`, with a url — excluding the given attachment id.
+ *
+ * Used at export time to tell the user, when their selected take can't be
+ * resolved, whether the cell still has recordings they could switch to (vs.
+ * needing a re-record / re-sync). Unlike `pickAudioAttachment` — which ignores
+ * `isMissing` on purpose so the resolver gets the final say — this DOES honor
+ * `isMissing`, because here we only want to point the user at takes that are
+ * likely to actually resolve.
+ */
+export function countAvailableAlternativeTakes(cell: unknown, excludeId: string): number {
+    const meta = (cell as { metadata?: Record<string, unknown> } | undefined)?.metadata;
+    if (!meta || typeof meta !== "object") return 0;
+
+    const attachments = (meta as { attachments?: Record<string, unknown> }).attachments;
+    if (!attachments || typeof attachments !== "object") return 0;
+
+    let count = 0;
+    for (const [attId, attVal] of Object.entries(attachments)) {
+        if (attId === excludeId) continue;
+        if (!attVal || typeof attVal !== "object") continue;
+        const att = attVal as {
+            type?: string;
+            isDeleted?: boolean;
+            isMissing?: boolean;
+            url?: string;
+        };
+        if (att.type !== "audio") continue;
+        if (att.isDeleted) continue;
+        if (att.isMissing) continue;
+        if (!att.url || typeof att.url !== "string") continue;
+        count++;
+    }
+    return count;
+}
+
+/**
+ * Returns true when the given attachment on a cell is flagged `isMissing`.
+ *
+ * `pickAudioAttachment` deliberately ignores this flag (the resolver gets the
+ * final say at access time), so a selected take whose bytes are flagged missing
+ * still resolves as `"ready"`. The Step 1 pre-flight uses this to warn that the
+ * selected take is *possibly* missing — the flag is a stale migration-scan hint,
+ * so the export may still recover it, but the user should know before committing.
+ */
+export function isTakeFlaggedMissing(cell: unknown, attachmentId: string): boolean {
+    const meta = (cell as { metadata?: Record<string, unknown> } | undefined)?.metadata;
+    if (!meta || typeof meta !== "object") return false;
+    const attachments = (meta as { attachments?: Record<string, unknown> }).attachments;
+    if (!attachments || typeof attachments !== "object") return false;
+    const att = (attachments as Record<string, unknown>)[attachmentId];
+    if (!att || typeof att !== "object") return false;
+    return (att as { isMissing?: boolean }).isMissing === true;
+}
+
+/**
  * Returns true when a cell is an audio recording target. Mirrors the predicate
  * used by `computeDialogueLineNumbers` in `audioExporter.ts` so chapter-start
  * milestones and paratext (book intros, headings, etc.) are never counted as

--- a/src/exportHandler/audioAttachmentUtils.ts
+++ b/src/exportHandler/audioAttachmentUtils.ts
@@ -127,17 +127,14 @@ export function getCellAudioState(cell: unknown): CellAudioState {
 }
 
 /**
- * Counts a cell's *other* usable audio takes — non-deleted, not flagged
- * `isMissing`, with a url — excluding the given attachment id.
+ * Counts a cell's usable audio takes — non-deleted, NOT flagged `isMissing`,
+ * with a url — optionally excluding one attachment id.
  *
- * Used at export time to tell the user, when their selected take can't be
- * resolved, whether the cell still has recordings they could switch to (vs.
- * needing a re-record / re-sync). Unlike `pickAudioAttachment` — which ignores
- * `isMissing` on purpose so the resolver gets the final say — this DOES honor
- * `isMissing`, because here we only want to point the user at takes that are
- * likely to actually resolve.
+ * Unlike `pickAudioAttachment` — which ignores `isMissing` on purpose so the
+ * resolver gets the final say — this DOES honor `isMissing`, because callers
+ * here only care about takes likely to actually resolve.
  */
-export function countAvailableAlternativeTakes(cell: unknown, excludeId: string): number {
+function countUsableTakes(cell: unknown, excludeId?: string): number {
     const meta = (cell as { metadata?: Record<string, unknown> } | undefined)?.metadata;
     if (!meta || typeof meta !== "object") return 0;
 
@@ -146,7 +143,7 @@ export function countAvailableAlternativeTakes(cell: unknown, excludeId: string)
 
     let count = 0;
     for (const [attId, attVal] of Object.entries(attachments)) {
-        if (attId === excludeId) continue;
+        if (excludeId !== undefined && attId === excludeId) continue;
         if (!attVal || typeof attVal !== "object") continue;
         const att = attVal as {
             type?: string;
@@ -161,6 +158,34 @@ export function countAvailableAlternativeTakes(cell: unknown, excludeId: string)
         count++;
     }
     return count;
+}
+
+/**
+ * Counts a cell's *other* usable audio takes — non-deleted, not flagged
+ * `isMissing`, with a url — excluding the given attachment id.
+ *
+ * Used at export time to tell the user, when their selected take can't be
+ * resolved, whether the cell still has recordings they could switch to (vs.
+ * needing a re-record / re-sync).
+ */
+export function countAvailableAlternativeTakes(cell: unknown, excludeId: string): number {
+    return countUsableTakes(cell, excludeId);
+}
+
+/**
+ * Counts a cell's usable audio takes (non-deleted, not flagged `isMissing`,
+ * with a url).
+ *
+ * Callers use `=== 0` to detect a cell whose only remaining takes are flagged
+ * missing: `pickAudioAttachment` would still report `none-selected` (it ignores
+ * `isMissing`), but there's nothing the user could actually pick that would
+ * resolve — so it's presented as "without audio" instead of "with audio, none
+ * selected". This is only applied to the unselected case; when a take is
+ * explicitly selected we still defer to the resolver (the flag may be stale),
+ * which is why it isn't folded into `pickAudioAttachment`.
+ */
+export function countUsableNonMissingTakes(cell: unknown): number {
+    return countUsableTakes(cell);
 }
 
 /**

--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -10,7 +10,7 @@ import { isLfsPointerContent, parsePointerContent } from "../utils/lfsHelpers";
 import { getCachedLfsBytes, setCachedLfsBytes } from "../utils/mediaCache";
 import { getMediaFilesStrategy } from "../utils/localProjectSettings";
 import type { ExportProgressReporter, ExportMissingReason } from "./exportProgress";
-import { pickAudioAttachment, isExportableCell, type AudioPick, type AudioPickOutcome } from "./audioAttachmentUtils";
+import { pickAudioAttachment, isExportableCell, countAvailableAlternativeTakes, type AudioPick, type AudioPickOutcome } from "./audioAttachmentUtils";
 import { formatCellDisplayLabel } from "./cellLabelUtils";
 import { CodexCellTypes } from "../../types/enums";
 import { buildMilestoneIndexModel } from "../../sharedUtils/milestoneIndexUtils";
@@ -723,6 +723,10 @@ export async function exportAudioAttachments(
     let notRecordedCount = 0;
     let noneSelectedCount = 0;
     let selectionMissingCount = 0;
+    // Selected take's bytes couldn't be resolved, but the cell has other usable
+    // recordings to switch to — counted separately (and reported as a warning)
+    // rather than folded into the hard "could not be resolved" total.
+    let selectedMissingWithAltCount = 0;
 
     for (const [index, file] of selectedFiles.entries()) {
         // Stop before starting another book once cancellation is requested.
@@ -877,6 +881,13 @@ export async function exportAudioAttachments(
             originalExt: string;
             start?: number;
             end?: number;
+            /**
+             * How many *other* usable takes (non-deleted, non-missing) the cell
+             * has. When the selected take fails to resolve, a value > 0 means
+             * the user can recover by selecting a different take — surfaced as a
+             * warning rather than a hard "could not be resolved" error.
+             */
+            alternativeTakeCount: number;
         };
 
         const tasks: AudioExportTask[] = [];
@@ -940,6 +951,7 @@ export async function exportAudioAttachments(
                 originalExt,
                 start,
                 end,
+                alternativeTakeCount: countAvailableAlternativeTakes(cell, pick.id),
             });
         }
 
@@ -1027,13 +1039,29 @@ export async function exportAudioAttachments(
                 const isPointerCorrupt = err.includes("Invalid LFS pointer");
                 if (task.cellLabel) {
                     if (isStreamFailure) streamFailCount++;
-                    const reason: ExportMissingReason = isStreamFailure
-                        ? "download-failed"
-                        : isPointerCorrupt
-                            ? "pointer-corrupt"
-                            : "audio-file-missing";
-                    reporter.fileMissing(task.cellLabel, reason, err);
-                    missingCount++;
+                    // When the selected take simply can't be found (not a stream
+                    // or pointer error) but the cell has other usable takes, the
+                    // user can recover by re-selecting — report it as a warning
+                    // and keep it out of the hard "could not be resolved" total.
+                    const recoverableViaOtherTake =
+                        !isStreamFailure && !isPointerCorrupt && task.alternativeTakeCount > 0;
+                    if (recoverableViaOtherTake) {
+                        const n = task.alternativeTakeCount;
+                        reporter.fileMissing(
+                            task.cellLabel,
+                            "selected-audio-missing-alternatives",
+                            `The recording selected for this cell is missing, but the cell has ${n} other recording${n === 1 ? "" : "s"} available. Open the cell to select a different take.`
+                        );
+                        selectedMissingWithAltCount++;
+                    } else {
+                        const reason: ExportMissingReason = isStreamFailure
+                            ? "download-failed"
+                            : isPointerCorrupt
+                                ? "pointer-corrupt"
+                                : "audio-file-missing";
+                        reporter.fileMissing(task.cellLabel, reason, err);
+                        missingCount++;
+                    }
                 }
                 continue;
             }
@@ -1159,7 +1187,8 @@ export async function exportAudioAttachments(
         `Export summary: ${copiedCount} files copied, ${missingCount} skipped, ` +
         `${streamFailCount} stream failures, ${notRecordedCount} cells without recorded audio, ` +
         `${noneSelectedCount} cells with audio but none selected, ` +
-        `${selectionMissingCount} cells with selected audio missing`
+        `${selectionMissingCount} cells with selected audio missing, ` +
+        `${selectedMissingWithAltCount} selected take missing with alternatives available`
     );
 
     if (streamFailCount > 0 && copiedCount === 0) {
@@ -1175,6 +1204,9 @@ export async function exportAudioAttachments(
     if (streamFailCount > 0) summaryParts.push(`${streamFailCount} failed to download`);
     if (missingCount - streamFailCount > 0) {
         summaryParts.push(`${missingCount - streamFailCount} could not be resolved`);
+    }
+    if (selectedMissingWithAltCount > 0) {
+        summaryParts.push(`${selectedMissingWithAltCount} with selected take missing (other takes available)`);
     }
     if (notRecordedCount > 0) summaryParts.push(`${notRecordedCount} cells without recorded audio`);
     if (noneSelectedCount > 0) summaryParts.push(`${noneSelectedCount} cells with audio, none selected`);

--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -514,6 +514,109 @@ export function tokenToAbortSignal(
 }
 
 /**
+ * Sleeps for `ms`, resolving early (without throwing) if the signal aborts —
+ * so a cancellation during a retry backoff doesn't have to wait out the delay.
+ */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+        if (signal?.aborted) {
+            resolve();
+            return;
+        }
+        const timer = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timer);
+            resolve();
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+    });
+}
+
+/**
+ * Decides whether a failed LFS download is worth retrying. Transient
+ * server/network hiccups (5xx, 429, timeouts, reset connections) usually
+ * succeed on a second attempt; permanent conditions (404, auth, a corrupt
+ * pointer, or a user-initiated abort) do not, so we fail fast on those.
+ */
+function isRetryableDownloadError(error: unknown, signal?: AbortSignal): boolean {
+    // Never retry something the user cancelled.
+    if (signal?.aborted) return false;
+    const name = (error as { name?: string; })?.name;
+    if (name === "AbortError") return false;
+
+    const message = error instanceof Error ? error.message : String(error ?? "");
+    const haystack = message.toLowerCase();
+
+    // Permanent / non-retryable signals — bail out immediately.
+    if (/\b(400|401|403|404|409|410|422)\b/.test(message)) return false;
+    if (haystack.includes("invalid lfs pointer")) return false;
+
+    // Transient signals worth another attempt.
+    return (
+        /\b(429|500|502|503|504)\b/.test(message) ||
+        haystack.includes("internal server error") ||
+        haystack.includes("bad gateway") ||
+        haystack.includes("service unavailable") ||
+        haystack.includes("gateway timeout") ||
+        haystack.includes("timeout") ||
+        haystack.includes("timed out") ||
+        haystack.includes("econnreset") ||
+        haystack.includes("econnrefused") ||
+        haystack.includes("etimedout") ||
+        haystack.includes("enotfound") ||
+        haystack.includes("socket hang up") ||
+        haystack.includes("network") ||
+        haystack.includes("fetch failed")
+    );
+}
+
+/** Max LFS download attempts (1 initial + retries) and the base backoff. */
+const LFS_DOWNLOAD_MAX_ATTEMPTS = 4;
+const LFS_DOWNLOAD_BACKOFF_BASE_MS = 600;
+
+/**
+ * Downloads an LFS object with bounded exponential backoff + jitter. The
+ * Frontier server occasionally returns a transient 500 for an object that
+ * downloads fine moments later; retrying here lets a whole-project audio
+ * export ride over those blips instead of surfacing them as "couldn't be
+ * downloaded" and forcing a manual retry.
+ */
+async function downloadLfsWithRetry(
+    frontierApi: { downloadLFSFile: (projectPath: string, oid: string, size: number, signal?: AbortSignal) => Promise<Uint8Array>; },
+    projectPath: string,
+    oid: string,
+    size: number,
+    signal?: AbortSignal
+): Promise<Uint8Array> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= LFS_DOWNLOAD_MAX_ATTEMPTS; attempt++) {
+        try {
+            return await frontierApi.downloadLFSFile(projectPath, oid, size, signal);
+        } catch (error) {
+            lastError = error;
+            const canRetry =
+                attempt < LFS_DOWNLOAD_MAX_ATTEMPTS &&
+                isRetryableDownloadError(error, signal);
+            if (!canRetry) break;
+            // Exponential backoff (0.6s, 1.2s, 2.4s …) with up to 50% jitter to
+            // avoid 30 concurrent workers hammering the server in lockstep.
+            const base = LFS_DOWNLOAD_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+            const wait = base + Math.floor(Math.random() * base * 0.5);
+            debug(
+                `LFS download for ${oid} failed (attempt ${attempt}/${LFS_DOWNLOAD_MAX_ATTEMPTS}), ` +
+                `retrying in ${wait}ms: ${error instanceof Error ? error.message : String(error)}`
+            );
+            await delay(wait, signal);
+            if (signal?.aborted) break;
+        }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
  * Runs async tasks with a sliding-window concurrency pool.
  * Keeps exactly `concurrency` tasks active at all times — as soon as one
  * finishes, the next pending task starts immediately.
@@ -616,7 +719,9 @@ async function resolveAudioBytes(
             return { error: "Frontier API not available — cannot stream audio for export" };
         }
 
-        const lfsData = await frontierApi.downloadLFSFile(projectPath, pointer.oid, pointer.size, signal);
+        const lfsData = await downloadLfsWithRetry(
+            frontierApi, projectPath, pointer.oid, pointer.size, signal
+        );
         setCachedLfsBytes(pointer.oid, lfsData);
         return { data: lfsData };
     };
@@ -742,8 +847,9 @@ export async function exportAudioAttachments(
         if (token?.isCancellationRequested) break;
         reporter.report({
             stage: "processing",
+            // Count lives in the title; `file` is omitted so the book name isn't
+            // echoed again on the secondary line.
             message: `Processing ${basename(file.fsPath)} (${index + 1}/${selectedFiles.length})`,
-            file: basename(file.fsPath),
             current: index + 1,
             total: selectedFiles.length,
         });
@@ -1014,10 +1120,13 @@ export async function exportAudioAttachments(
                 return { data: resolved.data };
             },
             (completed, total) => {
+                // Downloads run concurrently, so there's no single "current"
+                // file — surface the recording count (in the title) and omit
+                // `file` so the secondary line doesn't show the misleading
+                // ".codex" name (which isn't what's being downloaded).
                 reporter.report({
                     stage: "downloading",
-                    message: `${basename(file.fsPath)}: downloading audio (${completed}/${total})`,
-                    file: basename(file.fsPath),
+                    message: `Downloading ${bookCode} audio (${completed}/${total})`,
                     current: completed,
                     total,
                 });
@@ -1037,8 +1146,10 @@ export async function exportAudioAttachments(
 
             reporter.report({
                 stage: "writing",
-                message: `${basename(file.fsPath)}: writing audio (${ti + 1}/${tasks.length})`,
-                file: basename(file.fsPath),
+                // Writing is sequential per cell, so the secondary line can show
+                // the specific cell being written; the count stays in the title.
+                message: `Writing ${bookCode} audio (${ti + 1}/${tasks.length})`,
+                file: task.cellLabel ?? undefined,
                 current: ti + 1,
                 total: tasks.length,
             });

--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -473,15 +473,52 @@ async function prepareAudioForExport(
 const EXPORT_CONCURRENCY = 30;
 
 /**
+ * Error used to mark a concurrency-pool slot that was never run because the
+ * export was cancelled. Callers can recognise it to suppress per-cell failure
+ * reporting for work that simply never started.
+ */
+export class ExportCancelledError extends Error {
+    constructor(message = "Export cancelled") {
+        super(message);
+        this.name = "ExportCancelledError";
+    }
+}
+
+/**
+ * Bridges a VS Code `CancellationToken` to a DOM `AbortSignal` so it can be
+ * handed to fetch-based APIs (e.g. the Frontier LFS download). The returned
+ * `dispose` must be called to detach the listener and avoid leaks.
+ */
+export function tokenToAbortSignal(
+    token?: vscode.CancellationToken
+): { signal: AbortSignal | undefined; dispose: () => void; } {
+    if (!token) {
+        return { signal: undefined, dispose: () => undefined };
+    }
+    const controller = new AbortController();
+    if (token.isCancellationRequested) {
+        controller.abort();
+        return { signal: controller.signal, dispose: () => undefined };
+    }
+    const sub = token.onCancellationRequested(() => controller.abort());
+    return { signal: controller.signal, dispose: () => sub.dispose() };
+}
+
+/**
  * Runs async tasks with a sliding-window concurrency pool.
  * Keeps exactly `concurrency` tasks active at all times — as soon as one
  * finishes, the next pending task starts immediately.
+ *
+ * When `token` is cancelled, workers stop pulling new items; any items that
+ * were never started are recorded as rejected with `ExportCancelledError` so
+ * the results array stays dense (one entry per input item).
  */
 export async function runWithConcurrencyPool<T, R>(
     items: T[],
     concurrency: number,
     processor: (item: T, index: number) => Promise<R>,
-    onProgress?: (completed: number, total: number) => void
+    onProgress?: (completed: number, total: number) => void,
+    token?: vscode.CancellationToken
 ): Promise<Array<PromiseSettledResult<R>>> {
     const results: Array<PromiseSettledResult<R>> = new Array(items.length);
     let nextIndex = 0;
@@ -490,6 +527,13 @@ export async function runWithConcurrencyPool<T, R>(
     const runWorker = async (): Promise<void> => {
         let idx = nextIndex++;
         while (idx < items.length) {
+            if (token?.isCancellationRequested) {
+                // Stop scheduling new work; keep the slot dense so the
+                // downstream write loop never reads `undefined`.
+                results[idx] = { status: "rejected", reason: new ExportCancelledError() };
+                idx = nextIndex++;
+                continue;
+            }
             try {
                 const value = await processor(items[idx], idx);
                 results[idx] = { status: "fulfilled", value };
@@ -540,7 +584,8 @@ type ResolveResult =
 async function resolveAudioBytes(
     absoluteSrc: vscode.Uri,
     workspaceFolderUri: vscode.Uri,
-    frontierApi: { downloadLFSFile: (projectPath: string, oid: string, size: number) => Promise<Uint8Array>; } | null
+    frontierApi: { downloadLFSFile: (projectPath: string, oid: string, size: number, signal?: AbortSignal) => Promise<Uint8Array>; } | null,
+    signal?: AbortSignal
 ): Promise<ResolveResult> {
     const projectPath = workspaceFolderUri.fsPath;
 
@@ -562,7 +607,7 @@ async function resolveAudioBytes(
             return { error: "Frontier API not available — cannot stream audio for export" };
         }
 
-        const lfsData = await frontierApi.downloadLFSFile(projectPath, pointer.oid, pointer.size);
+        const lfsData = await frontierApi.downloadLFSFile(projectPath, pointer.oid, pointer.size, signal);
         setCachedLfsBytes(pointer.oid, lfsData);
         return { data: lfsData };
     };
@@ -607,8 +652,13 @@ export async function exportAudioAttachments(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportAudioOptions
+    options?: ExportAudioOptions,
+    token?: vscode.CancellationToken
 ): Promise<void> {
+    // The host owns the CancellationTokenSource and disposes it when the export
+    // settles, which also detaches the listener this signal registers — so an
+    // early return without an explicit dispose does not leak.
+    const { signal: abortSignal } = tokenToAbortSignal(token);
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) {
         reporter.error("No project folder found. Please open a project first.");
@@ -632,7 +682,7 @@ export async function exportAudioAttachments(
     const mayNeedStreaming = mediaStrategy === "stream-only" || mediaStrategy === "stream-and-save";
 
     // Obtain the Frontier API for LFS downloads (may be null if not available)
-    let frontierApi: { downloadLFSFile: (projectPath: string, oid: string, size: number) => Promise<Uint8Array>; } | null = null;
+    let frontierApi: { downloadLFSFile: (projectPath: string, oid: string, size: number, signal?: AbortSignal) => Promise<Uint8Array>; } | null = null;
     if (mayNeedStreaming) {
         // Enforce version gates before attempting any LFS operations
         try {
@@ -675,6 +725,8 @@ export async function exportAudioAttachments(
     let selectionMissingCount = 0;
 
     for (const [index, file] of selectedFiles.entries()) {
+        // Stop before starting another book once cancellation is requested.
+        if (token?.isCancellationRequested) break;
         reporter.report({
             stage: "processing",
             message: `Processing ${basename(file.fsPath)} (${index + 1}/${selectedFiles.length})`,
@@ -910,7 +962,7 @@ export async function exportAudioAttachments(
             async (task) => {
                 debug(`Cell ${task.cellId}: downloading ${task.absoluteSrc.fsPath}`);
                 const resolved = await resolveAudioBytes(
-                    task.absoluteSrc, workspaceFolder.uri, frontierApi
+                    task.absoluteSrc, workspaceFolder.uri, frontierApi, abortSignal
                 );
                 if (resolved.error || !resolved.data) {
                     return { error: resolved.error ?? "No data returned" };
@@ -925,12 +977,17 @@ export async function exportAudioAttachments(
                     current: completed,
                     total,
                 });
-            }
+            },
+            token
         );
 
         // Phase 2b: Convert and write each file (CPU/disk-bound, sequential
         // to avoid FFmpeg contention and show per-file progress).
         for (let ti = 0; ti < tasks.length; ti++) {
+            // Stop writing the moment cancellation is requested. The
+            // isMissing reconciliation below still runs for whatever already
+            // resolved, and the orchestrator deletes the partial folder.
+            if (token?.isCancellationRequested) break;
             const task = tasks[ti];
             const dlResult = downloadResults[ti];
 
@@ -943,6 +1000,11 @@ export async function exportAudioAttachments(
             });
 
             if (dlResult.status === "rejected") {
+                // A slot skipped because of cancellation is not a real
+                // failure — don't report it as a missing/failed cell.
+                if (dlResult.reason instanceof ExportCancelledError) {
+                    continue;
+                }
                 console.error("Failed to download audio:", dlResult.reason);
                 if (task.cellLabel) {
                     reporter.fileMissing(
@@ -1084,6 +1146,13 @@ export async function exportAudioAttachments(
                 err
             );
         }
+    }
+
+    // Cancelled: skip the terminal summary entirely. The orchestrator
+    // (exportCodexContent) observes the token after Promise.all, deletes the
+    // partial export folder, and emits the single `cancelled` event.
+    if (token?.isCancellationRequested) {
+        return;
     }
 
     debug(

--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -10,7 +10,7 @@ import { isLfsPointerContent, parsePointerContent } from "../utils/lfsHelpers";
 import { getCachedLfsBytes, setCachedLfsBytes } from "../utils/mediaCache";
 import { getMediaFilesStrategy } from "../utils/localProjectSettings";
 import type { ExportProgressReporter, ExportMissingReason } from "./exportProgress";
-import { pickAudioAttachment, isExportableCell, countAvailableAlternativeTakes, type AudioPick, type AudioPickOutcome } from "./audioAttachmentUtils";
+import { pickAudioAttachment, isExportableCell, countAvailableAlternativeTakes, countUsableNonMissingTakes, type AudioPick, type AudioPickOutcome } from "./audioAttachmentUtils";
 import { formatCellDisplayLabel } from "./cellLabelUtils";
 import { CodexCellTypes } from "../../types/enums";
 import { buildMilestoneIndexModel } from "../../sharedUtils/milestoneIndexUtils";
@@ -34,6 +34,15 @@ function debug(...args: any[]) {
 type ExportAudioOptions = {
     includeTimestamps?: boolean;
     selectedMilestonesByFile?: Record<string, number[]>;
+    /**
+     * Targeted-retry filter: codex file fsPath → set of cellIds to (re)export.
+     * When present, only those cells are processed and written into the
+     * (existing) export folder; every other cell is skipped entirely — no
+     * tasks, no "no audio recorded" reporting. Used by "retry failed downloads"
+     * to re-attempt just the cells that failed, merging recovered files into
+     * the original export output.
+     */
+    retryCellFilter?: Map<string, Set<string>>;
 };
 
 type AudioCellData = {
@@ -740,6 +749,9 @@ export async function exportAudioAttachments(
         });
 
         const bookCode = basename(file.fsPath).split(".")[0] || "BOOK";
+        // Targeted retry: when set, only the listed cells in this file are
+        // processed (and merged into the existing export folder).
+        const retryFilter = options?.retryCellFilter?.get(file.fsPath);
         const milestoneSelection = options?.selectedMilestonesByFile;
         const milestoneFilter = milestoneSelection?.[file.fsPath];
         // Empty array means the user cleared every milestone for this file on step 3.
@@ -791,6 +803,8 @@ export async function exportAudioAttachments(
             if (!isExportableCell(cell)) continue;
             const cellId: string | undefined = cell?.metadata?.id;
             if (!cellId) continue;
+            // Targeted retry skips everything not on the retry list.
+            if (retryFilter && !retryFilter.has(cellId)) continue;
             const outcome = pickAudioAttachmentForCell(cell);
             if (outcome.state === "ready" && outcome.pick) {
                 audioCells.push({ cell, cellId, pick: outcome.pick });
@@ -816,6 +830,19 @@ export async function exportAudioAttachments(
                 continue;
             }
             if (outcome.state === "none-selected") {
+                // `none-selected` means non-deleted takes exist but none is
+                // picked. If every one of those takes is flagged `isMissing`,
+                // there's nothing the user could choose that would resolve —
+                // report it as "no audio recorded" rather than "none selected"
+                // (mirrors the Step 1 pre-flight in exportViewUtils.ts).
+                if (countUsableNonMissingTakes(cell) === 0) {
+                    reporter.fileMissing(label, "no-audio-recorded", undefined, {
+                        cellId,
+                        codexPath: file.fsPath,
+                    });
+                    notRecordedCount++;
+                    continue;
+                }
                 // There are valid takes on this cell but the user has
                 // never picked one (or their previous pick was cleared
                 // when its take was deleted). We refuse to auto-pick.

--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -809,7 +809,8 @@ export async function exportAudioAttachments(
                 reporter.fileMissing(
                     label,
                     "audio-file-missing",
-                    "The audio file you selected for this cell cannot be found. Open the cell to choose another take or re-record."
+                    "The audio file you selected for this cell cannot be found. Open the cell to choose another take or re-record.",
+                    { cellId, codexPath: file.fsPath }
                 );
                 selectionMissingCount++;
                 continue;
@@ -821,13 +822,17 @@ export async function exportAudioAttachments(
                 reporter.fileMissing(
                     label,
                     "no-audio-selected",
-                    "Audio is recorded for this cell but no take has been selected. Open the cell to choose which take to export."
+                    "Audio is recorded for this cell but no take has been selected. Open the cell to choose which take to export.",
+                    { cellId, codexPath: file.fsPath }
                 );
                 noneSelectedCount++;
                 continue;
             }
             // No usable attachment at all — Tier 1 informational.
-            reporter.fileMissing(label, "no-audio-recorded");
+            reporter.fileMissing(label, "no-audio-recorded", undefined, {
+                cellId,
+                codexPath: file.fsPath,
+            });
             notRecordedCount++;
         }
 
@@ -1022,7 +1027,8 @@ export async function exportAudioAttachments(
                     reporter.fileMissing(
                         task.cellLabel,
                         "download-failed",
-                        dlResult.reason ? String(dlResult.reason) : undefined
+                        dlResult.reason ? String(dlResult.reason) : undefined,
+                        { cellId: task.cellId, codexPath: file.fsPath }
                     );
                     streamFailCount++;
                     missingCount++;
@@ -1050,7 +1056,8 @@ export async function exportAudioAttachments(
                         reporter.fileMissing(
                             task.cellLabel,
                             "selected-audio-missing-alternatives",
-                            `The recording selected for this cell is missing, but the cell has ${n} other recording${n === 1 ? "" : "s"} available. Open the cell to select a different take.`
+                            `The recording selected for this cell is missing, but the cell has ${n} other recording${n === 1 ? "" : "s"} available. Open the cell to select a different take.`,
+                            { cellId: task.cellId, codexPath: file.fsPath }
                         );
                         selectedMissingWithAltCount++;
                     } else {
@@ -1059,7 +1066,10 @@ export async function exportAudioAttachments(
                             : isPointerCorrupt
                                 ? "pointer-corrupt"
                                 : "audio-file-missing";
-                        reporter.fileMissing(task.cellLabel, reason, err);
+                        reporter.fileMissing(task.cellLabel, reason, err, {
+                            cellId: task.cellId,
+                            codexPath: file.fsPath,
+                        });
                         missingCount++;
                     }
                 }
@@ -1089,7 +1099,8 @@ export async function exportAudioAttachments(
                         reporter.fileMissing(
                             task.cellLabel,
                             "transcode-failed",
-                            e instanceof Error ? e.message : String(e)
+                            e instanceof Error ? e.message : String(e),
+                            { cellId: task.cellId, codexPath: file.fsPath }
                         );
                         missingCount++;
                     }
@@ -1118,7 +1129,8 @@ export async function exportAudioAttachments(
                     reporter.fileMissing(
                         task.cellLabel,
                         "write-failed",
-                        e instanceof Error ? e.message : String(e)
+                        e instanceof Error ? e.message : String(e),
+                        { cellId: task.cellId, codexPath: file.fsPath }
                     );
                     missingCount++;
                 }

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -1644,7 +1644,7 @@ async function exportCodexContentAsRebuild(
     // a single overall summary at the bottom of this orchestrator.
     const childReporter: ExportProgressReporter = {
         report: (event) => reporter.report(event),
-        fileMissing: (file, reason, detail) => reporter.fileMissing(file, reason, detail),
+        fileMissing: (file, reason, detail, location) => reporter.fileMissing(file, reason, detail, location),
         complete: () => undefined,
         error: (message) => reporter.fileMissing(message, "error"),
         cancelled: () => undefined,
@@ -1762,9 +1762,9 @@ export async function exportCodexContent(
 
     const childReporter: ExportProgressReporter = {
         report: (event) => reporter.report(event),
-        fileMissing: (file, reason, detail) => {
-            aggregated.missingFiles.push({ file, reason, detail });
-            reporter.fileMissing(file, reason, detail);
+        fileMissing: (file, reason, detail, location) => {
+            aggregated.missingFiles.push({ file, reason, detail, ...location });
+            reporter.fileMissing(file, reason, detail, location);
         },
         complete: (summary) => {
             if (summary.extraMessages) aggregated.extraMessages.push(...summary.extraMessages);

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -1510,7 +1510,8 @@ async function exportCodexContentAsRebuild(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders) {
@@ -1526,6 +1527,7 @@ async function exportCodexContentAsRebuild(
 
     // Analyze each file's corpusMarker
     for (const filePath of filesToExport) {
+        if (token?.isCancellationRequested) return;
         try {
             const file = vscode.Uri.file(filePath);
             const codexNotebook = await readCodexNotebookFromUri(file);
@@ -1645,6 +1647,7 @@ async function exportCodexContentAsRebuild(
         fileMissing: (file, reason, detail) => reporter.fileMissing(file, reason, detail),
         complete: () => undefined,
         error: (message) => reporter.fileMissing(message, "error"),
+        cancelled: () => undefined,
     };
 
     let processedCount = 0;
@@ -1665,6 +1668,7 @@ async function exportCodexContentAsRebuild(
         ];
 
     for (const group of groups) {
+        if (token?.isCancellationRequested) return;
         const paths = filesByType[group.key];
         if (!paths || paths.length === 0) continue;
         console.log(`[Rebuild Export] Exporting ${paths.length} ${group.label} file(s)...`);
@@ -1711,7 +1715,8 @@ export async function exportCodexContent(
     userSelectedPath: string,
     filesToExport: string[],
     options?: ExportOptions,
-    reporter: ExportProgressReporter = createNoopReporter()
+    reporter: ExportProgressReporter = createNoopReporter(),
+    token?: vscode.CancellationToken
 ) {
     const includeAudio = options?.includeAudio === true && format !== CodexExportFormat.AUDIO;
     const isMulti = includeAudio;
@@ -1780,54 +1785,55 @@ export async function exportCodexContent(
         error: (message) => {
             aggregated.errorMessages.push(message);
         },
+        cancelled: () => undefined,
     };
 
     const exportPromises: Promise<void>[] = [];
 
     switch (format) {
         case CodexExportFormat.PLAINTEXT:
-            exportPromises.push(exportCodexContentAsPlaintext(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsPlaintext(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.USFM:
-            exportPromises.push(exportCodexContentAsUsfm(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsUsfm(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.HTML:
-            exportPromises.push(exportCodexContentAsHtml(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsHtml(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.AUDIO: {
             const { exportAudioAttachments } = await import("./audioExporter");
             exportPromises.push(exportAudioAttachments(wrapperPath, filesToExport, childReporter, {
                 includeTimestamps: options?.includeTimestamps,
                 selectedMilestonesByFile: options?.selectedMilestonesByFile,
-            }));
+            }, token));
             break;
         }
         case CodexExportFormat.SUBTITLES_VTT_WITH_STYLES:
-            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, true));
+            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, true, false, token));
             break;
         case CodexExportFormat.SUBTITLES_VTT_WITHOUT_STYLES:
-            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, false));
+            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, false, false, token));
             break;
         case CodexExportFormat.SUBTITLES_VTT_WITH_CUE_SPLITTING:
-            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, false, true));
+            exportPromises.push(exportCodexContentAsSubtitlesVtt(formatPath, filesToExport, childReporter, options, false, true, token));
             break;
         case CodexExportFormat.SUBTITLES_SRT:
-            exportPromises.push(exportCodexContentAsSubtitlesSrt(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsSubtitlesSrt(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.XLIFF:
-            exportPromises.push(exportCodexContentAsXliff(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsXliff(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.CSV:
-            exportPromises.push(exportCodexContentAsCsv(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsCsv(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.TSV:
-            exportPromises.push(exportCodexContentAsTsv(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsTsv(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.REBUILD_EXPORT:
-            exportPromises.push(exportCodexContentAsRebuild(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsRebuild(formatPath, filesToExport, childReporter, options, token));
             break;
         case CodexExportFormat.BACKTRANSLATIONS:
-            exportPromises.push(exportCodexContentAsBacktranslations(formatPath, filesToExport, childReporter, options));
+            exportPromises.push(exportCodexContentAsBacktranslations(formatPath, filesToExport, childReporter, options, token));
             break;
     }
 
@@ -1837,11 +1843,28 @@ export async function exportCodexContent(
             exportAudioAttachments(audioPath, filesToExport, childReporter, {
                 includeTimestamps: options?.includeTimestamps,
                 selectedMilestonesByFile: options?.selectedMilestonesByFile,
-            })
+            }, token)
         );
     }
 
     await Promise.all(exportPromises);
+
+    // If the user cancelled, delete the freshly-created (and unique) wrapper
+    // folder so no partial export is left behind, and report a terminal
+    // "cancelled" state instead of complete/error. All sub-export promises
+    // have already settled above, so there is no write/delete race here.
+    if (token?.isCancellationRequested) {
+        try {
+            await vscode.workspace.fs.delete(vscode.Uri.file(wrapperPath), {
+                recursive: true,
+                useTrash: false,
+            });
+        } catch (e) {
+            debug("Failed to delete partial export folder after cancellation:", e);
+        }
+        reporter.cancelled({ exportPath: wrapperPath });
+        return;
+    }
 
     // Write NOTICE.txt in per-file folders that will be empty due to missing content,
     // and emit fileMissing events for them so the webview sees a complete list.
@@ -1959,7 +1982,8 @@ export const exportCodexContentAsSubtitlesSrt = async (
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) => {
     try {
         debug("Starting exportCodexContentAsSubtitlesSrt function");
@@ -1982,6 +2006,7 @@ export const exportCodexContentAsSubtitlesSrt = async (
         await vscode.workspace.fs.createDirectory(exportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,
@@ -2028,7 +2053,8 @@ export const exportCodexContentAsSubtitlesVtt = async (
     reporter: ExportProgressReporter,
     options?: ExportOptions,
     includeStyles: boolean = true,
-    cueSplitting: boolean = false
+    cueSplitting: boolean = false,
+    token?: vscode.CancellationToken
 ) => {
     try {
         debug("Starting exportCodexContentAsSubtitlesVtt function");
@@ -2051,6 +2077,7 @@ export const exportCodexContentAsSubtitlesVtt = async (
         await vscode.workspace.fs.createDirectory(exportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,
@@ -2186,18 +2213,20 @@ async function exportCodexContentAsCsv(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
-    await exportCodexContentAsDelimited(userSelectedPath, filesToExport, 'csv', reporter, options);
+    await exportCodexContentAsDelimited(userSelectedPath, filesToExport, 'csv', reporter, options, token);
 }
 
 async function exportCodexContentAsTsv(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
-    await exportCodexContentAsDelimited(userSelectedPath, filesToExport, 'tsv', reporter, options);
+    await exportCodexContentAsDelimited(userSelectedPath, filesToExport, 'tsv', reporter, options, token);
 }
 
 async function exportCodexContentAsDelimited(
@@ -2205,7 +2234,8 @@ async function exportCodexContentAsDelimited(
     filesToExport: string[],
     format: 'csv' | 'tsv',
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
         const formatName = format.toUpperCase();
@@ -2237,6 +2267,7 @@ async function exportCodexContentAsDelimited(
         await vscode.workspace.fs.createDirectory(exportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,
@@ -2439,9 +2470,11 @@ async function exportCodexContentAsBacktranslations(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
+        if (token?.isCancellationRequested) return;
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders) {
             reporter.error("No project folder found. Please open a project first.");
@@ -2492,6 +2525,7 @@ async function exportCodexContentAsBacktranslations(
         let filesWritten = 0;
 
         for (const [targetPath, entries] of fileGroups) {
+            if (token?.isCancellationRequested) return;
             try {
                 reporter.report({
                     stage: "writing",

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -1891,6 +1891,7 @@ export async function exportCodexContent(
 
     reporter.complete({
         exportPath: wrapperPath,
+        audioExportPath: isAudioExport ? audioPath : undefined,
         filesExported: aggregated.filesExported || filesToExport.length,
         audioCopied: aggregated.audioCopied,
         audioMissing: aggregated.audioMissing,

--- a/src/exportHandler/exportProgress.ts
+++ b/src/exportHandler/exportProgress.ts
@@ -82,6 +82,13 @@ export interface ExportProgressReporter {
     fileMissing(file: string, reason: ExportMissingReason, detail?: string): void;
     complete(summary: ExportSummary): void;
     error(message: string): void;
+    /**
+     * Signals that the export was cancelled by the user before it finished.
+     * Implementations should treat this as a terminal state distinct from
+     * `complete`/`error` (the partial output has already been cleaned up by the
+     * time this fires).
+     */
+    cancelled(summary?: ExportSummary): void;
 }
 
 /**
@@ -95,6 +102,7 @@ export function createNoopReporter(): ExportProgressReporter {
         fileMissing: () => undefined,
         complete: () => undefined,
         error: () => undefined,
+        cancelled: () => undefined,
     };
 }
 
@@ -136,6 +144,9 @@ export function createAggregatingReporter(target: ExportProgressReporter): {
             error(message) {
                 hadError = true;
                 errorMessages.push(message);
+            },
+            cancelled(summary) {
+                target.cancelled(summary);
             },
         },
         drain() {
@@ -183,6 +194,13 @@ export function createWebviewReporter(
             safePostMessageToPanel(
                 panel,
                 { command: "exportError", message },
+                context
+            );
+        },
+        cancelled(summary) {
+            safePostMessageToPanel(
+                panel,
+                { command: "exportCancelled", summary },
                 context
             );
         },

--- a/src/exportHandler/exportProgress.ts
+++ b/src/exportHandler/exportProgress.ts
@@ -14,6 +14,10 @@ export type ExportMissingReason =
     | "no-text-recorded"
     // Tier 2 — soft warning (yellow)
     | "no-audio-selected"
+    // The selected take's bytes couldn't be resolved, but the cell still has
+    // other usable (non-deleted, non-missing) recordings the user can switch
+    // to — recoverable without re-recording, hence a warning rather than error.
+    | "selected-audio-missing-alternatives"
     | "audio-file-missing"
     | "pointer-corrupt"
     | "source-not-found"
@@ -35,6 +39,7 @@ export function severityForReason(reason: ExportMissingReason): ExportMissingSev
         case "no-text-recorded":
             return "info";
         case "no-audio-selected":
+        case "selected-audio-missing-alternatives":
         case "pointer-corrupt":
         case "source-not-found":
             return "warn";

--- a/src/exportHandler/exportProgress.ts
+++ b/src/exportHandler/exportProgress.ts
@@ -66,10 +66,22 @@ export interface ExportProgressEvent {
     increment?: number;
 }
 
+/**
+ * Optional pointer to the exact cell a missing-file event came from. When
+ * present, the webview renders the entry as a clickable row that deep-links
+ * into the codex editor (same UX as the Step 1 audio-stats popover).
+ */
+export interface ExportMissingFileLocation {
+    cellId?: string;
+    codexPath?: string;
+}
+
 export interface ExportMissingFile {
     file: string;
     reason: ExportMissingReason;
     detail?: string;
+    cellId?: string;
+    codexPath?: string;
 }
 
 export interface ExportSummary {
@@ -84,7 +96,12 @@ export interface ExportSummary {
 
 export interface ExportProgressReporter {
     report(event: ExportProgressEvent): void;
-    fileMissing(file: string, reason: ExportMissingReason, detail?: string): void;
+    fileMissing(
+        file: string,
+        reason: ExportMissingReason,
+        detail?: string,
+        location?: ExportMissingFileLocation
+    ): void;
     complete(summary: ExportSummary): void;
     error(message: string): void;
     /**
@@ -137,9 +154,9 @@ export function createAggregatingReporter(target: ExportProgressReporter): {
             report(event) {
                 target.report(event);
             },
-            fileMissing(file, reason, detail) {
-                missingFiles.push({ file, reason, detail });
-                target.fileMissing(file, reason, detail);
+            fileMissing(file, reason, detail, location) {
+                missingFiles.push({ file, reason, detail, ...location });
+                target.fileMissing(file, reason, detail, location);
             },
             complete(summary) {
                 if (summary.exportPath) lastExportPath = summary.exportPath;
@@ -181,10 +198,17 @@ export function createWebviewReporter(
                 context
             );
         },
-        fileMissing(file, reason, detail) {
+        fileMissing(file, reason, detail, location) {
             safePostMessageToPanel(
                 panel,
-                { command: "exportFileMissing", file, reason, detail },
+                {
+                    command: "exportFileMissing",
+                    file,
+                    reason,
+                    detail,
+                    cellId: location?.cellId,
+                    codexPath: location?.codexPath,
+                },
                 context
             );
         },

--- a/src/exportHandler/exportProgress.ts
+++ b/src/exportHandler/exportProgress.ts
@@ -86,6 +86,13 @@ export interface ExportMissingFile {
 
 export interface ExportSummary {
     exportPath: string;
+    /**
+     * Directory the audio files were written into. Differs from `exportPath`
+     * in multi-format exports (where audio lives in an `audio/` subfolder). The
+     * export view remembers this so a targeted "retry failed downloads" can
+     * write the recovered files back into the same folder.
+     */
+    audioExportPath?: string;
     filesExported?: number;
     audioCopied?: number;
     audioMissing?: number;

--- a/src/exportHandler/htmlExporter.ts
+++ b/src/exportHandler/htmlExporter.ts
@@ -142,7 +142,8 @@ export async function exportCodexContentAsHtml(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
         debug("Starting exportCodexContentAsHtml function");
@@ -172,6 +173,7 @@ export async function exportCodexContentAsHtml(
         await vscode.workspace.fs.createDirectory(baseExportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,

--- a/src/exportHandler/plaintextExporter.ts
+++ b/src/exportHandler/plaintextExporter.ts
@@ -16,7 +16,8 @@ export async function exportCodexContentAsPlaintext(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
         debug("Starting exportCodexContentAsPlaintext");
@@ -41,6 +42,7 @@ export async function exportCodexContentAsPlaintext(
         await vscode.workspace.fs.createDirectory(exportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,

--- a/src/exportHandler/usfmExporter.ts
+++ b/src/exportHandler/usfmExporter.ts
@@ -166,7 +166,8 @@ export async function exportCodexContentAsUsfm(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
         debug("Starting exportCodexContentAsUsfm function");
@@ -208,6 +209,7 @@ export async function exportCodexContentAsUsfm(
         const warnings: string[] = [];
 
         for (let i = 0; i < selectedFiles.length; i++) {
+            if (token?.isCancellationRequested) return;
             const file = selectedFiles[i];
             reporter.report({
                 stage: "writing",

--- a/src/exportHandler/xliffExporter.ts
+++ b/src/exportHandler/xliffExporter.ts
@@ -37,7 +37,8 @@ export async function exportCodexContentAsXliff(
     userSelectedPath: string,
     filesToExport: string[],
     reporter: ExportProgressReporter,
-    options?: ExportOptions
+    options?: ExportOptions,
+    token?: vscode.CancellationToken
 ) {
     try {
         debug("Starting exportCodexContentAsXliff function");
@@ -77,6 +78,7 @@ export async function exportCodexContentAsXliff(
         await vscode.workspace.fs.createDirectory(exportFolder);
 
         for (const [index, file] of selectedFiles.entries()) {
+            if (token?.isCancellationRequested) return;
             reporter.report({
                 stage: "writing",
                 message: `Processing file ${index + 1}/${selectedFiles.length}`,

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -980,6 +980,95 @@ function getWebviewContent(
                 .export-extra-messages div { padding: 2px 0; }
 
                 /*
+                 * Post-export "issues" list. Each problem category (one per
+                 * ExportMissingReason) renders as a collapsible group whose
+                 * header shows a severity-coloured icon, a human label, a
+                 * one-line explanation, and a count badge. Collapsed by
+                 * default — the user expands to see the affected cells/files.
+                 * Severity colours mirror the Step 1 stat pills above.
+                 */
+                .export-issues {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                }
+                .export-issue-group {
+                    border: 1px solid var(--vscode-input-border);
+                    border-radius: 6px;
+                    overflow: hidden;
+                    background: var(--vscode-input-background);
+                }
+                .export-issue-header {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    padding: 8px 10px;
+                    cursor: pointer;
+                    user-select: none;
+                    font-size: 0.88em;
+                }
+                .export-issue-header:hover { background: var(--vscode-list-hoverBackground); }
+                .export-issue-header .export-issue-chevron {
+                    flex-shrink: 0;
+                    opacity: 0.7;
+                    transition: transform 120ms ease;
+                }
+                .export-issue-group.open .export-issue-header .export-issue-chevron { transform: rotate(90deg); }
+                .export-issue-header .export-issue-icon { flex-shrink: 0; }
+                .export-issue-title { font-weight: 600; }
+                .export-issue-count {
+                    margin-left: auto;
+                    flex-shrink: 0;
+                    font-size: 0.85em;
+                    padding: 0 7px;
+                    border-radius: 10px;
+                    border: 1px solid transparent;
+                }
+                .export-issue-desc {
+                    font-size: 0.82em;
+                    color: var(--vscode-descriptionForeground);
+                    padding: 0 10px 8px 34px;
+                    margin-top: -2px;
+                }
+                .export-issue-list {
+                    display: none;
+                    flex-direction: column;
+                    gap: 2px;
+                    padding: 0 10px 8px 34px;
+                    max-height: 220px;
+                    overflow-y: auto;
+                }
+                .export-issue-group.open .export-issue-list { display: flex; }
+                .export-issue-item {
+                    font-size: 0.82em;
+                    color: var(--vscode-foreground);
+                    padding: 2px 0;
+                }
+                .export-issue-item .export-issue-item-detail {
+                    display: block;
+                    color: var(--vscode-descriptionForeground);
+                    font-size: 0.95em;
+                }
+                .export-issue-group.sev-error .export-issue-icon { color: var(--vscode-errorForeground, #dc2626); }
+                .export-issue-group.sev-error .export-issue-count {
+                    color: var(--vscode-errorForeground, #dc2626);
+                    background-color: rgba(220, 38, 38, 0.10);
+                    border-color: rgba(220, 38, 38, 0.32);
+                }
+                .export-issue-group.sev-warn .export-issue-icon { color: var(--vscode-charts-yellow, #ca8a04); }
+                .export-issue-group.sev-warn .export-issue-count {
+                    color: var(--vscode-charts-yellow, #ca8a04);
+                    background-color: rgba(202, 138, 4, 0.10);
+                    border-color: rgba(202, 138, 4, 0.32);
+                }
+                .export-issue-group.sev-info .export-issue-icon { color: var(--vscode-descriptionForeground); }
+                .export-issue-group.sev-info .export-issue-count {
+                    color: var(--vscode-descriptionForeground);
+                    background-color: var(--vscode-input-background);
+                    border-color: var(--vscode-input-border);
+                }
+
+                /*
                  * Clickable Step 1 audio-stat counters. Styled as actual
                  * tags (matching the existing .file-status-tag pattern in
                  * this view) so the affordance reads immediately. The
@@ -1473,6 +1562,8 @@ function getWebviewContent(
 
                             <div class="export-extra-messages" id="exportExtraMessages" style="display:none;"></div>
 
+                            <div class="export-issues" id="exportIssues" style="display:none;"></div>
+
                             <div class="export-output-path" id="exportOutputPath" style="display:none;"></div>
 
                             <div class="export-action-row" id="exportCancelRow">
@@ -1825,6 +1916,7 @@ function getWebviewContent(
                     scrollMemory: new Map(),
                     bucketKeys: {
                         selectionMissing: 'selectionMissingCells',
+                        selectedPossiblyMissing: 'selectedPossiblyMissingCells',
                         noneSelected: 'noneSelectedCells',
                         noAudioRecorded: 'noAudioRecordedCells'
                     }
@@ -2145,6 +2237,16 @@ function getWebviewContent(
                                         f.audioStats.selectionMissingCount,
                                         'with selected audio missing',
                                         f.displayName + ' — selected audio is missing'
+                                    ));
+                                }
+                                if (f.audioStats.selectedPossiblyMissingCount > 0) {
+                                    parts.push(renderStatPill(
+                                        gIdx, fIdx,
+                                        'selectedPossiblyMissing',
+                                        'warn',
+                                        f.audioStats.selectedPossiblyMissingCount,
+                                        'with selected take possibly missing',
+                                        f.displayName + ' — selected take flagged as possibly missing'
                                     ));
                                 }
                                 if (f.audioStats.noneSelectedCount > 0) {
@@ -2596,6 +2698,10 @@ function getWebviewContent(
                     cancelled: false,
                     stageIndex: -1,
                     extraMessages: [],
+                    // Per-cell/per-file problems collected from exportFileMissing
+                    // events during the run, rendered as a grouped, expandable
+                    // list once the export completes.
+                    missingFiles: [],
                     outputPath: null,
                     lastTitle: 'Exporting...',
                     lastSubtitle: 'This may take a moment. Please keep this view open.',
@@ -2609,6 +2715,7 @@ function getWebviewContent(
                     exportState.cancelled = false;
                     exportState.stageIndex = -1;
                     exportState.extraMessages = [];
+                    exportState.missingFiles = [];
                     exportState.outputPath = null;
                     exportState.lastTitle = 'Exporting...';
                     exportState.lastSubtitle = 'This may take a moment. Please keep this view open.';
@@ -2633,6 +2740,9 @@ function getWebviewContent(
 
                     const extras = document.getElementById('exportExtraMessages');
                     if (extras) { extras.style.display = 'none'; extras.innerHTML = ''; }
+
+                    const issues = document.getElementById('exportIssues');
+                    if (issues) { issues.style.display = 'none'; issues.innerHTML = ''; }
 
                     const outPath = document.getElementById('exportOutputPath');
                     if (outPath) { outPath.style.display = 'none'; outPath.textContent = ''; }
@@ -2731,6 +2841,148 @@ function getWebviewContent(
                         .map(m => '<div>' + String(m).replace(/</g, '&lt;') + '</div>')
                         .join('');
                     extras.style.display = 'block';
+                }
+
+                // Human-readable metadata for each ExportMissingReason emitted by
+                // the exporters. Severity drives colour + ordering (error >
+                // warn > info); the description spells out what the category
+                // means so the count in the summary line is actionable. Keep in
+                // sync with ExportMissingReason / severityForReason in
+                // src/exportHandler/exportProgress.ts.
+                const EXPORT_REASON_META = {
+                    'download-failed': {
+                        severity: 'error',
+                        icon: 'cloud-download',
+                        label: 'Failed to download',
+                        description: "The audio is stored remotely but couldn't be downloaded — usually a network drop or sign-in issue. Re-running the export often recovers these.",
+                    },
+                    'audio-file-missing': {
+                        severity: 'error',
+                        icon: 'circle-slash',
+                        label: 'Audio could not be resolved',
+                        description: "A take is selected for the cell, but its audio file couldn't be found locally or on the server. The recording may need to be re-synced or re-recorded.",
+                    },
+                    'transcode-failed': {
+                        severity: 'error',
+                        icon: 'error',
+                        label: 'Audio conversion failed',
+                        description: 'The audio was found but could not be trimmed/converted for export. The source file may be corrupt or in an unsupported format.',
+                    },
+                    'write-failed': {
+                        severity: 'error',
+                        icon: 'error',
+                        label: 'Could not write file',
+                        description: 'The audio was resolved but writing the output file to disk failed (e.g. permissions or disk space).',
+                    },
+                    'error': {
+                        severity: 'error',
+                        icon: 'error',
+                        label: 'Export error',
+                        description: 'These files could not be exported due to an unexpected error. See the detail next to each entry.',
+                    },
+                    'selected-audio-missing-alternatives': {
+                        severity: 'warn',
+                        icon: 'warning',
+                        label: 'Selected recording missing — other takes available',
+                        description: "The recording selected for these cells couldn't be found, but each cell has other recordings. Open the cell and select a different take to export it (no re-recording needed).",
+                    },
+                    'no-audio-selected': {
+                        severity: 'warn',
+                        icon: 'warning',
+                        label: 'Audio recorded, none selected',
+                        description: 'These cells have one or more recordings but no take was selected to export. Open the cell to choose a take.',
+                    },
+                    'pointer-corrupt': {
+                        severity: 'warn',
+                        icon: 'warning',
+                        label: 'Corrupt media pointer',
+                        description: "The reference to this audio is malformed, so its bytes can't be located. The file likely needs to be re-synced.",
+                    },
+                    'source-not-found': {
+                        severity: 'warn',
+                        icon: 'warning',
+                        label: 'Source not found',
+                        description: 'The source file backing this export could not be found, so it was skipped.',
+                    },
+                    'no-audio-recorded': {
+                        severity: 'info',
+                        icon: 'info',
+                        label: 'No audio recorded',
+                        description: 'These cells have no recorded audio, so there was nothing to export for them.',
+                    },
+                    'no-text-recorded': {
+                        severity: 'info',
+                        icon: 'info',
+                        label: 'No text recorded',
+                        description: 'These files have no translated text, so there was nothing to export for them.',
+                    },
+                };
+                const EXPORT_SEVERITY_ORDER = { error: 0, warn: 1, info: 2 };
+
+                function toggleExportIssue(headerEl) {
+                    const group = headerEl.closest('.export-issue-group');
+                    if (group) group.classList.toggle('open');
+                }
+
+                function renderExportIssues() {
+                    const container = document.getElementById('exportIssues');
+                    if (!container) return;
+                    const items = exportState.missingFiles || [];
+                    if (items.length === 0) {
+                        container.style.display = 'none';
+                        container.innerHTML = '';
+                        return;
+                    }
+
+                    // Group by reason, preserving first-seen order within a group.
+                    const groups = new Map();
+                    for (const it of items) {
+                        const reason = it.reason || 'error';
+                        if (!groups.has(reason)) groups.set(reason, []);
+                        groups.get(reason).push(it);
+                    }
+
+                    // Order groups by severity (error first), then alphabetically
+                    // by label for stable output.
+                    const ordered = Array.from(groups.entries()).sort((a, b) => {
+                        const ma = EXPORT_REASON_META[a[0]] || { severity: 'error', label: a[0] };
+                        const mb = EXPORT_REASON_META[b[0]] || { severity: 'error', label: b[0] };
+                        const sa = EXPORT_SEVERITY_ORDER[ma.severity] ?? 0;
+                        const sb = EXPORT_SEVERITY_ORDER[mb.severity] ?? 0;
+                        if (sa !== sb) return sa - sb;
+                        return String(ma.label).localeCompare(String(mb.label));
+                    });
+
+                    container.innerHTML = ordered.map(([reason, list]) => {
+                        const meta = EXPORT_REASON_META[reason] || {
+                            severity: 'error',
+                            icon: 'error',
+                            label: reason,
+                            description: '',
+                        };
+                        const itemsHtml = list.map(it => {
+                            const name = escapeHtml(String(it.file || ''));
+                            const detail = it.detail
+                                ? '<span class="export-issue-item-detail">' + escapeHtml(String(it.detail)) + '</span>'
+                                : '';
+                            return '<div class="export-issue-item">' + name + detail + '</div>';
+                        }).join('');
+                        return (
+                            '<div class="export-issue-group sev-' + meta.severity + '">' +
+                                '<div class="export-issue-header" onclick="toggleExportIssue(this)">' +
+                                    '<i class="codicon codicon-chevron-right export-issue-chevron"></i>' +
+                                    '<i class="codicon codicon-' + meta.icon + ' export-issue-icon"></i>' +
+                                    '<span class="export-issue-title">' + escapeHtml(meta.label) + '</span>' +
+                                    '<span class="export-issue-count">' + list.length + '</span>' +
+                                '</div>' +
+                                (meta.description
+                                    ? '<div class="export-issue-desc">' + escapeHtml(meta.description) + '</div>'
+                                    : '') +
+                                '<div class="export-issue-list">' + itemsHtml + '</div>' +
+                            '</div>'
+                        );
+                    }).join('');
+                    container.style.display = 'flex';
                 }
 
                 function showOutputPath(path) {
@@ -2909,11 +3161,19 @@ function getWebviewContent(
                         return;
                     }
                     if (message.command === 'exportFileMissing') {
-                        // Per-cell missing/info events are intentionally ignored
-                        // in the UI now. Each exporter rolls these counts up
-                        // into its single extraMessages summary line (see
-                        // audioExporter.ts, htmlExporter.ts, etc.), which we
-                        // render via showExtraMessages on completion.
+                        // Collect per-cell/per-file problems as they arrive.
+                        // They're rolled up into the single extraMessages
+                        // summary line by the exporters; here we keep the
+                        // individual entries so the completion screen can show
+                        // an expandable, grouped breakdown. Stop collecting once
+                        // we've reached a terminal state (late events from
+                        // in-flight work draining after a cancel).
+                        if (exportState.finished || exportState.cancelled) return;
+                        exportState.missingFiles.push({
+                            file: message.file,
+                            reason: message.reason,
+                            detail: message.detail,
+                        });
                         return;
                     }
                     if (message.command === 'exportCompleted') {
@@ -2926,6 +3186,9 @@ function getWebviewContent(
                             showExtraMessages(summary.extraMessages);
                         }
                         showExportFinished(true);
+                        // Render after marking finished so the grouped issue
+                        // list reflects everything collected during the run.
+                        renderExportIssues();
                         return;
                     }
                     if (message.command === 'exportError') {

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1161,28 +1161,46 @@ function getWebviewContent(
                     display: flex;
                     align-items: center;
                     justify-content: space-between;
-                    gap: 8px;
-                    padding: 0 2px 2px;
+                    gap: 12px;
+                    /* Extra bottom space so the toggle's hover/active fill never
+                     * crowds the first group's header/description below it. */
+                    padding: 2px 2px 10px;
                 }
                 .export-issues-summary {
                     font-size: 0.82em;
                     color: var(--vscode-descriptionForeground);
                 }
+                /*
+                 * Rendered as a compact secondary button rather than a bare text
+                 * link. A link-coloured label became unreadable once selected
+                 * (blue text on the blue selection highlight); a solid button
+                 * background + matching foreground stays legible in every state,
+                 * and user-select:none stops it being text-selected at all.
+                 */
                 .export-issues-toggle-all {
                     display: inline-flex;
                     align-items: center;
                     gap: 5px;
                     font: inherit;
                     font-size: 0.82em;
-                    color: var(--vscode-textLink-foreground);
-                    background: transparent;
-                    border: none;
+                    color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+                    background: var(--vscode-button-secondaryBackground, transparent);
+                    border: 1px solid var(--vscode-input-border, transparent);
+                    border-radius: 4px;
                     cursor: pointer;
-                    padding: 2px 4px;
+                    padding: 3px 8px;
+                    user-select: none;
                     -webkit-appearance: none;
                     appearance: none;
                 }
-                .export-issues-toggle-all:hover { text-decoration: underline; }
+                .export-issues-toggle-all:hover {
+                    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-list-hoverBackground, rgba(0,0,0,0.06)));
+                    color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+                }
+                .export-issues-toggle-all:focus-visible {
+                    outline: 1px solid var(--vscode-focusBorder, transparent);
+                    outline-offset: 1px;
+                }
                 .export-issues-toggle-all .codicon { font-size: 0.95em; }
                 .export-issue-group {
                     border: 1px solid var(--vscode-input-border);
@@ -3208,15 +3226,17 @@ function getWebviewContent(
                         setExportTitle(message, exportState.lastSubtitle);
                     }
 
+                    // The progress count now lives in the title (message); this
+                    // line shows only the specific item in flight — a cell label
+                    // while writing, or a file name for text exports. Audio
+                    // downloads run concurrently (no single item) so the exporter
+                    // omits the file and this line stays hidden, which removes the
+                    // duplicate count and the misleading ".codex" name that isn't
+                    // actually what's being downloaded.
                     const currentFile = document.getElementById('exportCurrentFile');
                     if (currentFile) {
-                        const parts = [];
-                        if (typeof current === 'number' && typeof total === 'number' && total > 0) {
-                            parts.push('(' + current + '/' + total + ')');
-                        }
-                        if (file) parts.push(file);
-                        if (parts.length > 0) {
-                            currentFile.textContent = parts.join(' ');
+                        if (file) {
+                            currentFile.textContent = file;
                             currentFile.style.display = 'block';
                         } else {
                             currentFile.style.display = 'none';

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1098,6 +1098,51 @@ function getWebviewContent(
                     color: var(--vscode-descriptionForeground);
                     font-size: 0.95em;
                 }
+                /*
+                 * Clickable variant — rendered as a <button> (keyboard focus +
+                 * Enter/Space for free) that deep-links into the cell, mirroring
+                 * the Step 1 audio-stats popover rows. UA chrome stripped so it
+                 * sits flush with the static rows around it.
+                 */
+                button.export-issue-item {
+                    width: 100%;
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    text-align: left;
+                    font-family: inherit;
+                    background: transparent;
+                    border: none;
+                    border-radius: 3px;
+                    cursor: pointer;
+                    -webkit-appearance: none;
+                    appearance: none;
+                }
+                button.export-issue-item .export-issue-item-label {
+                    flex: 1;
+                    min-width: 0;
+                    word-break: break-word;
+                }
+                button.export-issue-item .export-issue-item-icon {
+                    flex-shrink: 0;
+                    font-size: 0.85em;
+                    opacity: 0.55;
+                    transition: transform 80ms ease, opacity 80ms ease;
+                }
+                button.export-issue-item:hover,
+                button.export-issue-item:focus-visible {
+                    background-color: var(--vscode-list-hoverBackground, rgba(0,0,0,0.04));
+                    color: var(--vscode-list-hoverForeground, var(--vscode-foreground));
+                    outline: none;
+                }
+                button.export-issue-item:hover .export-issue-item-icon,
+                button.export-issue-item:focus-visible .export-issue-item-icon {
+                    opacity: 1;
+                    transform: translateX(2px);
+                }
+                button.export-issue-item:focus-visible {
+                    box-shadow: inset 0 0 0 1px var(--vscode-focusBorder, transparent);
+                }
                 .export-issue-group.sev-error .export-issue-icon { color: var(--vscode-errorForeground, #dc2626); }
                 .export-issue-group.sev-error .export-issue-count {
                     color: var(--vscode-errorForeground, #dc2626);
@@ -2169,6 +2214,24 @@ function getWebviewContent(
                         const target = event.target;
                         if (!target || !target.closest) return;
 
+                        // Clickable cell row in the completion screen's grouped
+                        // issues list — deep-link into the codex editor, same as
+                        // the Step 1 popover rows below.
+                        const issueRow = target.closest('button.export-issue-item.is-clickable');
+                        if (issueRow) {
+                            const cellId = issueRow.getAttribute('data-cell-id');
+                            const filePath = issueRow.getAttribute('data-file-path');
+                            if (cellId && filePath) {
+                                vscode.postMessage({
+                                    command: 'openCellInEditor',
+                                    cellId: cellId,
+                                    filePath: filePath,
+                                });
+                                event.stopPropagation();
+                                return;
+                            }
+                        }
+
                         // Clickable cell row inside the popover — deep-link
                         // into the codex editor. We intentionally KEEP the
                         // popover open: opening the cell sends the export tab
@@ -3019,68 +3082,68 @@ function getWebviewContent(
                     'download-failed': {
                         severity: 'error',
                         icon: 'cloud-download',
-                        label: 'Failed to download',
-                        description: "The audio is stored remotely but couldn't be downloaded — usually a network drop or sign-in issue. Re-running the export often recovers these.",
+                        label: "Audio couldn't be downloaded",
+                        description: "This audio is stored online but couldn't be downloaded — usually a network or sign-in problem. Trying the export again often fixes it.",
                     },
                     'audio-file-missing': {
                         severity: 'error',
                         icon: 'circle-slash',
-                        label: 'Audio could not be resolved',
-                        description: "A take is selected for the cell, but its audio file couldn't be found locally or on the server. The recording may need to be re-synced or re-recorded.",
+                        label: 'Audio file(s) missing',
+                        description: "An audio recording is selected for the cell, but it couldn't be found locally or on the server. The recording may need to be re-recorded.",
                     },
                     'transcode-failed': {
                         severity: 'error',
                         icon: 'error',
-                        label: 'Audio conversion failed',
-                        description: 'The audio was found but could not be trimmed/converted for export. The source file may be corrupt or in an unsupported format.',
+                        label: "Audio couldn't be converted",
+                        description: "We found the audio but couldn't prepare it for export. The recording may be damaged or in a format we don't support.",
                     },
                     'write-failed': {
                         severity: 'error',
                         icon: 'error',
-                        label: 'Could not write file',
-                        description: 'The audio was resolved but writing the output file to disk failed (e.g. permissions or disk space).',
+                        label: "Couldn't save the file",
+                        description: "We found the audio but couldn't save the exported file. You may be out of disk space or not have permission to save there.",
                     },
                     'error': {
                         severity: 'error',
                         icon: 'error',
-                        label: 'Export error',
-                        description: 'These files could not be exported due to an unexpected error. See the detail next to each entry.',
+                        label: 'Something went wrong',
+                        description: "These cells couldn't be exported because of an unexpected problem. See the note next to each one for details.",
                     },
                     'selected-audio-missing-alternatives': {
                         severity: 'warn',
                         icon: 'warning',
-                        label: 'Selected recording missing — other takes available',
-                        description: "The recording selected for these cells couldn't be found, but each cell has other recordings. Open the cell and select a different take to export it (no re-recording needed).",
+                        label: 'Selected recording missing (other recordings available)',
+                        description: "The recording chosen for these cells couldn't be found, but each cell has other recordings. Open the cell and pick a different recording — no need to record again.",
                     },
                     'no-audio-selected': {
                         severity: 'warn',
                         icon: 'warning',
-                        label: 'Audio recorded, none selected',
-                        description: 'These cells have one or more recordings but no take was selected to export. Open the cell to choose a take.',
+                        label: 'No recording chosen',
+                        description: 'These cells have one or more recordings, but none was chosen to export. Open the cell and pick which recording to use.',
                     },
                     'pointer-corrupt': {
                         severity: 'warn',
                         icon: 'warning',
-                        label: 'Corrupt media pointer',
-                        description: "The reference to this audio is malformed, so its bytes can't be located. The file likely needs to be re-synced.",
+                        label: 'Audio reference is broken',
+                        description: "The link to this audio is broken, so we couldn't find the actual file. Re-syncing the project will likely fix it.",
                     },
                     'source-not-found': {
                         severity: 'warn',
                         icon: 'warning',
-                        label: 'Source not found',
-                        description: 'The source file backing this export could not be found, so it was skipped.',
+                        label: 'Source file missing',
+                        description: "The original file this export is based on couldn't be found, so it was skipped.",
                     },
                     'no-audio-recorded': {
                         severity: 'info',
                         icon: 'info',
                         label: 'No audio recorded',
-                        description: 'These cells have no recorded audio, so there was nothing to export for them.',
+                        description: "These cells don't have any audio recorded yet, so there was nothing to export.",
                     },
                     'no-text-recorded': {
                         severity: 'info',
                         icon: 'info',
-                        label: 'No text recorded',
-                        description: 'These files have no translated text, so there was nothing to export for them.',
+                        label: 'No text written',
+                        description: "These files don't have any translated text yet, so there was nothing to export.",
                     },
                 };
                 const EXPORT_SEVERITY_ORDER = { error: 0, warn: 1, info: 2 };
@@ -3126,12 +3189,32 @@ function getWebviewContent(
                             label: reason,
                             description: '',
                         };
+                        // The group header already explains the reason, so we
+                        // don't repeat the per-cell detail on every row (it was
+                        // redundant). Any per-cell specifics (e.g. a raw write
+                        // error) are kept on the title tooltip for hover. When
+                        // we know which cell an entry came from, render it as a
+                        // clickable row that deep-links into the editor — same
+                        // UX as the Step 1 "problematic cells" popover.
                         const itemsHtml = list.map(it => {
                             const name = escapeHtml(String(it.file || ''));
-                            const detail = it.detail
-                                ? '<span class="export-issue-item-detail">' + escapeHtml(String(it.detail)) + '</span>'
+                            const titleAttr = it.detail
+                                ? ' title="' + escapeHtml(String(it.detail)) + '"'
                                 : '';
-                            return '<div class="export-issue-item">' + name + detail + '</div>';
+                            const cellId = it.cellId ? escapeHtml(String(it.cellId)) : '';
+                            const filePath = it.codexPath ? escapeHtml(String(it.codexPath)) : '';
+                            if (cellId && filePath) {
+                                return (
+                                    '<button type="button" class="export-issue-item is-clickable"' +
+                                    ' data-cell-id="' + cellId + '"' +
+                                    ' data-file-path="' + filePath + '"' +
+                                    (it.detail ? titleAttr : ' title="Open this cell in the editor"') + '>' +
+                                        '<span class="export-issue-item-label">' + name + '</span>' +
+                                        '<i class="codicon codicon-arrow-right export-issue-item-icon" aria-hidden="true"></i>' +
+                                    '</button>'
+                                );
+                            }
+                            return '<div class="export-issue-item"' + titleAttr + '>' + name + '</div>';
                         }).join('');
                         return (
                             '<div class="export-issue-group sev-' + meta.severity + '">' +
@@ -3350,6 +3433,8 @@ function getWebviewContent(
                             file: message.file,
                             reason: message.reason,
                             detail: message.detail,
+                            cellId: message.cellId,
+                            codexPath: message.codexPath,
                         });
                         return;
                     }

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 import { safePostMessageToPanel } from "../utils/webviewUtils";
 import { EXPORT_OPTIONS_BY_FILE_TYPE } from "../../sharedUtils/exportOptionsEligibility";
-import { groupCodexFilesByImporterType, type FileGroup } from "./utils/exportViewUtils";
+import { groupCodexFilesByImporterType, analyzeCodexFileAudio, type FileGroup } from "./utils/exportViewUtils";
 import { readCodexNotebookFromUri } from "../exportHandler/exportHandlerUtils";
 import { compareHtmlStructure } from "../../sharedUtils/htmlStructureUtils";
 import { getMediaFilesStrategy } from "../utils/localProjectSettings";
@@ -139,6 +139,50 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
         }
     );
     activeExportPanel = panel;
+
+    // Live Step 1 counts: watch `.codex` files and push a per-file audio-stat
+    // refresh whenever one is saved while the wizard is open (e.g. the user
+    // picks a different take, records, or deletes a take in the cell editor).
+    // We recompute only the changed file and patch that row, so this stays
+    // cheap even on large projects.
+    const codexWatcher = vscode.workspace.createFileSystemWatcher("**/*.codex");
+    const audioStatsRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    const scheduleAudioStatsRefresh = (uri: vscode.Uri) => {
+        const key = uri.fsPath;
+        const existing = audioStatsRefreshTimers.get(key);
+        if (existing) {
+            clearTimeout(existing);
+        }
+        // Debounce: the document save path does a tmp-write + atomic rename
+        // (often surfacing as a create+change pair) and autosave can burst —
+        // coalesce into a single recompute per file.
+        audioStatsRefreshTimers.set(
+            key,
+            setTimeout(async () => {
+                audioStatsRefreshTimers.delete(key);
+                const result = await analyzeCodexFileAudio(uri);
+                // null = transient read/parse race or broken file; leave the
+                // existing count in place until the next save.
+                if (!result) {
+                    return;
+                }
+                safePostMessageToPanel(
+                    panel,
+                    {
+                        command: "fileAudioStatsUpdated",
+                        path: uri.fsPath,
+                        hasAudio: result.hasAudio,
+                        hasTranslations: result.hasTranslations,
+                        audioStats: result.audioStats,
+                    },
+                    "ProjectExport"
+                );
+            }, 400)
+        );
+    };
+    codexWatcher.onDidChange(scheduleAudioStatsRefresh);
+    codexWatcher.onDidCreate(scheduleAudioStatsRefresh);
+
     panel.onDidDispose(() => {
         // Closing the tab while an export is running aborts it (and triggers the
         // engine's partial-output cleanup). This also prevents a stale run from
@@ -146,6 +190,11 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
         if (isExporting) {
             activeExportCts?.cancel();
         }
+        codexWatcher.dispose();
+        for (const timer of audioStatsRefreshTimers.values()) {
+            clearTimeout(timer);
+        }
+        audioStatsRefreshTimers.clear();
         if (activeExportPanel === panel) {
             activeExportPanel = undefined;
         }
@@ -1922,6 +1971,69 @@ function getWebviewContent(
                     }
                 };
 
+                /*
+                 * Builds the popover body markup for a list of affected cells.
+                 * Shared by the initial open and the in-place refresh so both
+                 * render identical rows. Entries are { label, cellId } (see
+                 * analyzeNotebookAudioStats); when cellId + filePath are both
+                 * present we render a clickable button that deep-links into the
+                 * editor, otherwise a static row (defensive for older shapes).
+                 */
+                function renderCellListPopoverBody(cells, filePath) {
+                    if (!cells || cells.length === 0) {
+                        return '<div class="cell-list-popover-empty">No cells in this bucket.</div>';
+                    }
+                    return cells.map(entry => {
+                        const label = (entry && typeof entry === 'object') ? entry.label : entry;
+                        const cellId = (entry && typeof entry === 'object') ? entry.cellId : '';
+                        const clickable = !!(cellId && filePath);
+                        if (clickable) {
+                            return [
+                                '<button type="button" class="cell-list-popover-item is-clickable"',
+                                ' data-cell-id="' + escapeHtml(String(cellId)) + '"',
+                                ' data-file-path="' + escapeHtml(String(filePath)) + '"',
+                                ' title="Open this cell in the editor">',
+                                '<span class="cell-list-popover-item-label">' + escapeHtml(String(label || '')) + '</span>',
+                                '<i class="codicon codicon-arrow-right cell-list-popover-item-icon" aria-hidden="true"></i>',
+                                '</button>'
+                            ].join('');
+                        }
+                        return '<div class="cell-list-popover-item">' + escapeHtml(String(label || '')) + '</div>';
+                    }).join('');
+                }
+
+                /*
+                 * Refreshes the OPEN popover's contents in place when the file
+                 * it's showing gets a live stats update (e.g. the user fixed a
+                 * take, so it drops out of the list). Does NOT reposition — the
+                 * panel may be hidden in the background (layout rects read 0
+                 * there), and the popover should stay anchored where the user
+                 * left it. Closes the popover only if its bucket is now empty.
+                 */
+                function refreshOpenCellListPopover(path, audioStats) {
+                    if (!cellListPopoverState.open || typeof cellListPopoverState.currentKey !== 'string') return;
+                    // currentKey is 'filePath|bucket'; paths never contain '|',
+                    // so split on the last separator.
+                    const sep = cellListPopoverState.currentKey.lastIndexOf('|');
+                    if (sep < 0) return;
+                    const openPath = cellListPopoverState.currentKey.slice(0, sep);
+                    const openBucket = cellListPopoverState.currentKey.slice(sep + 1);
+                    if (openPath !== path) return;
+                    const statsKey = cellListPopoverState.bucketKeys[openBucket];
+                    const cells = (audioStats && statsKey && Array.isArray(audioStats[statsKey])) ? audioStats[statsKey] : [];
+                    if (cells.length === 0) {
+                        closeCellListPopover();
+                        return;
+                    }
+                    const countEl = document.getElementById('cellListPopoverCount');
+                    const bodyEl = document.getElementById('cellListPopoverBody');
+                    const footerEl = document.getElementById('cellListPopoverFooter');
+                    if (!countEl || !bodyEl || !footerEl) return;
+                    countEl.textContent = String(cells.length);
+                    bodyEl.innerHTML = renderCellListPopoverBody(cells, path);
+                    footerEl.textContent = cells.length === 1 ? '1 cell' : cells.length + ' cells';
+                }
+
                 function openCellListPopover(anchorEl, title, severity, cells, memoryKey, filePath) {
                     const root = document.getElementById('cellListPopover');
                     const backdrop = document.getElementById('cellListPopoverBackdrop');
@@ -1934,35 +2046,7 @@ function getWebviewContent(
                     titleEl.className = 'cell-list-popover-title title-' + severity;
                     titleEl.textContent = title;
                     countEl.textContent = String(cells.length);
-                    if (cells.length === 0) {
-                        bodyEl.innerHTML = '<div class="cell-list-popover-empty">No cells in this bucket.</div>';
-                    } else {
-                        // Entries are { label, cellId } now (see
-                        // analyzeNotebookAudioStats). When cellId + filePath
-                        // are both present we render a clickable button that
-                        // deep-links into the editor; otherwise we fall back
-                        // to a static row so older payload shapes don't
-                        // crash the popover.
-                        bodyEl.innerHTML = cells
-                            .map(entry => {
-                                const label = (entry && typeof entry === 'object') ? entry.label : entry;
-                                const cellId = (entry && typeof entry === 'object') ? entry.cellId : '';
-                                const clickable = !!(cellId && filePath);
-                                if (clickable) {
-                                    return [
-                                        '<button type="button" class="cell-list-popover-item is-clickable"',
-                                        ' data-cell-id="' + escapeHtml(String(cellId)) + '"',
-                                        ' data-file-path="' + escapeHtml(String(filePath)) + '"',
-                                        ' title="Open this cell in the editor">',
-                                        '<span class="cell-list-popover-item-label">' + escapeHtml(String(label || '')) + '</span>',
-                                        '<i class="codicon codicon-arrow-right cell-list-popover-item-icon" aria-hidden="true"></i>',
-                                        '</button>'
-                                    ].join('');
-                                }
-                                return '<div class="cell-list-popover-item">' + escapeHtml(String(label || '')) + '</div>';
-                            })
-                            .join('');
-                    }
+                    bodyEl.innerHTML = renderCellListPopoverBody(cells, filePath);
                     footerEl.textContent = cells.length === 1
                         ? '1 cell'
                         : cells.length + ' cells';
@@ -2086,8 +2170,13 @@ function getWebviewContent(
                         if (!target || !target.closest) return;
 
                         // Clickable cell row inside the popover — deep-link
-                        // into the codex editor. Handled BEFORE the outside-
-                        // click check below so the popover closes cleanly.
+                        // into the codex editor. We intentionally KEEP the
+                        // popover open: opening the cell sends the export tab
+                        // to the background, and the user wants the list still
+                        // there when they return so they can work through the
+                        // affected cells one by one. (As each cell is fixed and
+                        // saved, the live stats refresh drops it from the list.)
+                        // Handled before the outside-click fallback below.
                         const cellRow = target.closest('button.cell-list-popover-item.is-clickable');
                         if (cellRow) {
                             const cellId = cellRow.getAttribute('data-cell-id');
@@ -2098,7 +2187,6 @@ function getWebviewContent(
                                     cellId: cellId,
                                     filePath: filePath,
                                 });
-                                closeCellListPopover();
                                 event.stopPropagation();
                                 return;
                             }
@@ -2182,6 +2270,172 @@ function getWebviewContent(
                     }, true);
                 }
 
+                /*
+                 * Builds the audio-stat pill row for one file. Shared between
+                 * the initial render and the live per-file patch
+                 * (applyFileAudioStatsUpdate) so both always agree on layout,
+                 * severity ordering, and which buckets get a drill-down pill.
+                 * Returns '' when there's nothing to show.
+                 */
+                function buildAudioStatsHtml(f, gIdx, fIdx) {
+                    if (!f.audioStats || !(f.audioStats.eligibleCellCount > 0)) return '';
+                    const parts = [];
+                    if (f.audioStats.audioReadyCount > 0) {
+                        // No drill-down for the "ready" bucket — these
+                        // cells will export fine, nothing actionable.
+                        parts.push('<span>' + f.audioStats.audioReadyCount + ' with audio</span>');
+                    }
+                    // Severity ordering matches the post-export
+                    // summary: errors first, then warns, then info.
+                    if (f.audioStats.selectionMissingCount > 0) {
+                        parts.push(renderStatPill(
+                            gIdx, fIdx,
+                            'selectionMissing',
+                            'error',
+                            f.audioStats.selectionMissingCount,
+                            'with selected audio missing',
+                            f.displayName + ' — selected audio is missing'
+                        ));
+                    }
+                    if (f.audioStats.selectedPossiblyMissingCount > 0) {
+                        parts.push(renderStatPill(
+                            gIdx, fIdx,
+                            'selectedPossiblyMissing',
+                            'warn',
+                            f.audioStats.selectedPossiblyMissingCount,
+                            'with selected take possibly missing',
+                            f.displayName + ' — selected take flagged as possibly missing'
+                        ));
+                    }
+                    if (f.audioStats.noneSelectedCount > 0) {
+                        parts.push(renderStatPill(
+                            gIdx, fIdx,
+                            'noneSelected',
+                            'warn',
+                            f.audioStats.noneSelectedCount,
+                            'with audio, none selected',
+                            f.displayName + ' — audio available, none selected'
+                        ));
+                    }
+                    if (f.audioStats.noAudioRecordedCount > 0) {
+                        parts.push(renderStatPill(
+                            gIdx, fIdx,
+                            'noAudioRecorded',
+                            'info',
+                            f.audioStats.noAudioRecordedCount,
+                            'without audio',
+                            f.displayName + ' — cells without audio'
+                        ));
+                    }
+                    if (parts.length === 0) return '';
+                    return '<div class="file-audio-stats">' + parts.join(' \u00b7 ') + '</div>';
+                }
+
+                /*
+                 * Builds the markup for a single file row. Extracted so the
+                 * live patch can re-render just one row when a .codex is saved.
+                 */
+                function renderFileItem(group, f, gIdx, fIdx) {
+                    const id = 'file-' + gIdx + '-' + fIdx;
+                    const isEmpty = !f.hasTranslations && !f.hasAudio;
+                    const isAudioOnly = !f.hasTranslations && f.hasAudio;
+                    const isTextOnly = f.hasTranslations && !f.hasAudio;
+                    const isTextAudio = f.hasTranslations && f.hasAudio;
+                    const contentType = isEmpty ? 'none' : (isAudioOnly ? 'audio-only' : (isTextOnly ? 'text-only' : 'text-audio'));
+                    const disabledAttr = isEmpty ? 'disabled' : '';
+                    const itemClass = 'file-item' + (isEmpty ? ' file-item-disabled' : '');
+                    let tooltip = f.displayName;
+                    if (isEmpty) tooltip = 'No translations or audio to export';
+                    else if (isAudioOnly) tooltip = f.displayName + ' (audio only)';
+                    else if (isTextOnly) tooltip = f.displayName + ' (text only)';
+                    else if (isTextAudio) tooltip = f.displayName + ' (text + audio)';
+                    let statusTag = '';
+                    if (isEmpty) {
+                        statusTag = '<span class="file-status-tag no-content-tag">No content</span>';
+                    } else if (isAudioOnly) {
+                        statusTag = '<span class="file-status-tag audio-only-tag">Audio only</span>';
+                    } else if (isTextOnly) {
+                        statusTag = '<span class="file-status-tag text-only-tag">Text only</span>';
+                    } else if (isTextAudio) {
+                        statusTag = '<span class="file-status-tag text-audio-tag">Text + Audio</span>';
+                    }
+                    const audioStatsHtml = buildAudioStatsHtml(f, gIdx, fIdx);
+                    return \`
+                                <div class="\${itemClass}" data-content-type="\${contentType}">
+                                    <input type="checkbox" id="\${id}" value="\${f.path}" data-group-key="\${group.groupKey}" data-content-type="\${contentType}" \${disabledAttr} onchange="onFileCheckboxChange()">
+                                    <div class="file-item-main">
+                                        <label for="\${id}" title="\${tooltip}">\${f.displayName}</label>
+                                        \${audioStatsHtml}
+                                    </div>
+                                    \${statusTag}
+                                </div>
+                            \`;
+                }
+
+                /*
+                 * Live patch: a .codex was saved while the wizard is open, so
+                 * re-render just that file's row (keeping its checkbox selection
+                 * and refreshing filter/footer state). Falls back silently when
+                 * the file isn't on screen (e.g. a brand-new .codex — picked up
+                 * on the next time the wizard opens).
+                 */
+                function applyFileAudioStatsUpdate(path, hasAudio, hasTranslations, audioStats) {
+                    let gIdx = -1, fIdx = -1, group = null, f = null;
+                    for (let gi = 0; gi < fileGroups.length; gi++) {
+                        const files = fileGroups[gi].files;
+                        for (let fi = 0; fi < files.length; fi++) {
+                            if (files[fi].path === path) {
+                                gIdx = gi; fIdx = fi; group = fileGroups[gi]; f = files[fi];
+                                break;
+                            }
+                        }
+                        if (f) break;
+                    }
+                    if (!f) return;
+
+                    f.hasAudio = hasAudio;
+                    f.hasTranslations = hasTranslations;
+                    f.audioStats = audioStats;
+
+                    const cb = document.getElementById('file-' + gIdx + '-' + fIdx);
+                    const item = cb ? cb.closest('.file-item') : null;
+                    if (!item) return;
+
+                    const wasChecked = !!(cb && cb.checked);
+                    const tmp = document.createElement('div');
+                    tmp.innerHTML = renderFileItem(group, f, gIdx, fIdx).trim();
+                    const fresh = tmp.firstElementChild;
+                    if (!fresh) return;
+                    item.replaceWith(fresh);
+
+                    // Restore selection: the template renders unchecked, but the
+                    // file may still be selected. If it just became empty
+                    // (no content), drop it from the selection instead.
+                    const newCb = document.getElementById('file-' + gIdx + '-' + fIdx);
+                    const isEmptyNow = !f.hasTranslations && !f.hasAudio;
+                    if (newCb) {
+                        if (isEmptyNow) {
+                            newCb.checked = false;
+                            selectedFiles.delete(path);
+                        } else {
+                            newCb.checked = wasChecked;
+                            if (wasChecked) selectedFiles.add(path); else selectedFiles.delete(path);
+                        }
+                    }
+
+                    // Refresh dependent UI (group lock, compatibility, footer).
+                    updateSelectedGroup();
+                    syncHeaderCheckboxes();
+                    updateStep1Button();
+
+                    // If the drill-down popover is open for THIS file, refresh
+                    // its list in place (the popover is a separate top-level
+                    // element, so re-rendering the row above didn't disturb it).
+                    // This keeps the list open while the user fixes cells, with
+                    // fixed cells dropping out as their saves arrive.
+                    refreshOpenCellListPopover(path, audioStats);
+                }
+
                 function renderFileGroups() {
                     const container = document.getElementById('fileGroupsContainer');
                     if (!container) return;
@@ -2195,95 +2449,7 @@ function getWebviewContent(
                         const groupDisabled = enabledCount === 0;
                         const hasTextFiles = group.files.some(f => f.hasTranslations);
                         const hasAudioFiles = group.files.some(f => f.hasAudio);
-                        const filesHtml = group.files.map((f, fIdx) => {
-                            const id = 'file-' + gIdx + '-' + fIdx;
-                            const isEmpty = !f.hasTranslations && !f.hasAudio;
-                            const isAudioOnly = !f.hasTranslations && f.hasAudio;
-                            const isTextOnly = f.hasTranslations && !f.hasAudio;
-                            const isTextAudio = f.hasTranslations && f.hasAudio;
-                            const contentType = isEmpty ? 'none' : (isAudioOnly ? 'audio-only' : (isTextOnly ? 'text-only' : 'text-audio'));
-                            const disabledAttr = isEmpty ? 'disabled' : '';
-                            const itemClass = 'file-item' + (isEmpty ? ' file-item-disabled' : '');
-                            let tooltip = f.displayName;
-                            if (isEmpty) tooltip = 'No translations or audio to export';
-                            else if (isAudioOnly) tooltip = f.displayName + ' (audio only)';
-                            else if (isTextOnly) tooltip = f.displayName + ' (text only)';
-                            else if (isTextAudio) tooltip = f.displayName + ' (text + audio)';
-                            let statusTag = '';
-                            if (isEmpty) {
-                                statusTag = '<span class="file-status-tag no-content-tag">No content</span>';
-                            } else if (isAudioOnly) {
-                                statusTag = '<span class="file-status-tag audio-only-tag">Audio only</span>';
-                            } else if (isTextOnly) {
-                                statusTag = '<span class="file-status-tag text-only-tag">Text only</span>';
-                            } else if (isTextAudio) {
-                                statusTag = '<span class="file-status-tag text-audio-tag">Text + Audio</span>';
-                            }
-                            let audioStatsHtml = '';
-                            if (f.audioStats && f.audioStats.eligibleCellCount > 0) {
-                                const parts = [];
-                                if (f.audioStats.audioReadyCount > 0) {
-                                    // No drill-down for the "ready" bucket — these
-                                    // cells will export fine, nothing actionable.
-                                    parts.push('<span>' + f.audioStats.audioReadyCount + ' with audio</span>');
-                                }
-                                // Severity ordering matches the post-export
-                                // summary: errors first, then warns, then info.
-                                if (f.audioStats.selectionMissingCount > 0) {
-                                    parts.push(renderStatPill(
-                                        gIdx, fIdx,
-                                        'selectionMissing',
-                                        'error',
-                                        f.audioStats.selectionMissingCount,
-                                        'with selected audio missing',
-                                        f.displayName + ' — selected audio is missing'
-                                    ));
-                                }
-                                if (f.audioStats.selectedPossiblyMissingCount > 0) {
-                                    parts.push(renderStatPill(
-                                        gIdx, fIdx,
-                                        'selectedPossiblyMissing',
-                                        'warn',
-                                        f.audioStats.selectedPossiblyMissingCount,
-                                        'with selected take possibly missing',
-                                        f.displayName + ' — selected take flagged as possibly missing'
-                                    ));
-                                }
-                                if (f.audioStats.noneSelectedCount > 0) {
-                                    parts.push(renderStatPill(
-                                        gIdx, fIdx,
-                                        'noneSelected',
-                                        'warn',
-                                        f.audioStats.noneSelectedCount,
-                                        'with audio, none selected',
-                                        f.displayName + ' — audio available, none selected'
-                                    ));
-                                }
-                                if (f.audioStats.noAudioRecordedCount > 0) {
-                                    parts.push(renderStatPill(
-                                        gIdx, fIdx,
-                                        'noAudioRecorded',
-                                        'info',
-                                        f.audioStats.noAudioRecordedCount,
-                                        'without audio',
-                                        f.displayName + ' — cells without audio'
-                                    ));
-                                }
-                                if (parts.length > 0) {
-                                    audioStatsHtml = '<div class="file-audio-stats">' + parts.join(' \u00b7 ') + '</div>';
-                                }
-                            }
-                            return \`
-                                <div class="\${itemClass}" data-content-type="\${contentType}">
-                                    <input type="checkbox" id="\${id}" value="\${f.path}" data-group-key="\${group.groupKey}" data-content-type="\${contentType}" \${disabledAttr} onchange="onFileCheckboxChange()">
-                                    <div class="file-item-main">
-                                        <label for="\${id}" title="\${tooltip}">\${f.displayName}</label>
-                                        \${audioStatsHtml}
-                                    </div>
-                                    \${statusTag}
-                                </div>
-                            \`;
-                        }).join('');
+                        const filesHtml = group.files.map((f, fIdx) => renderFileItem(group, f, gIdx, fIdx)).join('');
                         return \`
                             <div class="file-group" id="\${groupId}" data-group-key="\${group.groupKey}">
                                 <div class="file-group-header">
@@ -3135,6 +3301,17 @@ function getWebviewContent(
                         const el = document.getElementById('exportPath');
                         if (el) el.textContent = message.path;
                         updateExportButton();
+                        return;
+                    }
+                    if (message.command === 'fileAudioStatsUpdated') {
+                        // A .codex was saved while the wizard is open — patch
+                        // just that file's row so the Step 1 counts stay live.
+                        applyFileAudioStatsUpdate(
+                            message.path,
+                            message.hasAudio,
+                            message.hasTranslations,
+                            message.audioStats
+                        );
                         return;
                     }
                     if (message.command === 'htmlStructureCheckResult') {

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1,5 +1,5 @@
 import { CodexExportFormat, exportCodexContent, checkSubtitleOverlapsAndConfirm } from "../exportHandler/exportHandler";
-import { createWebviewReporter } from "../exportHandler/exportProgress";
+import { createWebviewReporter, type ExportProgressReporter } from "../exportHandler/exportProgress";
 import * as fs from "fs";
 import * as vscode from "vscode";
 import { safePostMessageToPanel } from "../utils/webviewUtils";
@@ -372,6 +372,122 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
                     );
                 }
                 break;
+            case "retryExport": {
+                // Targeted retry: re-attempt only the cells that failed (with a
+                // transient/recoverable reason) and merge any recovered audio
+                // back into the original export folder. Audio-only path —
+                // download/transcode/write failures only happen there.
+                if (isExporting) {
+                    break;
+                }
+                const audioOutputPath = message.audioOutputPath as string | undefined;
+                const targets = message.targets as
+                    | { cellId: string; codexPath: string; }[]
+                    | undefined;
+                if (!audioOutputPath || !targets || targets.length === 0) {
+                    break;
+                }
+
+                // Group target cellIds by their codex file.
+                const retryCellFilter = new Map<string, Set<string>>();
+                for (const t of targets) {
+                    if (!t?.cellId || !t?.codexPath) continue;
+                    let set = retryCellFilter.get(t.codexPath);
+                    if (!set) {
+                        set = new Set<string>();
+                        retryCellFilter.set(t.codexPath, set);
+                    }
+                    set.add(t.cellId);
+                }
+                const codexPaths = Array.from(retryCellFilter.keys());
+                if (codexPaths.length === 0) {
+                    break;
+                }
+
+                // Custom reporter: still-failing cells stream back as
+                // `exportFileMissing` (so the issues list refreshes), but the
+                // terminal state is a `retryCompleted` — distinct from a full
+                // export's complete/error so the completion screen and its
+                // existing issue list aren't torn down.
+                const retryReporter: ExportProgressReporter = {
+                    report: () => undefined,
+                    fileMissing: (file, reason, detail, location) => {
+                        safePostMessageToPanel(
+                            panel,
+                            {
+                                command: "exportFileMissing",
+                                file,
+                                reason,
+                                detail,
+                                cellId: location?.cellId,
+                                codexPath: location?.codexPath,
+                            },
+                            "ProjectExport"
+                        );
+                    },
+                    complete: (summary) => {
+                        safePostMessageToPanel(
+                            panel,
+                            { command: "retryCompleted", summary },
+                            "ProjectExport"
+                        );
+                    },
+                    error: (errMessage) => {
+                        safePostMessageToPanel(
+                            panel,
+                            { command: "retryCompleted", error: errMessage },
+                            "ProjectExport"
+                        );
+                    },
+                    cancelled: () => {
+                        safePostMessageToPanel(
+                            panel,
+                            { command: "retryCompleted", cancelled: true },
+                            "ProjectExport"
+                        );
+                    },
+                };
+
+                activeExportCts = new vscode.CancellationTokenSource();
+                isExporting = true;
+                try {
+                    const { exportAudioAttachments } = await import(
+                        "../exportHandler/audioExporter"
+                    );
+                    await exportAudioAttachments(
+                        audioOutputPath,
+                        codexPaths,
+                        retryReporter,
+                        {
+                            // Reproduce timestamp behaviour so retried files
+                            // match the original. Milestones are intentionally
+                            // omitted — the cell filter is authoritative.
+                            includeTimestamps: message.options?.includeTimestamps === true,
+                            retryCellFilter,
+                        },
+                        activeExportCts.token
+                    );
+                } catch (error) {
+                    if (!activeExportCts.token.isCancellationRequested) {
+                        safePostMessageToPanel(
+                            panel,
+                            {
+                                command: "retryCompleted",
+                                error:
+                                    error instanceof Error
+                                        ? error.message
+                                        : "Retry failed.",
+                            },
+                            "ProjectExport"
+                        );
+                    }
+                } finally {
+                    isExporting = false;
+                    activeExportCts.dispose();
+                    activeExportCts = undefined;
+                }
+                break;
+            }
             case "openExportFolder": {
                 const target = message.path as string | undefined;
                 if (target && fs.existsSync(target)) {
@@ -1041,6 +1157,33 @@ function getWebviewContent(
                     flex-direction: column;
                     gap: 6px;
                 }
+                .export-issues-toolbar {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 8px;
+                    padding: 0 2px 2px;
+                }
+                .export-issues-summary {
+                    font-size: 0.82em;
+                    color: var(--vscode-descriptionForeground);
+                }
+                .export-issues-toggle-all {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 5px;
+                    font: inherit;
+                    font-size: 0.82em;
+                    color: var(--vscode-textLink-foreground);
+                    background: transparent;
+                    border: none;
+                    cursor: pointer;
+                    padding: 2px 4px;
+                    -webkit-appearance: none;
+                    appearance: none;
+                }
+                .export-issues-toggle-all:hover { text-decoration: underline; }
+                .export-issues-toggle-all .codicon { font-size: 0.95em; }
                 .export-issue-group {
                     border: 1px solid var(--vscode-input-border);
                     border-radius: 6px;
@@ -1143,23 +1286,17 @@ function getWebviewContent(
                 button.export-issue-item:focus-visible {
                     box-shadow: inset 0 0 0 1px var(--vscode-focusBorder, transparent);
                 }
-                .export-issue-group.sev-error .export-issue-icon { color: var(--vscode-errorForeground, #dc2626); }
-                .export-issue-group.sev-error .export-issue-count {
-                    color: var(--vscode-errorForeground, #dc2626);
-                    background-color: rgba(220, 38, 38, 0.10);
-                    border-color: rgba(220, 38, 38, 0.32);
-                }
-                .export-issue-group.sev-warn .export-issue-icon { color: var(--vscode-charts-yellow, #ca8a04); }
-                .export-issue-group.sev-warn .export-issue-count {
+                /*
+                 * All issue groups share one accent (amber) regardless of
+                 * severity — the icon glyph already conveys the distinction,
+                 * and a uniform colour reads as a single calm "things to
+                 * review" list rather than a red/yellow/grey alarm board.
+                 */
+                .export-issue-group .export-issue-icon { color: var(--vscode-charts-yellow, #ca8a04); }
+                .export-issue-group .export-issue-count {
                     color: var(--vscode-charts-yellow, #ca8a04);
                     background-color: rgba(202, 138, 4, 0.10);
                     border-color: rgba(202, 138, 4, 0.32);
-                }
-                .export-issue-group.sev-info .export-issue-icon { color: var(--vscode-descriptionForeground); }
-                .export-issue-group.sev-info .export-issue-count {
-                    color: var(--vscode-descriptionForeground);
-                    background-color: var(--vscode-input-background);
-                    border-color: var(--vscode-input-border);
                 }
 
                 /*
@@ -1668,6 +1805,10 @@ function getWebviewContent(
                             </div>
 
                             <div class="export-action-row" id="exportActionRow" style="display:none;">
+                                <button class="secondary" id="exportRetryBtn" onclick="retryFailedExport()" style="display:none;">
+                                    <i class="codicon codicon-refresh"></i>
+                                    <span id="exportRetryBtnText">Retry failed</span>
+                                </button>
                                 <button class="secondary" id="exportOpenFolderBtn" onclick="openExportFolder()">
                                     <i class="codicon codicon-folder-opened"></i>
                                     Open Export Folder
@@ -2932,9 +3073,29 @@ function getWebviewContent(
                     // list once the export completes.
                     missingFiles: [],
                     outputPath: null,
+                    // Folder the audio files landed in (may be an audio/ subfolder
+                    // for multi-format). A targeted retry writes recovered files
+                    // back here.
+                    audioOutputPath: null,
+                    // Options from the last export request, reused for retry.
+                    lastOptions: null,
+                    // True while a targeted "retry failed downloads" is running.
+                    retrying: false,
+                    // How many cells the in-flight retry attempted (for the
+                    // "X recovered, Y still failing" summary).
+                    retryAttempted: 0,
                     lastTitle: 'Exporting...',
                     lastSubtitle: 'This may take a moment. Please keep this view open.',
                 };
+
+                // Failure reasons that are worth retrying — transient / recoverable
+                // (network, disk, transcode hiccups). User-action reasons (no take
+                // chosen, selected-missing, nothing recorded) are excluded.
+                const RETRYABLE_EXPORT_REASONS = new Set([
+                    'download-failed',
+                    'transcode-failed',
+                    'write-failed',
+                ]);
 
                 function resetExportProgressView() {
                     exportState.started = false;
@@ -2946,6 +3107,9 @@ function getWebviewContent(
                     exportState.extraMessages = [];
                     exportState.missingFiles = [];
                     exportState.outputPath = null;
+                    exportState.audioOutputPath = null;
+                    exportState.retrying = false;
+                    exportState.retryAttempted = 0;
                     exportState.lastTitle = 'Exporting...';
                     exportState.lastSubtitle = 'This may take a moment. Please keep this view open.';
 
@@ -3151,6 +3315,29 @@ function getWebviewContent(
                 function toggleExportIssue(headerEl) {
                     const group = headerEl.closest('.export-issue-group');
                     if (group) group.classList.toggle('open');
+                    syncExpandAllLabel();
+                }
+
+                // Expand / collapse every issue group at once. If any group is
+                // still collapsed, the action expands all; otherwise it collapses
+                // all.
+                function toggleAllExportIssues() {
+                    const groups = Array.from(document.querySelectorAll('#exportIssues .export-issue-group'));
+                    if (groups.length === 0) return;
+                    const anyClosed = groups.some(g => !g.classList.contains('open'));
+                    groups.forEach(g => g.classList.toggle('open', anyClosed));
+                    syncExpandAllLabel();
+                }
+
+                // Keep the toggle's label/icon in sync with the current state.
+                function syncExpandAllLabel() {
+                    const btn = document.getElementById('exportIssuesToggleAll');
+                    if (!btn) return;
+                    const groups = Array.from(document.querySelectorAll('#exportIssues .export-issue-group'));
+                    const allOpen = groups.length > 0 && groups.every(g => g.classList.contains('open'));
+                    btn.innerHTML = allOpen
+                        ? '<i class="codicon codicon-collapse-all"></i>Collapse all'
+                        : '<i class="codicon codicon-expand-all"></i>Expand all';
                 }
 
                 function renderExportIssues() {
@@ -3182,7 +3369,17 @@ function getWebviewContent(
                         return String(ma.label).localeCompare(String(mb.label));
                     });
 
-                    container.innerHTML = ordered.map(([reason, list]) => {
+                    // Header bar: total count + an expand/collapse-all toggle.
+                    const totalIssues = items.length;
+                    const headerHtml =
+                        '<div class="export-issues-toolbar">' +
+                            '<span class="export-issues-summary">' + totalIssues + ' item' + (totalIssues === 1 ? '' : 's') + ' to review</span>' +
+                            '<button type="button" class="export-issues-toggle-all" id="exportIssuesToggleAll" onclick="toggleAllExportIssues()">' +
+                                '<i class="codicon codicon-expand-all"></i>Expand all' +
+                            '</button>' +
+                        '</div>';
+
+                    const groupsHtml = ordered.map(([reason, list]) => {
                         const meta = EXPORT_REASON_META[reason] || {
                             severity: 'error',
                             icon: 'error',
@@ -3231,7 +3428,10 @@ function getWebviewContent(
                             '</div>'
                         );
                     }).join('');
+                    container.innerHTML = headerHtml + groupsHtml;
                     container.style.display = 'flex';
+                    syncExpandAllLabel();
+                    updateRetryButton();
                 }
 
                 function showOutputPath(path) {
@@ -3326,6 +3526,88 @@ function getWebviewContent(
                     const openBtn = document.getElementById('exportOpenFolderBtn');
                     if (actionRow) actionRow.style.display = 'flex';
                     if (openBtn) openBtn.style.display = (success && exportState.outputPath) ? 'flex' : 'none';
+                }
+
+                // Failed cells worth retrying: transient/recoverable reason AND
+                // we know which cell to re-run (cellId + codexPath).
+                function getRetryTargets() {
+                    return (exportState.missingFiles || []).filter(it =>
+                        it && it.cellId && it.codexPath && RETRYABLE_EXPORT_REASONS.has(it.reason)
+                    );
+                }
+
+                function updateRetryButton() {
+                    const btn = document.getElementById('exportRetryBtn');
+                    if (!btn) return;
+                    if (exportState.retrying) {
+                        btn.style.display = 'flex';
+                        btn.disabled = true;
+                        return;
+                    }
+                    const targets = getRetryTargets();
+                    const canRetry = targets.length > 0 && !!exportState.audioOutputPath;
+                    btn.style.display = canRetry ? 'flex' : 'none';
+                    btn.disabled = false;
+                    const txt = document.getElementById('exportRetryBtnText');
+                    if (txt) txt.textContent = 'Retry failed (' + targets.length + ')';
+                }
+
+                function retryFailedExport() {
+                    if (exportState.retrying) return;
+                    const targets = getRetryTargets();
+                    if (targets.length === 0 || !exportState.audioOutputPath) return;
+
+                    const retrySet = new Set(targets.map(t => t.cellId));
+                    // Remove the cells we're about to re-run; the ones that fail
+                    // again stream back in via exportFileMissing.
+                    exportState.missingFiles = (exportState.missingFiles || []).filter(it =>
+                        !(it && it.cellId && RETRYABLE_EXPORT_REASONS.has(it.reason) && retrySet.has(it.cellId))
+                    );
+                    exportState.retrying = true;
+                    exportState.retryAttempted = targets.length;
+                    renderExportIssues();
+
+                    const btnText = document.getElementById('exportRetryBtnText');
+                    if (btnText) btnText.textContent = 'Retrying ' + targets.length + '…';
+                    const closeBtn = document.getElementById('exportCloseBtn');
+                    if (closeBtn) closeBtn.disabled = true;
+                    setExportTitle(
+                        'Retrying ' + targets.length + ' cell' + (targets.length === 1 ? '' : 's') + '…',
+                        'Re-attempting the recordings that could not be exported.'
+                    );
+
+                    vscode.postMessage({
+                        command: 'retryExport',
+                        audioOutputPath: exportState.audioOutputPath,
+                        options: exportState.lastOptions || {},
+                        targets: targets.map(t => ({ cellId: t.cellId, codexPath: t.codexPath })),
+                    });
+                }
+
+                function finishRetry(message) {
+                    exportState.retrying = false;
+                    const closeBtn = document.getElementById('exportCloseBtn');
+                    if (closeBtn) closeBtn.disabled = false;
+
+                    if (message && message.error) {
+                        setExportTitle('Retry failed', String(message.error));
+                    } else if (!(message && message.cancelled)) {
+                        const stillFailing = getRetryTargets().length;
+                        const attempted = exportState.retryAttempted || 0;
+                        const recovered = Math.max(0, attempted - stillFailing);
+                        let subtitle;
+                        if (stillFailing === 0) {
+                            subtitle = recovered > 0
+                                ? 'Recovered ' + recovered + ' recording' + (recovered === 1 ? '' : 's') + '.'
+                                : 'Nothing left to retry.';
+                        } else {
+                            subtitle = recovered + ' recovered, ' + stillFailing + ' still need attention.';
+                        }
+                        setExportTitle(exportState.succeeded ? 'Export complete' : exportState.lastTitle, subtitle);
+                    }
+
+                    renderExportIssues();
+                    updateRetryButton();
                 }
 
                 function enterExportingView() {
@@ -3428,7 +3710,10 @@ function getWebviewContent(
                         // an expandable, grouped breakdown. Stop collecting once
                         // we've reached a terminal state (late events from
                         // in-flight work draining after a cancel).
-                        if (exportState.finished || exportState.cancelled) return;
+                        // During a targeted retry the run is already "finished",
+                        // but we still want to collect the cells that failed
+                        // again so the issues list reflects the new state.
+                        if ((exportState.finished && !exportState.retrying) || exportState.cancelled) return;
                         exportState.missingFiles.push({
                             file: message.file,
                             reason: message.reason,
@@ -3436,6 +3721,11 @@ function getWebviewContent(
                             cellId: message.cellId,
                             codexPath: message.codexPath,
                         });
+                        if (exportState.retrying) {
+                            // Live-refresh while retrying so recovered cells drop
+                            // off and any that still fail re-appear.
+                            renderExportIssues();
+                        }
                         return;
                     }
                     if (message.command === 'exportCompleted') {
@@ -3444,6 +3734,7 @@ function getWebviewContent(
                         if (exportState.cancelled) return;
                         const summary = message.summary || {};
                         if (summary.exportPath) showOutputPath(summary.exportPath);
+                        if (summary.audioExportPath) exportState.audioOutputPath = summary.audioExportPath;
                         if (summary.extraMessages && summary.extraMessages.length > 0) {
                             showExtraMessages(summary.extraMessages);
                         }
@@ -3462,6 +3753,10 @@ function getWebviewContent(
                         // Terminal: the host deleted the partial output and will
                         // not send complete/error for this run.
                         showExportCancelled();
+                        return;
+                    }
+                    if (message.command === 'retryCompleted') {
+                        finishRetry(message);
                         return;
                     }
                     if (message.command === 'subtitleOverlapResult') {
@@ -3652,6 +3947,9 @@ function getWebviewContent(
                     // the user does not see Cancel / Back / Export anymore. The host
                     // also broadcasts exportStarted, which is idempotent.
                     enterExportingView();
+                    // Remember the options so a "retry failed downloads" can
+                    // reproduce the same export behaviour (e.g. timestamps).
+                    exportState.lastOptions = options;
                     vscode.postMessage({
                         command: 'export',
                         format: formatToSend,

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -100,6 +100,20 @@ async function checkHtmlStructureMismatches(
  */
 let activeExportPanel: vscode.WebviewPanel | undefined;
 
+/**
+ * Cancellation source for the export currently running in the active panel.
+ * Created when an export starts and disposed when it settles. Used to abort the
+ * run when the user clicks Cancel or closes the export tab mid-export.
+ */
+let activeExportCts: vscode.CancellationTokenSource | undefined;
+
+/**
+ * True while an export is actively running in the active panel. Guards against
+ * starting a second export (e.g. the run still draining its in-flight LFS
+ * downloads after a cancel) before the first has settled.
+ */
+let isExporting = false;
+
 export async function openProjectExportView(context: vscode.ExtensionContext) {
     if (activeExportPanel) {
         // Bring the existing wizard forward instead of stacking another one.
@@ -126,6 +140,12 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
     );
     activeExportPanel = panel;
     panel.onDidDispose(() => {
+        // Closing the tab while an export is running aborts it (and triggers the
+        // engine's partial-output cleanup). This also prevents a stale run from
+        // continuing in the background after the panel is gone.
+        if (isExporting) {
+            activeExportCts?.cancel();
+        }
         if (activeExportPanel === panel) {
             activeExportPanel = undefined;
         }
@@ -222,6 +242,11 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
                 );
                 break;
             case "export":
+                // Guard against a second export starting while one is still
+                // running (or draining in-flight downloads after a cancel).
+                if (isExporting) {
+                    break;
+                }
                 try {
                     // For round-trip exports, check for HTML structure mismatches and prompt
                     if (message.format === "rebuild-export" && message.filesToExport?.length) {
@@ -251,23 +276,39 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
 
                     const reporter = createWebviewReporter(panel, "ProjectExport");
 
+                    // Fresh cancellation source for this run. The token is
+                    // threaded through the export engine so Cancel / tab-close
+                    // can stop downloads and trigger partial-output cleanup.
+                    activeExportCts = new vscode.CancellationTokenSource();
+                    isExporting = true;
                     try {
                         await exportCodexContent(
                             message.format as CodexExportFormat,
                             message.userSelectedPath,
                             message.filesToExport,
                             message.options,
-                            reporter
+                            reporter,
+                            activeExportCts.token
                         );
                     } catch (error) {
-                        reporter.error(
-                            error instanceof Error
-                                ? error.message
-                                : "Failed to export project. Please check your configuration."
-                        );
+                        // A cancellation surfaces here as an AbortError from an
+                        // in-flight download; the engine has already emitted the
+                        // `cancelled` event and cleaned up, so don't also report
+                        // it as a failure.
+                        if (!activeExportCts.token.isCancellationRequested) {
+                            reporter.error(
+                                error instanceof Error
+                                    ? error.message
+                                    : "Failed to export project. Please check your configuration."
+                            );
+                        }
+                    } finally {
+                        isExporting = false;
+                        activeExportCts.dispose();
+                        activeExportCts = undefined;
                     }
                     // Intentionally do NOT dispose the panel. The webview owns
-                    // the success/error UI and the user clicks Close when ready.
+                    // the success/error/cancelled UI and the user clicks Close when ready.
                 } catch (error) {
                     safePostMessageToPanel(
                         panel,
@@ -340,6 +381,12 @@ export async function openProjectExportView(context: vscode.ExtensionContext) {
             }
             case "cancel":
                 panel.dispose();
+                break;
+            case "cancelExport":
+                // Stop the in-progress export. Keep the panel open: the engine
+                // cleans up partial output and emits `exportCancelled`, which
+                // the webview renders as a terminal cancelled state.
+                activeExportCts?.cancel();
                 break;
         }
     });
@@ -1427,6 +1474,13 @@ function getWebviewContent(
                             <div class="export-extra-messages" id="exportExtraMessages" style="display:none;"></div>
 
                             <div class="export-output-path" id="exportOutputPath" style="display:none;"></div>
+
+                            <div class="export-action-row" id="exportCancelRow">
+                                <button class="secondary" id="exportCancelBtn" onclick="cancelExportRun()">
+                                    <i class="codicon codicon-close"></i>
+                                    Cancel
+                                </button>
+                            </div>
 
                             <div class="export-action-row" id="exportActionRow" style="display:none;">
                                 <button class="secondary" id="exportOpenFolderBtn" onclick="openExportFolder()">
@@ -2521,12 +2575,25 @@ function getWebviewContent(
                     vscode.postMessage({ command: 'cancel' });
                 }
 
+                function cancelExportRun() {
+                    // Avoid a double-send if the user mashes the button; also a
+                    // no-op once the run has already settled.
+                    if (exportState.finished || exportState.cancelRequested) return;
+                    exportState.cancelRequested = true;
+                    const btn = document.getElementById('exportCancelBtn');
+                    if (btn) btn.disabled = true;
+                    setExportTitle('Cancelling export...', 'Stopping downloads and cleaning up partial output.');
+                    vscode.postMessage({ command: 'cancelExport' });
+                }
+
                 // Step 4 (Exporting) state
                 const STAGE_ORDER = ['preparing', 'processing', 'downloading', 'writing', 'finalizing'];
                 const exportState = {
                     started: false,
                     finished: false,
                     succeeded: false,
+                    cancelRequested: false,
+                    cancelled: false,
                     stageIndex: -1,
                     extraMessages: [],
                     outputPath: null,
@@ -2538,6 +2605,8 @@ function getWebviewContent(
                     exportState.started = false;
                     exportState.finished = false;
                     exportState.succeeded = false;
+                    exportState.cancelRequested = false;
+                    exportState.cancelled = false;
                     exportState.stageIndex = -1;
                     exportState.extraMessages = [];
                     exportState.outputPath = null;
@@ -2546,7 +2615,7 @@ function getWebviewContent(
 
                     const icon = document.getElementById('exportProgressIcon');
                     if (icon) {
-                        icon.classList.remove('success', 'error');
+                        icon.classList.remove('success', 'error', 'warn');
                         icon.classList.add('export-spinner');
                         icon.innerHTML = '<i class="codicon codicon-sync"></i>';
                     }
@@ -2570,6 +2639,12 @@ function getWebviewContent(
 
                     const actionRow = document.getElementById('exportActionRow');
                     if (actionRow) actionRow.style.display = 'none';
+
+                    // Cancel control is visible only while the export is running.
+                    const cancelRow = document.getElementById('exportCancelRow');
+                    if (cancelRow) cancelRow.style.display = 'flex';
+                    const cancelBtn = document.getElementById('exportCancelBtn');
+                    if (cancelBtn) cancelBtn.disabled = false;
                 }
 
                 function escapeHtml(s) {
@@ -2609,12 +2684,21 @@ function getWebviewContent(
                 function handleExportStage(stageKey, message, file, current, total) {
                     const idx = STAGE_ORDER.indexOf(stageKey);
                     if (idx === -1) return;
-                    if (idx > exportState.stageIndex) {
-                        for (let i = 0; i < idx; i++) setStageState(STAGE_ORDER[i], 'done');
-                        setStageState(stageKey, 'active');
+                    // Reflect the most-recently-reported stage as the active one.
+                    // Exports interleave stages: the text exporter's "writing"
+                    // runs concurrently with audio "downloading", and audio
+                    // alternates download/write per file. A monotonic (furthest-
+                    // wins) indicator would get stuck on "Writing output" while
+                    // audio is still downloading, so we follow the latest event
+                    // instead. Only re-render when the stage actually changes to
+                    // avoid redundant DOM churn.
+                    if (idx !== exportState.stageIndex) {
+                        for (let i = 0; i < STAGE_ORDER.length; i++) {
+                            if (i < idx) setStageState(STAGE_ORDER[i], 'done');
+                            else if (i === idx) setStageState(STAGE_ORDER[i], 'active');
+                            else setStageState(STAGE_ORDER[i], 'pending');
+                        }
                         exportState.stageIndex = idx;
-                    } else if (idx === exportState.stageIndex) {
-                        setStageState(stageKey, 'active');
                     }
 
                     if (message) {
@@ -2658,16 +2742,58 @@ function getWebviewContent(
                     el.style.display = 'block';
                 }
 
+                function hideCancelRow() {
+                    const cancelRow = document.getElementById('exportCancelRow');
+                    if (cancelRow) cancelRow.style.display = 'none';
+                }
+
+                function showExportCancelled() {
+                    // Terminal state distinct from success/failure. The host has
+                    // already deleted the partial output before sending this.
+                    exportState.finished = true;
+                    exportState.cancelled = true;
+                    exportState.succeeded = false;
+
+                    hideCancelRow();
+
+                    // Reset any spinning stage row back to a static pending icon
+                    // (toggling the class alone leaves the codicon-sync spinning).
+                    document.querySelectorAll('#exportStageList .stage-row.active').forEach(row => {
+                        setStageState(row.dataset.stage, 'pending');
+                    });
+
+                    const icon = document.getElementById('exportProgressIcon');
+                    if (icon) {
+                        icon.classList.remove('export-spinner', 'success', 'error', 'warn');
+                        icon.classList.add('warn');
+                        icon.innerHTML = '<i class="codicon codicon-circle-slash"></i>';
+                    }
+
+                    setExportTitle('Export cancelled', 'The partial export was removed.');
+
+                    const currentFile = document.getElementById('exportCurrentFile');
+                    if (currentFile) { currentFile.style.display = 'none'; currentFile.textContent = ''; }
+
+                    // Output is gone, so only offer Close (no Open Folder).
+                    const actionRow = document.getElementById('exportActionRow');
+                    const openBtn = document.getElementById('exportOpenFolderBtn');
+                    if (openBtn) openBtn.style.display = 'none';
+                    if (actionRow) actionRow.style.display = 'flex';
+                }
+
                 function showExportFinished(success, summaryText) {
                     exportState.finished = true;
                     exportState.succeeded = success;
+
+                    hideCancelRow();
 
                     document.querySelectorAll('#exportStageList .stage-row').forEach(row => {
                         if (success) {
                             setStageState(row.dataset.stage, 'done');
                         } else if (row.classList.contains('active')) {
-                            row.classList.remove('active');
-                            row.classList.add('pending');
+                            // Reset via setStageState so the spinning icon stops
+                            // (toggling the class alone leaves codicon-sync spinning).
+                            setStageState(row.dataset.stage, 'pending');
                         }
                     });
 
@@ -2770,6 +2896,10 @@ function getWebviewContent(
                         return;
                     }
                     if (message.command === 'exportProgress') {
+                        // Ignore late progress once we have reached a terminal
+                        // state (e.g. trailing events from in-flight downloads
+                        // draining after a cancel).
+                        if (exportState.finished || exportState.cancelled) return;
                         const event = message.event || {};
                         if (event.stage) {
                             handleExportStage(event.stage, event.message, event.file, event.current, event.total);
@@ -2787,6 +2917,9 @@ function getWebviewContent(
                         return;
                     }
                     if (message.command === 'exportCompleted') {
+                        // A cancel that already won the race takes precedence;
+                        // don't flip a cancelled run to "complete".
+                        if (exportState.cancelled) return;
                         const summary = message.summary || {};
                         if (summary.exportPath) showOutputPath(summary.exportPath);
                         if (summary.extraMessages && summary.extraMessages.length > 0) {
@@ -2796,7 +2929,14 @@ function getWebviewContent(
                         return;
                     }
                     if (message.command === 'exportError') {
+                        if (exportState.cancelled) return;
                         showExportFinished(false, message.message || 'Export failed.');
+                        return;
+                    }
+                    if (message.command === 'exportCancelled') {
+                        // Terminal: the host deleted the partial output and will
+                        // not send complete/error for this run.
+                        showExportCancelled();
                         return;
                     }
                     if (message.command === 'subtitleOverlapResult') {

--- a/src/projectManager/utils/exportViewUtils.ts
+++ b/src/projectManager/utils/exportViewUtils.ts
@@ -5,6 +5,7 @@ import {
     isExportableCell,
     isLabelableCell,
     isTakeFlaggedMissing,
+    countUsableNonMissingTakes,
 } from "../../exportHandler/audioAttachmentUtils";
 import { formatCellDisplayLabel } from "../../exportHandler/cellLabelUtils";
 import {
@@ -227,7 +228,16 @@ export function analyzeNotebookAudioStats(
         if (state === "selection-missing") {
             selectionMissingCells.push(entry);
         } else if (state === "none-selected") {
-            noneSelectedCells.push(entry);
+            // `pickAudioAttachment` ignores `isMissing`, so a cell whose only
+            // non-deleted takes are all flagged missing still reads as
+            // "none-selected". There's nothing the user could pick that would
+            // resolve, so present it as "without audio" instead. (Mirrored in
+            // audioExporter.ts so Step 1 and the export agree.)
+            if (countUsableNonMissingTakes(cell) === 0) {
+                noAudioRecordedCells.push(entry);
+            } else {
+                noneSelectedCells.push(entry);
+            }
         } else {
             noAudioRecordedCells.push(entry);
         }

--- a/src/projectManager/utils/exportViewUtils.ts
+++ b/src/projectManager/utils/exportViewUtils.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode";
 import { CodexNotebookAsJSONData, MilestoneInfo } from "../../../types";
 import {
-    getCellAudioState,
+    pickAudioAttachment,
     isExportableCell,
     isLabelableCell,
+    isTakeFlaggedMissing,
 } from "../../exportHandler/audioAttachmentUtils";
 import { formatCellDisplayLabel } from "../../exportHandler/cellLabelUtils";
 import {
@@ -56,6 +57,13 @@ export interface NotebookAudioStats {
      */
     noneSelectedCount: number;
     /**
+     * The selected take is flagged `isMissing`. The export will still attempt
+     * to resolve it (the flag is a stale migration-scan hint), so this is a
+     * *possibly* missing warning, not a certainty — carved out of
+     * `audioReadyCount` so the user is forewarned before committing.
+     */
+    selectedPossiblyMissingCount: number;
+    /**
      * Cells in each non-ready bucket. Used by the Step 1 drill-down popover
      * so the user can see WHICH cells are affected, not just how many.
      * `label` matches the format the export progress reporter uses, so the
@@ -71,6 +79,7 @@ export interface NotebookAudioStats {
     noAudioRecordedCells: AudioStatsCellEntry[];
     selectionMissingCells: AudioStatsCellEntry[];
     noneSelectedCells: AudioStatsCellEntry[];
+    selectedPossiblyMissingCells: AudioStatsCellEntry[];
 }
 
 /** Per-cell entry surfaced by the Step 1 drill-down popover. */
@@ -182,25 +191,38 @@ export function analyzeNotebookAudioStats(
     const noAudioRecordedCells: AudioStatsCellEntry[] = [];
     const selectionMissingCells: AudioStatsCellEntry[] = [];
     const noneSelectedCells: AudioStatsCellEntry[] = [];
+    const selectedPossiblyMissingCells: AudioStatsCellEntry[] = [];
 
     for (const cell of notebook.cells) {
         if (!isExportableCell(cell)) continue;
         eligibleCellCount += 1;
-        const state = getCellAudioState(cell);
-        if (state === "ready") {
-            audioReadyCount += 1;
-            continue;
-        }
+        const outcome = pickAudioAttachment(cell);
+        const state = outcome.state;
+
         // Mirror the exporter: cells we can't label aren't surfaced as
         // missing-audio rows, so they shouldn't inflate the Step 1 counts.
-        if (!isLabelableCell(cell)) continue;
-        const cellId: string | undefined = (cell.metadata as any)?.id;
-        if (!cellId) continue;
-        const label = formatCellDisplayLabel(cell, cellId, bookCode);
         // Belt-and-suspenders: `isLabelableCell` should match
         // `formatCellDisplayLabel`'s null contract, but defending here keeps
         // the array contents consistent with the counts even if those drift.
-        if (!label) continue;
+        const cellId: string | undefined = (cell.metadata as any)?.id;
+        const label = isLabelableCell(cell) && cellId
+            ? formatCellDisplayLabel(cell, cellId, bookCode)
+            : null;
+
+        if (state === "ready") {
+            // The picker ignores `isMissing`, so a selected take flagged
+            // missing still resolves as "ready". When we can label/list it,
+            // carve it into a *possibly missing* warning so the user is
+            // forewarned; otherwise treat it as ready (it may still resolve).
+            if (label && cellId && outcome.pick && isTakeFlaggedMissing(cell, outcome.pick.id)) {
+                selectedPossiblyMissingCells.push({ label, cellId });
+            } else {
+                audioReadyCount += 1;
+            }
+            continue;
+        }
+
+        if (!label || !cellId) continue;
         const entry: AudioStatsCellEntry = { label, cellId };
         if (state === "selection-missing") {
             selectionMissingCells.push(entry);
@@ -217,9 +239,11 @@ export function analyzeNotebookAudioStats(
         noAudioRecordedCount: noAudioRecordedCells.length,
         selectionMissingCount: selectionMissingCells.length,
         noneSelectedCount: noneSelectedCells.length,
+        selectedPossiblyMissingCount: selectedPossiblyMissingCells.length,
         noAudioRecordedCells,
         selectionMissingCells,
         noneSelectedCells,
+        selectedPossiblyMissingCells,
     };
 }
 

--- a/src/projectManager/utils/exportViewUtils.ts
+++ b/src/projectManager/utils/exportViewUtils.ts
@@ -398,6 +398,38 @@ function getGroupKeyFromMetadata(metadata: Record<string, unknown>): string {
 }
 
 /**
+ * Recomputes a single `.codex` file's audio/translation summary — the same
+ * per-file work `groupCodexFilesByImporterType` does, scoped to one URI.
+ *
+ * Used by the export wizard's live refresh: when a `.codex` is saved while the
+ * wizard is open (e.g. the user picks a different take in the cell editor), the
+ * host re-runs just this for the changed file and patches that row's pills,
+ * instead of re-scanning every notebook. `bookCode` is derived identically to
+ * the bulk path so labels stay aligned with the export's missing-files report.
+ *
+ * Returns `null` when the file can't be read/parsed (transient write race or a
+ * genuinely broken file) so callers can simply leave the existing count in place.
+ */
+export async function analyzeCodexFileAudio(uri: vscode.Uri): Promise<{
+    hasTranslations: boolean;
+    hasAudio: boolean;
+    audioStats: NotebookAudioStats | undefined;
+} | null> {
+    try {
+        const notebook = await readCodexNotebookFromUri(uri);
+        const name = uri.fsPath.split(/[/\\]/).pop() || "";
+        const { hasTranslations, hasAudio } = analyzeNotebookContent(notebook);
+        const bookCode = name.split(".")[0] || "BOOK";
+        const audioStats = hasAudio
+            ? analyzeNotebookAudioStats(notebook, bookCode)
+            : undefined;
+        return { hasTranslations, hasAudio, audioStats };
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Groups codex files by their importer type for the export view.
  * Returns an array of groups, each with a display name and list of files.
  */

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -3369,6 +3369,25 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                         // actually on disk (e.g. auto-download -> [stream-only, not applied]
                         // -> stream-and-save prompts as auto-download -> stream-and-save).
                         const appliedStrategy = flags?.lastModeRun ?? currentStrategy;
+
+                        // Counting downloaded/video/audio files walks the entire
+                        // attachments/files tree and reads each file to test
+                        // pointer-ness, which can take seconds on large projects.
+                        // Signal the webview so the dropdown shows a disabled
+                        // "Calculating..." state until the next prompt appears.
+                        const setCalculating = (calculating: boolean) => {
+                            try {
+                                this.safeSendMessage({
+                                    command: "project.mediaStrategyCalculating",
+                                    projectPath,
+                                    calculating,
+                                } as any);
+                            } catch {
+                                /* non-fatal UI hint */
+                            }
+                        };
+                        setCalculating(true);
+
                         const { countDownloadedMediaFiles, countLocalVideoFiles, countSyncedDeletableAudioFiles } = await import("../../utils/mediaStrategyManager");
                         const { readLocalProjectSettings, writeLocalProjectSettings } = await import("../../utils/localProjectSettings");
 
@@ -3379,6 +3398,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                         let streamAndSavePreserveVideos: boolean | undefined;
 
                         const cancelSwitch = () => {
+                            setCalculating(false);
                             this.safeSendMessage({
                                 command: "project.setMediaStrategyResult",
                                 success: false,
@@ -3507,6 +3527,10 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                                 }
                             }
                         }
+
+                        // Counting + prompts are done; stop the "Calculating..."
+                        // hint before persisting (the result message also clears it).
+                        setCalculating(false);
 
                         // Persist the choices for this transition and clear any choice
                         // flags that don't apply, so a stale choice from an earlier

--- a/src/test/suite/audio/audioExporter.test.ts
+++ b/src/test/suite/audio/audioExporter.test.ts
@@ -1,5 +1,10 @@
 import * as assert from "assert";
-import { runWithConcurrencyPool } from "../../../exportHandler/audioExporter";
+import * as vscode from "vscode";
+import {
+    runWithConcurrencyPool,
+    tokenToAbortSignal,
+    ExportCancelledError,
+} from "../../../exportHandler/audioExporter";
 
 suite("Audio Exporter - runWithConcurrencyPool", () => {
     test("should process all items and return results in input order", async () => {
@@ -209,5 +214,104 @@ suite("Audio Exporter - runWithConcurrencyPool", () => {
         // Verify we actually used all slots at some point
         const hitMax = activeSamples.some((s) => s === concurrency);
         assert.ok(hitMax, `Should have reached max concurrency of ${concurrency}`);
+    });
+
+    test("should stop scheduling new tasks after the token is cancelled mid-run", async () => {
+        const concurrency = 2;
+        const items = Array.from({ length: 20 }, (_, i) => i);
+        const cts = new vscode.CancellationTokenSource();
+        let processed = 0;
+
+        const results = await runWithConcurrencyPool(
+            items,
+            concurrency,
+            async (item) => {
+                processed++;
+                // Cancel partway through; subsequent slots should be skipped.
+                if (processed === 3) {
+                    cts.cancel();
+                }
+                await new Promise((resolve) => setTimeout(resolve, 5));
+                return item;
+            },
+            undefined,
+            cts.token
+        );
+
+        // Results array stays dense (one entry per input item).
+        assert.strictEqual(results.length, items.length);
+        // We must have processed fewer than all items (the rest were skipped).
+        assert.ok(
+            processed < items.length,
+            `Expected to short-circuit, but processed all ${processed} items`
+        );
+        // Skipped slots are rejected with ExportCancelledError.
+        const cancelledSlots = results.filter(
+            (r) => r.status === "rejected" &&
+                (r as PromiseRejectedResult).reason instanceof ExportCancelledError
+        );
+        assert.ok(
+            cancelledSlots.length > 0,
+            "Expected at least one slot marked as cancelled"
+        );
+        cts.dispose();
+    });
+
+    test("should run zero processors when the token is already cancelled", async () => {
+        const items = Array.from({ length: 10 }, (_, i) => i);
+        const cts = new vscode.CancellationTokenSource();
+        cts.cancel();
+        let processed = 0;
+
+        const results = await runWithConcurrencyPool(
+            items,
+            4,
+            async (item) => {
+                processed++;
+                return item;
+            },
+            undefined,
+            cts.token
+        );
+
+        assert.strictEqual(processed, 0, "No processor should run for a pre-cancelled token");
+        assert.strictEqual(results.length, items.length);
+        assert.ok(
+            results.every(
+                (r) => r.status === "rejected" &&
+                    (r as PromiseRejectedResult).reason instanceof ExportCancelledError
+            ),
+            "Every slot should be marked cancelled"
+        );
+        cts.dispose();
+    });
+});
+
+suite("Audio Exporter - tokenToAbortSignal", () => {
+    test("aborts the signal when the token is cancelled", () => {
+        const cts = new vscode.CancellationTokenSource();
+        const { signal, dispose } = tokenToAbortSignal(cts.token);
+        assert.ok(signal, "Signal should be created for a live token");
+        assert.strictEqual(signal!.aborted, false);
+        cts.cancel();
+        assert.strictEqual(signal!.aborted, true, "Signal should abort with the token");
+        dispose();
+        cts.dispose();
+    });
+
+    test("returns an already-aborted signal for a pre-cancelled token", () => {
+        const cts = new vscode.CancellationTokenSource();
+        cts.cancel();
+        const { signal } = tokenToAbortSignal(cts.token);
+        assert.ok(signal, "Signal should be created");
+        assert.strictEqual(signal!.aborted, true);
+        cts.dispose();
+    });
+
+    test("returns no signal when no token is provided", () => {
+        const { signal, dispose } = tokenToAbortSignal(undefined);
+        assert.strictEqual(signal, undefined);
+        // dispose should be a safe no-op
+        dispose();
     });
 });

--- a/src/test/suite/export/exportCancellation.test.ts
+++ b/src/test/suite/export/exportCancellation.test.ts
@@ -1,0 +1,75 @@
+import * as assert from "assert";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import { exportCodexContent } from "../../../exportHandler/exportHandler";
+import { CodexExportFormat } from "../../../exportHandler/exportHandler";
+import type { ExportProgressReporter, ExportSummary } from "../../../exportHandler/exportProgress";
+
+/**
+ * Verifies that a cancelled export reports the terminal "cancelled" state and
+ * deletes the partial output folder, rather than completing or erroring.
+ */
+suite("Export Cancellation - exportCodexContent", () => {
+    test("cancelled token deletes the partial folder and reports cancelled (not complete)", async () => {
+        const tmpRoot = path.join(os.tmpdir(), `codex-export-cancel-${Date.now()}`);
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpRoot));
+
+        const cts = new vscode.CancellationTokenSource();
+        // Pre-cancel: the plaintext exporter creates its output folder, then the
+        // top-of-loop check bails before processing any file. The orchestrator
+        // then cleans up the freshly-created folder and reports cancelled.
+        cts.cancel();
+
+        const calls: { type: string; summary?: ExportSummary; }[] = [];
+        const reporter: ExportProgressReporter = {
+            report: () => undefined,
+            fileMissing: () => undefined,
+            complete: (summary) => calls.push({ type: "complete", summary }),
+            error: () => calls.push({ type: "error" }),
+            cancelled: (summary) => calls.push({ type: "cancelled", summary }),
+        };
+
+        // A non-empty (but non-existent) file list passes the "no files" guard
+        // so the exporter reaches its directory-creation + loop, where the token
+        // check short-circuits before any file is read.
+        await exportCodexContent(
+            CodexExportFormat.PLAINTEXT,
+            tmpRoot,
+            [path.join(tmpRoot, "does-not-exist.codex")],
+            {},
+            reporter,
+            cts.token
+        );
+
+        const cancelledCall = calls.find((c) => c.type === "cancelled");
+        assert.ok(cancelledCall, "reporter.cancelled should have been called");
+        assert.strictEqual(
+            calls.some((c) => c.type === "complete"),
+            false,
+            "reporter.complete must NOT be called on cancellation"
+        );
+
+        // The wrapper folder reported by the cancelled summary must be gone.
+        const wrapperPath = cancelledCall?.summary?.exportPath;
+        assert.ok(wrapperPath, "cancelled summary should include the export path");
+        let stillExists = true;
+        try {
+            await vscode.workspace.fs.stat(vscode.Uri.file(wrapperPath!));
+        } catch {
+            stillExists = false;
+        }
+        assert.strictEqual(stillExists, false, "partial export folder should be deleted");
+
+        // Cleanup the temp root.
+        try {
+            await vscode.workspace.fs.delete(vscode.Uri.file(tmpRoot), {
+                recursive: true,
+                useTrash: false,
+            });
+        } catch {
+            // best effort
+        }
+        cts.dispose();
+    });
+});

--- a/src/utils/mediaStrategyManager.ts
+++ b/src/utils/mediaStrategyManager.ts
@@ -424,6 +424,35 @@ export async function replaceFilesWithPointers(
 ): Promise<number> {
     let replacedCount = 0;
 
+    // Diagnostic tally so the summary log can explain *why* media was kept.
+    // Users report synced audio "lingering" after a stream-only switch; this
+    // reveals which guard retained each file (persisted / unsynced / already a
+    // pointer) without changing any behaviour.
+    type MediaKind = "audio" | "video";
+    type PointerizeResult =
+        | "replaced"
+        | "skip-restricted"
+        | "skip-persisted"
+        | "skip-unsynced"
+        | "skip-already-pointer"
+        | "error";
+    type PointerizeOutcome = { kind: MediaKind; result: PointerizeResult; };
+    const emptyTally = (): Record<PointerizeResult, number> => ({
+        replaced: 0,
+        "skip-restricted": 0,
+        "skip-persisted": 0,
+        "skip-unsynced": 0,
+        "skip-already-pointer": 0,
+        error: 0,
+    });
+    const tally: Record<MediaKind, Record<PointerizeResult, number>> = {
+        audio: emptyTally(),
+        video: emptyTally(),
+    };
+    const tallyOutcome = (outcome: PointerizeOutcome) => {
+        tally[outcome.kind][outcome.result]++;
+    };
+
     try {
         const pointersDir = path.join(projectPath, ".project", "attachments", "pointers");
         const filesDir = path.join(projectPath, ".project", "attachments", "files");
@@ -441,12 +470,11 @@ export async function replaceFilesWithPointers(
                 (await getPersistedMediaFiles(vscode.Uri.file(projectPath))).map(normalizePersistedMediaRelPath)
             );
 
-        // When restricting by media kind, resolve the ambiguous `.webm` extension
-        // against real notebook video references so audio takes aren't treated
-        // as videos (and vice-versa).
-        const videoRefs = options?.restrictToVideos || options?.restrictToAudio
-            ? await collectVideoReferenceRelPaths(projectPath)
-            : new Set<string>();
+        // Resolve the ambiguous `.webm` extension against real notebook video
+        // references so audio takes aren't treated as videos (and vice-versa).
+        // Always computed (not just for restricted runs) so the diagnostic
+        // summary below can split outcomes by media kind accurately.
+        const videoRefs = await collectVideoReferenceRelPaths(projectPath);
 
         await vscode.window.withProgress(
             {
@@ -467,30 +495,34 @@ export async function replaceFilesWithPointers(
 
                 for (const batch of batches) {
                     const results = await Promise.allSettled(
-                        batch.map(async (relPath) => {
+                        batch.map(async (relPath): Promise<PointerizeOutcome> => {
                             const pointerPath = path.join(pointersDir, relPath);
                             const filesPath = path.join(filesDir, relPath);
+                            // Track whether files/ currently holds real bytes so the
+                            // diagnostic summary can distinguish "kept real audio"
+                            // (what the user notices) from no-op pointer entries.
+                            const relIsVideo = isVideoRelPath(relPath.replace(/\\/g, "/"), videoRefs);
+                            const kind: MediaKind = relIsVideo ? "video" : "audio";
 
                             try {
                                 // When restricted to videos (e.g. stream-only ->
                                 // stream-and-save "don't preserve"), leave non-video
                                 // media exactly as-is.
-                                const relIsVideo = isVideoRelPath(relPath.replace(/\\/g, "/"), videoRefs);
                                 if (options?.restrictToVideos && !relIsVideo) {
-                                    return false;
+                                    return { kind, result: "skip-restricted" };
                                 }
                                 // When restricted to audio (e.g. auto-download ->
                                 // stream-and-save "keep video, free audio"), leave
                                 // videos exactly as-is.
                                 if (options?.restrictToAudio && relIsVideo) {
-                                    return false;
+                                    return { kind, result: "skip-restricted" };
                                 }
 
                                 // PROTECTED: user explicitly saved this file via
                                 // "Save to project" — never revert it to a pointer.
                                 if (persisted.has(normalizePersistedMediaRelPath(relPath))) {
                                     debug(`PROTECTED: Skipping user-saved media file: ${relPath}`);
-                                    return false;
+                                    return { kind, result: "skip-persisted" };
                                 }
 
                                 // CRITICAL: Check if this is a locally recorded, unsynced file
@@ -505,7 +537,7 @@ export async function replaceFilesWithPointers(
 
                                     if (status === "local-unsynced") {
                                         debug(`PROTECTED: Skipping local unsynced recording: ${relPath}`);
-                                        return false; // Do NOT replace local recordings!
+                                        return { kind, result: "skip-unsynced" };
                                     }
                                 }
 
@@ -514,7 +546,7 @@ export async function replaceFilesWithPointers(
                                     const stat = await vscode.workspace.fs.stat(vscode.Uri.file(filesPath));
                                     if (stat.size < 200) { // Pointer files are tiny (~130 bytes)
                                         // Likely already a pointer, skip
-                                        return false;
+                                        return { kind, result: "skip-already-pointer" };
                                     }
                                 } catch {
                                     // files/ doesn't exist, continue
@@ -528,16 +560,22 @@ export async function replaceFilesWithPointers(
                                 const pointerContent = await vscode.workspace.fs.readFile(vscode.Uri.file(pointerPath));
                                 await vscode.workspace.fs.writeFile(vscode.Uri.file(filesPath), pointerContent);
 
-                                return true;
+                                return { kind, result: "replaced" };
                             } catch {
-                                return false;
+                                return { kind, result: "error" };
                             }
                         })
                     );
 
                     for (const result of results) {
-                        if (result.status === 'fulfilled' && result.value) {
-                            replacedCount++;
+                        if (result.status === "fulfilled") {
+                            const outcome = result.value;
+                            tallyOutcome(outcome);
+                            if (outcome.result === "replaced") {
+                                replacedCount++;
+                            }
+                        } else {
+                            tallyOutcome({ kind: "audio", result: "error" });
                         }
                     }
 
@@ -550,6 +588,26 @@ export async function replaceFilesWithPointers(
 
                 progress.report({ increment: 100, message: "Complete" });
             }
+        );
+
+        let scopeLabel = "all media";
+        if (options?.restrictToVideos) {
+            scopeLabel = "videos only";
+        } else if (options?.restrictToAudio) {
+            scopeLabel = "audio only";
+        }
+        const a = tally.audio;
+        // Always-on summary (not behind the debug flag): when audio "lingers"
+        // after a stream-only switch, the kept[...] counts pinpoint the guard
+        // that retained it — persisted (saved), unsynced (local recording), or
+        // alreadyPointer (no real bytes to free).
+        console.log(
+            `[MediaStrategy] replaceFilesWithPointers (${scopeLabel}): ` +
+            `audio replaced=${a.replaced}, kept[persisted=${a["skip-persisted"]}, ` +
+            `unsynced=${a["skip-unsynced"]}, alreadyPointer=${a["skip-already-pointer"]}, ` +
+            `restricted=${a["skip-restricted"]}, error=${a.error}]; ` +
+            `video replaced=${tally.video.replaced}, kept[persisted=${tally.video["skip-persisted"]}, ` +
+            `unsynced=${tally.video["skip-unsynced"]}, alreadyPointer=${tally.video["skip-already-pointer"]}]`
         );
 
         debug(`Replaced ${replacedCount} files with pointers`);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2554,6 +2554,9 @@ export interface ExportMissingFilePayload {
     file: string;
     reason: ExportMissingFileReason;
     detail?: string;
+    /** Cell + codex path the entry came from, when known. Enables a deep-link. */
+    cellId?: string;
+    codexPath?: string;
 }
 
 export interface ExportSummaryPayload {
@@ -2571,7 +2574,7 @@ export type MessagesToProjectExportView =
     | { command: "htmlStructureCheckResult"; mismatches: { totalMismatches: number; fileDetails: { file: string; count: number; }[]; }; }
     | { command: "exportStarted"; }
     | { command: "exportProgress"; event: ExportProgressEventPayload; }
-    | { command: "exportFileMissing"; file: string; reason: ExportMissingFileReason; detail?: string; }
+    | { command: "exportFileMissing"; file: string; reason: ExportMissingFileReason; detail?: string; cellId?: string; codexPath?: string; }
     | { command: "exportCompleted"; summary: ExportSummaryPayload; }
     | { command: "exportError"; message: string; };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2561,6 +2561,8 @@ export interface ExportMissingFilePayload {
 
 export interface ExportSummaryPayload {
     exportPath: string;
+    /** Folder audio landed in (an `audio/` subfolder in multi-format). Used for targeted retry. */
+    audioExportPath?: string;
     filesExported?: number;
     audioCopied?: number;
     audioMissing?: number;
@@ -2576,7 +2578,8 @@ export type MessagesToProjectExportView =
     | { command: "exportProgress"; event: ExportProgressEventPayload; }
     | { command: "exportFileMissing"; file: string; reason: ExportMissingFileReason; detail?: string; cellId?: string; codexPath?: string; }
     | { command: "exportCompleted"; summary: ExportSummaryPayload; }
-    | { command: "exportError"; message: string; };
+    | { command: "exportError"; message: string; }
+    | { command: "retryCompleted"; summary?: ExportSummaryPayload; error?: string; cancelled?: boolean; };
 
 export type MessagesFromProjectExportView =
     | { command: "selectExportPath"; }
@@ -2586,4 +2589,5 @@ export type MessagesFromProjectExportView =
     | { command: "openExportFolder"; path: string; }
     | { command: "closeExportView"; }
     | { command: "openCellInEditor"; cellId: string; filePath: string; }
+    | { command: "retryExport"; audioOutputPath: string; targets: { cellId: string; codexPath: string; }[]; options?: Record<string, unknown>; }
     | { command: "cancel"; };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2529,6 +2529,7 @@ export type ExportMissingFileReason =
     | "no-text-recorded"
     // Tier 2 — soft warning
     | "no-audio-selected"
+    | "selected-audio-missing-alternatives"
     | "audio-file-missing"
     | "pointer-corrupt"
     | "source-not-found"

--- a/webviews/codex-webviews/src/StartupFlow/components/projects-list/ProjectCard.tsx
+++ b/webviews/codex-webviews/src/StartupFlow/components/projects-list/ProjectCard.tsx
@@ -79,6 +79,10 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     const userInitiatedStrategyChangeRef = React.useRef<boolean>(false);
     const [isApplyingStrategyDuringOtherOp, setIsApplyingStrategyDuringOtherOp] =
         useState<boolean>(false);
+    // True while the host is counting downloaded media files to decide which
+    // keep/free prompt to show. Surfaces a disabled "Calculating..." state so
+    // the delay before the prompt appears isn't silent.
+    const [isCalculatingStrategy, setIsCalculatingStrategy] = useState<boolean>(false);
     // CRITICAL: If we're offline, "orphaned" is not trustworthy -- the server couldn't
     // be reached to confirm the project is genuinely missing. Override to "serverUnreachable"
     // to prevent destructive actions like "Fix & Open".
@@ -113,7 +117,8 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
         isZipping ||
         isZippingMini ||
         isCleaning ||
-        isApplyingStrategyDuringOtherOp;
+        isApplyingStrategyDuringOtherOp ||
+        isCalculatingStrategy;
 
     // Sync local state with project.mediaStrategy when it changes from backend
     // This ensures the UI always reflects the persisted value from localProjectSettings.json
@@ -172,8 +177,16 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     React.useEffect(() => {
         const onMessage = (event: MessageEvent) => {
             const msg = event.data;
+            if (msg?.command === "project.mediaStrategyCalculating") {
+                if (msg.projectPath === project.path) {
+                    setIsCalculatingStrategy(!!msg.calculating && isProjectLocal);
+                }
+                return;
+            }
             if (msg?.command === "project.mediaStrategyApplying") {
                 if (msg.projectPath === project.path) {
+                    // Applying supersedes the calculating hint.
+                    setIsCalculatingStrategy(false);
                     if (msg.applying && isProjectLocal) {
                         // Check if this was user-initiated (user changed dropdown) or auto-applied (mismatch detected)
                         if (userInitiatedStrategyChangeRef.current) {
@@ -202,6 +215,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                 // Success case: parent component will update the project prop via its message handler
                 setPendingStrategy(null);
                 setPreviousStrategy(null); // Clear previous strategy after handling result
+                setIsCalculatingStrategy(false);
                 userInitiatedStrategyChangeRef.current = false;
             }
             if (msg?.command === "project.updatingInProgress") {
@@ -288,9 +302,17 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
 
     const renderMediaStrategyDropdown = () => {
         // Highlight dropdown when strategy is being changed/applied (either explicitly or during open/clone)
-        const isStrategyHighlighted = isChangingStrategy || isApplyingStrategyDuringOtherOp;
+        const isStrategyHighlighted =
+            isChangingStrategy || isApplyingStrategyDuringOtherOp || isCalculatingStrategy;
         // Disable media strategy changes if user is update (swap) initiator (must keep auto-download until update completes)
         const isDisabled = disableControls || disableMediaStrategyForSwap;
+        // Busy label shown in place of the strategy name while the host works.
+        let strategyBusyLabel: string | null = null;
+        if (isCalculatingStrategy) {
+            strategyBusyLabel = "Calculating...";
+        } else if (isChangingStrategy) {
+            strategyBusyLabel = "Applying...";
+        }
 
         const dropdown = (
             <DropdownMenu>
@@ -306,10 +328,10 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                         )}
                         disabled={isDisabled}
                     >
-                        {isChangingStrategy ? (
+                        {strategyBusyLabel ? (
                             <>
                                 <i className="codicon codicon-loading codicon-modifier-spin mr-1" />
-                                Applying...
+                                {strategyBusyLabel}
                             </>
                         ) : (
                             <>

--- a/webviews/codex-webviews/src/StartupFlow/types.ts
+++ b/webviews/codex-webviews/src/StartupFlow/types.ts
@@ -186,7 +186,8 @@ export interface FrontierAPI {
     downloadLFSFile: (
         projectPath: string,
         oid: string,
-        size: number
+        size: number,
+        signal?: AbortSignal
     ) => Promise<Buffer>;
 
     /**


### PR DESCRIPTION
## Cancel export and media download strategy improvement

Frontier: https://github.com/genesis-ai-dev/frontier-authentication/pull/34

Pinned Project: 1050-cancel-export-and-media-download-strategy-improvement

#997 

## Summary


Adds the ability to cancel an in-progress project export (cleaning up any
partial output), makes whole-project audio export resilient to transient
LFS/network failures, and overhauls how unresolved/missing audio is surfaced
to the user — including a categorized, expandable, clickable issues list, a
targeted "retry failed" action, and clearer real-time progress.

Also tightens the media-download-strategy switch (clear "Calculating…" feedback
and diagnostic logging into why some media is retained).

## Changes

**Export cancellation**
- Cancel button on the export progress view; threads a `CancellationToken`
  through every exporter (audio, plaintext, USFM, HTML, VTT/SRT, XLIFF, CSV/TSV,
  rebuild, backtranslations).
- Aborts in-flight LFS downloads via an `AbortSignal` bridged from the token.
- Deletes the partial (unique) export folder on cancel and shows a terminal
  "Cancelled — partial output removed" state with a Close button.
- Re-entrancy guard prevents starting a second export while one is running;
  closing the export tab aborts the run.

**Resilient audio downloads**
- New `downloadLfsWithRetry`: up to 4 attempts with exponential backoff + jitter.
- Retries only transient errors (5xx, 429, timeouts, `ECONNRESET`, `fetch failed`,
  etc.); fails fast on permanent ones (4xx, corrupt pointer) and never retries a
  user-initiated abort.

**Export issues UX**
- "X audio file(s) exported, Y could not be resolved" now expands into a
  categorized, collapsible list with human-readable labels/descriptions and an
  "Expand all / Collapse all" toggle.
- Each issue row is clickable and deep-links to the exact cell in the editor
  (cell id + codex path threaded through the reporter chain).
- New "selected take missing but other takes available" warning category
  (recoverable) split out from hard "could not be resolved" errors.
- "Retry failed" action re-runs only the recoverable failed cells and merges
  recovered audio back into the existing export folder.
- Unified amber accent across all issue groups.

**Pre-flight (Step 1) + real-time stats**
- Cells whose selected take is flagged `isMissing` are surfaced as "possibly
  missing"; cells whose only remaining takes are all missing are reclassified as
  "without audio" (consistently in pre-flight and export).
- Audio stat pills update in real time via a debounced `.codex` file watcher;
  the cell-list popover stays open when navigating to a cell.

**Progress display**
- Count shown once (in the title); the secondary line shows the actual item
  (cell label while writing) instead of repeating the `.codex` filename during
  concurrent downloads.

**Media download strategy switch**
- Disabled "Calculating…" state while counting media files before the prompt.
- Diagnostic tally in `replaceFilesWithPointers` explaining why each file was
  retained (persisted / unsynced / already-pointer) without changing behavior.

## Testing Checklist

### Export cancellation
- [x] Start an audio export, cancel mid-download → run stops, partial folder is deleted, "Cancelled — partial output removed" state shows with a Close button.
- [x] Close the export tab mid-export → the run aborts.
- [x] Attempt to start a second export while one is running → blocked.
- [x] Cancel during a retry backoff → aborts promptly (doesn't wait out the delay) and surfaces as cancellation, not an error.

### Resilient audio downloads (retry/backoff)
- [x] Export against a flaky/500-prone server → transient failures (5xx, 429, timeouts, `ECONNRESET`, `fetch failed`) auto-recover via retry.
- [x] Permanent errors (404/401/403, corrupt pointer) fail fast without retrying.

### Export issues UX
- [x] Trigger unresolved cells → issues list groups them by category with human-readable labels/descriptions.
- [x] "Expand all / Collapse all" toggle works and stays readable in hover/selected states.
- [x] Issue rows deep-link to the correct cell in the editor.
- [x] "Selected take missing but other takes available" appears as a recoverable warning, separate from hard "could not be resolved" errors.
- [x] "Retry failed" → recovered cells drop off, still-failing ones remain, recovered audio lands in the original export folder.
- [x] All issue groups share the unified amber accent.

### Pre-flight (Step 1) + real-time stats
- [x] Cells with a selected `isMissing` take show as "possibly missing".
- [x] Cells whose only remaining takes are all missing are classified as "without audio" (consistent in pre-flight and export).
- [x] Edit a cell's audio on Step 1 → stat pills update live; the cell-list popover stays open when navigating to a cell.

### Progress display
- [x] Count shows once (in the title); the secondary line shows the actual item (cell label while writing), not the `.codex` filename during concurrent downloads.

### Media download strategies — audio pointerization (`replaceFilesWithPointers`)
- [x] Default stream-only run reverts a **synced** audio take (`pointers/` holds the pointer, `files/` holds real bytes) to a pointer.
- [x] Default stream-only run **preserves an unsynced** audio take (real bytes in both `files/` and `pointers/`) — bytes untouched.
- [x] `restrictToAudio` pointerizes audio only, leaving video untouched.
- [x] `restrictToVideos` pointerizes video only, leaving audio untouched.
- [x] Persisted (user-saved) audio is protected on automatic cleanup; `ignorePersisted` frees it.
- [x] Mixed audio + video, default run: both synced files pointerized, both unsynced files preserved (regression for the "always compute videoRefs" refactor).

### Media download strategies — `countSyncedDeletableAudioFiles`
- [x] Counts synced audio (pointer in `pointers/`, real bytes in `files/`).
- [x] Excludes unsynced audio (no/real-bytes pointer).
- [x] Excludes persisted (allowlisted) audio.
- [x] Excludes files that are already pointer stubs.
- [x] Excludes video files.
- [x] Counts ambiguous `.webm` recordings as audio (not referenced by a notebook `videoUrl`).

### Media download strategies — counting & stubs
- [x] `countDownloadedMediaFiles` counts real downloaded media, ignores pointer stubs.
- [x] `removeFilesPointerStubs` (less-restrictive switch, audio): removes audio pointer stubs so they re-download; preserves real downloaded audio bytes.

### Media download strategies — `applyMediaStrategy` transition matrix
- [x] auto-download → stream-only (default): synced media freed, unsynced preserved.
- [x] auto-download → stream-only (`keep-video`): local videos allowlisted and kept; rest freed.
- [x] auto-download → stream-only (`free-all`): everything freed incl. saved videos; video allowlist cleared.
- [x] auto-download → stream-and-save (granular `keepVideo`/`keepAudio` combinations).
- [x] auto-download → stream-and-save (`keepFilesOnStreamAndSave === false`): explicit free incl. saved videos.
- [x] stream-only → auto-download: pointer stubs removed + pending swap downloads processed.
- [x] stream-only → stream-and-save: preserve-videos behavior.
- [x] stream-and-save → stream-only / auto-download: restrictive vs less-restrictive outcomes.
- [x] Same strategy (no change) is a no-op; `forceApply` re-runs anyway.

### Media download strategies — "Calculating…" UX (`project.mediaStrategyCalculating`)
- [x] Switch media strategy on a large project → disabled "Calculating…" state shows while counting.
- [x] Message sent (`calculating: true`) before counting media files.
- [x] Cleared (`calculating: false`) on cancel and before persisting the result.

### Frontier-authentication — AbortSignal for LFS downloads
- [x] Cancel an export while LFS objects are downloading → downloads abort promptly and surface as cancellation, not errors.
- [x] Two callers request the same OID; one aborts → the other still completes (refcounted abort).
- [x] All waiters for an OID abort → the shared fetch is actually cancelled (no lingering bandwidth use).
- [x] An already-aborted signal never joins/starts a shared download.
- [x] Normal (uncancelled) downloads and the dedup fast-path still work.
- [x] Aborted requests propagate `AbortError` untouched (callers can distinguish cancel vs failure).