### PR TITLE
1051-bug-fix-milestone-hoisting-in-reorderverserangecells

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,3 +19,5 @@ Describe the bug.
 ## Expected Behavior
 
 ## Actual Behavior
+
+## Acceptance Criteria

--- a/sharedUtils/importerTypeUtils.ts
+++ b/sharedUtils/importerTypeUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Importer types whose notebooks contain scripture organized by book/chapter/verse.
+ * Single source of truth shared by the NewSourceUploader (milestone insertion) and the
+ * extension host (verse-range reorder during migration and sync merges).
+ *
+ * All entries must be lowercase — callers normalize before comparing.
+ */
+export const BIBLE_TYPE_IMPORTERS: readonly string[] = [
+    "usfm",
+    "usfm-experimental",
+    "paratext",
+    "ebiblecorpus",
+    "ebible",
+    "ebible-download",
+    "maculabible",
+    "macula",
+    "biblica",
+    "obs",
+    "pdf", // PDF can contain Bible content
+    "indesign", // InDesign can contain Bible content
+];
+
+/**
+ * Returns true when the importer type produces scripture-shaped notebooks (per-chapter
+ * milestones and verse-level globalReferences). Unknown or missing types return false.
+ */
+export function isBibleTypeImporter(importerType: string | undefined | null): boolean {
+    if (!importerType) {
+        return false;
+    }
+    return BIBLE_TYPE_IMPORTERS.includes(importerType.toLowerCase().trim());
+}

--- a/sharedUtils/index.ts
+++ b/sharedUtils/index.ts
@@ -283,3 +283,4 @@ export const deriveTargetPathFromSource = (sourcePath: string): string => {
 // Re-export corpus utilities
 export * from "./corpusUtils";
 export * from "./exportOptionsEligibility";
+export * from "./importerTypeUtils";

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -1286,11 +1286,21 @@ export async function resolveCodexCustomMerge(
     // Re-apply verse-range reordering (and idempotent cellLabel/chapterNumber autofill) so
     // that the migrated cell ordering survives git syncs regardless of which side is "ours".
     // The helper:
+    //   - no-ops for known non-Bible importer types (documents, subtitles, spreadsheets, …);
     //   - bails out as a no-op on files with no milestones and no verse-range cells;
+    //   - bails out when no content cell has a parseable verse ref (book-only globalReferences,
+    //     e.g. IDML imports) or when no milestone can be matched to any content chapter;
+    //   - keeps cells it cannot place (headings, markers, style cells) anchored next to their
+    //     original neighbors instead of moving them to the end of the file;
     //   - never adds edit-history entries;
     //   - never soft-deletes cells (orphan paratext handling stays in the migration);
     //   - skips cellLabel autofill on cells the user has hand-labeled.
-    const reordered = reorderVerseRangeCells(resultCells);
+    const reordered = reorderVerseRangeCells(resultCells, {
+        importerType:
+            mergedMetadata?.importerType ??
+            ourMetadata?.importerType ??
+            theirMetadata?.importerType,
+    });
     const finalCells = reordered.cells;
 
     // Return the full notebook structure with merged cells and metadata

--- a/src/projectManager/utils/merge/utils/verseRangeReorder.ts
+++ b/src/projectManager/utils/merge/utils/verseRangeReorder.ts
@@ -6,6 +6,8 @@ import {
     stripCellIdSuffix,
     type ParsedVerseRef,
 } from "../../../../utils/verseRefUtils";
+import { isBibleTypeImporter } from "../../../../../sharedUtils/importerTypeUtils";
+import bibleData from "../../../../../webviews/codex-webviews/src/assets/bible-books-lookup.json";
 
 /**
  * Result of running {@link reorderVerseRangeCells}.
@@ -24,6 +26,22 @@ export interface VerseRangeReorderResult {
     cells: any[];
     mutated: boolean;
     orderChanged: boolean;
+}
+
+export interface VerseRangeReorderOptions {
+    /**
+     * The notebook's `metadata.importerType`. When provided and the type is a known
+     * non-Bible importer (docx, markdown, subtitles, …) the helper is a strict no-op:
+     * those notebooks are documents, and any verse references they carry are citations,
+     * not structural verse cells. Missing/unknown types fall back to the content checks.
+     */
+    importerType?: string | null;
+}
+
+/** Inclusive chapter range a milestone covers ("John 4" -> 4..4, "Job 4-31" -> 4..31). */
+interface ChapterRange {
+    start: number;
+    end: number;
 }
 
 /** Decide whether a cell already carries a non-MIGRATION edit on `metadata.cellLabel`. */
@@ -46,25 +64,43 @@ function hasUserCellLabelEdit(cell: any): boolean {
  * the codex merge resolver so that the migrated cell ordering survives git syncs.
  *
  * Behavior:
+ *   - No-ops when `options.importerType` names a known non-Bible importer.
  *   - Early-exits when the file has no milestones AND no verse-range cells (`parsed.kind === "range"`).
  *     Non-scripture notebooks (notes, glossaries, etc.) are returned untouched.
- *   - Always emits paratext cells immediately BEFORE their parent verse cell. Section-heading
- *     style paratexts in scripture (e.g. \\s) belong above the verse they introduce, so the
- *     helper places every parented paratext on the BEFORE side regardless of its original
- *     index. Multiple paratexts pointing at the same parent retain their original relative
- *     order in the BEFORE block.
+ *   - Bails out (original order preserved) when no content cell carries a parseable verse ref —
+ *     e.g. IDML-imported files whose globalReferences are book-only, like ["JOB"] — and when
+ *     milestones exist but none of them can be matched to any content chapter (e.g. every
+ *     milestone value is unparseable). Reordering in those cases would hoist every milestone to
+ *     the top of the file and dump all text cells after them.
+ *   - Milestone values may cover a chapter range ("Job 4-31"); content for any chapter in the
+ *     range is placed under that milestone. In multi-book files the milestone's book name is
+ *     resolved against the Bible book lookup so "Job 4" cannot capture "SNG 4:1" content.
+ *   - Cells the helper cannot place by verse ref (section headings and markers imported as TEXT
+ *     cells with empty globalReferences, STYLE cells, orphan paratexts, unmatched-chapter refs)
+ *     stay anchored to the nearest preceding milestone/verse cell, preserving their original
+ *     neighborhood instead of being moved to the end of the file.
+ *   - Always emits paratext cells immediately BEFORE their parent cell. Section-heading style
+ *     paratexts in scripture (e.g. \\s) belong above the verse they introduce. Multiple
+ *     paratexts pointing at the same parent retain their original relative order.
  *   - Strips legacy `:1`-style cell-id suffixes from `globalReferences[0]` (idempotent).
  *   - Auto-fills `cellLabel` and `chapterNumber` on verse-range cells from the parsed ref, but
  *     skips the autofill when the cell already has a non-MIGRATION `metadata.cellLabel` edit so
  *     that human relabels are not clobbered.
- *   - Orphan paratexts (parentId not present in the file) are NOT touched: they keep their
- *     original index and are never soft-deleted by this helper. The migration handles orphan
- *     soft-delete itself so that resolver-time calls have zero mutating side-effects beyond
- *     ordering and the safe relabel/cleanup listed above.
+ *   - Never drops cells: a final sweep appends anything not otherwise emitted, in original order.
  */
-export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
+export function reorderVerseRangeCells(
+    cells: any[],
+    options?: VerseRangeReorderOptions
+): VerseRangeReorderResult {
     if (!Array.isArray(cells) || cells.length === 0) {
         return { cells: cells ?? [], mutated: false, orderChanged: false };
+    }
+
+    // Known non-Bible importer -> the notebook is a document, not scripture. Any verse refs on
+    // its cells are citations; reordering by them would scramble the document.
+    const importerType = options?.importerType;
+    if (typeof importerType === "string" && importerType.trim() && !isBibleTypeImporter(importerType)) {
+        return { cells, mutated: false, orderChanged: false };
     }
 
     // First pass: cheap detection so we can no-op on non-scripture notebooks.
@@ -92,30 +128,38 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
         return { cells, mutated: false, orderChanged: false };
     }
 
-    // Second pass: full partition. We track each cell's original index so we can re-insert
-    // orphan paratexts at their original index in the tail.
-    const milestones: Array<{ cell: any; chapter: number | null; originalIndex: number; }> = [];
-    const contentWithRef: Array<{
+    // Second pass: full partition. We track each cell's original index so paratext parents can
+    // be located, content can be assigned to the nearest milestone, and the final ordering stays
+    // deterministic.
+    type ContentItem = {
         cell: any;
         parsed: ParsedVerseRef;
-        sortKey: { book: string; chapter: number; verse: number; };
+        sortKey: SortKey;
         originalIndex: number;
+    };
+    const milestones: Array<{
+        cell: any;
+        range: ChapterRange | null;
+        bookAbbr: string | null;
+        originalIndex: number;
+        assigned: ContentItem[];
     }> = [];
-    const contentWithoutRef: Array<{ cell: any; originalIndex: number; }> = [];
-    const styleOrOther: Array<{ cell: any; originalIndex: number; }> = [];
-    const paratextOriginal: Array<{ cell: any; originalIndex: number; parentId: string | null; }> = [];
+    const contentWithRef: ContentItem[] = [];
+    const parentedParatexts = new Set<any>();
 
     let mutated = false;
 
-    // First pass: classify every cell and remember the original index of each id.
     const originalIndexById = new Map<string, number>();
     for (let i = 0; i < cells.length; i++) {
-        const cell = cells[i];
-        const id = cell?.metadata?.id;
-        if (typeof id === "string" && id.length > 0) {
+        const id = cells[i]?.metadata?.id;
+        if (typeof id === "string" && id.length > 0 && !originalIndexById.has(id)) {
             originalIndexById.set(id, i);
         }
     }
+
+    // Paratexts are emitted immediately before their parent. Orphans (parent id missing from
+    // the file) are NOT bucketed — they stay anchored in place like any other unplaceable cell.
+    const paratextBeforeParent = new Map<string, any[]>();
 
     for (let i = 0; i < cells.length; i++) {
         const cell = cells[i];
@@ -125,8 +169,13 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
 
         if (cellType === CodexCellTypes.MILESTONE) {
             const milestoneValue = typeof cell?.value === "string" ? cell.value : "";
-            const chapter = extractChapterNumberFromMilestoneValue(milestoneValue);
-            milestones.push({ cell, chapter, originalIndex: i });
+            milestones.push({
+                cell,
+                range: extractChapterRangeFromMilestoneValue(milestoneValue),
+                bookAbbr: resolveBookAbbrFromMilestoneValue(milestoneValue),
+                originalIndex: i,
+                assigned: [],
+            });
             continue;
         }
 
@@ -135,12 +184,15 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
                 typeof cellId === "string" ? cellId : String(cellId),
                 md
             );
-            paratextOriginal.push({ cell, originalIndex: i, parentId });
+            if (typeof parentId === "string" && originalIndexById.has(parentId)) {
+                if (!paratextBeforeParent.has(parentId)) paratextBeforeParent.set(parentId, []);
+                paratextBeforeParent.get(parentId)!.push(cell);
+                parentedParatexts.add(cell);
+            }
             continue;
         }
 
         if (cellType === CodexCellTypes.STYLE) {
-            styleOrOther.push({ cell, originalIndex: i });
             continue;
         }
 
@@ -159,153 +211,246 @@ export function reorderVerseRangeCells(cells: any[]): VerseRangeReorderResult {
         if (parsed) {
             const sortKey = getSortKeyFromParsedRef(parsed);
             contentWithRef.push({ cell, parsed, sortKey, originalIndex: i });
-        } else {
-            contentWithoutRef.push({ cell, originalIndex: i });
         }
     }
 
-    // Bucket every parented paratext into a single BEFORE-parent block. Section-heading
-    // paratexts belong above the verse they introduce, so we drop the original index and emit
-    // them above their parent regardless of where they sat in the input. Orphans (parentId
-    // not present) are kept aside and re-inserted at their original index further down.
-    const paratextBeforeParent = new Map<string, any[]>();
-    const orphanParatexts: Array<{ cell: any; originalIndex: number; }> = [];
-    for (const pt of paratextOriginal) {
-        const parentId = pt.parentId;
-        const parentIndex =
-            typeof parentId === "string" ? originalIndexById.get(parentId) : undefined;
-        if (parentId && parentIndex !== undefined) {
-            if (!paratextBeforeParent.has(parentId)) paratextBeforeParent.set(parentId, []);
-            paratextBeforeParent.get(parentId)!.push(pt.cell);
-        } else {
-            orphanParatexts.push({ cell: pt.cell, originalIndex: pt.originalIndex });
-        }
+    // Bail out when no content cell carries a parseable verse ref (e.g. IDML-imported files
+    // whose globalReferences are book-only, like ["JOB"], or empty). There is nothing to
+    // partition by chapter — preserve the original order.
+    if (contentWithRef.length === 0) {
+        return { cells, mutated, orderChanged: false };
     }
 
-    // Partition content-with-ref by (book, chapter), sort each by verse start.
-    const contentByChapter = new Map<string, typeof contentWithRef>();
+    // Auto-fill cellLabel / chapterNumber on verse-range cells from the parsed ref. This is a
+    // purely per-cell relabel that does not depend on ordering, so we apply it up front — that
+    // way the relabel still happens even when one of the order-preserving bail-outs below fires.
+    // User relabels (a non-MIGRATION cellLabel edit) are never clobbered.
     for (const item of contentWithRef) {
-        const key = `${item.sortKey.book}\t${item.sortKey.chapter}`;
-        if (!contentByChapter.has(key)) contentByChapter.set(key, []);
-        contentByChapter.get(key)!.push(item);
+        const parsed = item.parsed;
+        if (parsed.kind !== "range" || hasUserCellLabelEdit(item.cell)) continue;
+        const md = item.cell.metadata || {};
+        if (md.cellLabel !== parsed.cellLabel) {
+            md.cellLabel = parsed.cellLabel;
+            mutated = true;
+        }
+        if (md.chapterNumber === undefined || md.chapterNumber === null) {
+            md.chapterNumber = String(parsed.chapter);
+            mutated = true;
+        }
+        item.cell.metadata = md;
     }
-    for (const arr of contentByChapter.values()) {
-        arr.sort((a, b) => a.sortKey.verse - b.sortKey.verse);
+
+    // In multi-book files a milestone may only claim chapters of its own book; a milestone whose
+    // book cannot be resolved claims nothing. Single-book files match by chapter alone.
+    const contentBooks = new Set<string>();
+    for (const item of contentWithRef) contentBooks.add(item.sortKey.book.toUpperCase());
+    const multiBook = contentBooks.size > 1;
+
+    const covers = (
+        milestone: (typeof milestones)[number],
+        item: ContentItem
+    ): boolean => {
+        if (!milestone.range) return false;
+        if (multiBook) {
+            if (!milestone.bookAbbr) return false;
+            if (milestone.bookAbbr !== item.sortKey.book.toUpperCase()) return false;
+        }
+        return (
+            item.sortKey.chapter >= milestone.range.start &&
+            item.sortKey.chapter <= milestone.range.end
+        );
+    };
+
+    // Assign each content cell to the milestone section it lives in. We attach a cell ONLY to an
+    // immediately-adjacent milestone (no other milestone sitting between the cell and that
+    // milestone): the nearest milestone PRECEDING the cell if that one covers its chapter,
+    // otherwise the nearest milestone FOLLOWING the cell if THAT one covers it. A cell is never
+    // pulled across intervening milestones to a far-away covering milestone — that would, e.g.,
+    // yank a trailing block of empty duplicate verse cells up into the live scripture. Cells with
+    // no adjacent covering milestone stay anchored exactly where they are (handled below).
+    //
+    // Consequences worth noting:
+    //   - A verse already sitting under its chapter milestone keeps its section; we only re-sort
+    //     within the section, so a correctly-ordered notebook is a strict no-op.
+    //   - A verse-range cell that drifted just above its milestone (nothing between it and that
+    //     milestone) is pulled down via the "nearest following" branch — the original migration's
+    //     core job.
+    const milestoneIndices = milestones.map((m) => m.originalIndex);
+    const assignedCells = new Set<any>();
+    if (milestones.length > 0) {
+        for (const item of contentWithRef) {
+            // Binary-free scan is fine (milestone counts are small). Find the split point: the
+            // first milestone whose original index is greater than the cell's.
+            let nextM = milestones.length;
+            for (let m = 0; m < milestones.length; m++) {
+                if (milestoneIndices[m] > item.originalIndex) { nextM = m; break; }
+            }
+            const precedingM = nextM - 1; // nearest milestone before the cell, or -1
+            let chosen: (typeof milestones)[number] | null = null;
+            if (precedingM >= 0 && covers(milestones[precedingM], item)) {
+                chosen = milestones[precedingM];
+            } else if (nextM < milestones.length && covers(milestones[nextM], item)) {
+                chosen = milestones[nextM];
+            }
+            if (chosen) {
+                chosen.assigned.push(item);
+                assignedCells.add(item.cell);
+            }
+        }
+        // Sort each milestone's assigned content into canonical (chapter, verse) order. The sort
+        // is stable, so cells sharing a sort key keep their original relative order.
+        for (const milestone of milestones) {
+            milestone.assigned.sort(
+                (a, b) =>
+                    a.sortKey.chapter - b.sortKey.chapter ||
+                    a.sortKey.verse - b.sortKey.verse
+            );
+        }
+    }
+
+    // Bail out when milestones exist but none of them claimed any content (e.g. unparseable or
+    // index-based milestone values that don't correspond to content chapters). Reordering would
+    // detach every content cell from its milestone, so keep the original order.
+    if (milestones.length > 0 && assignedCells.size === 0) {
+        return { cells, mutated, orderChanged: false };
+    }
+
+    // Anchors are the cells the helper actively places: milestones plus the verse cells it
+    // assigned to them (or ALL ref cells when the file has no milestones — legacy global sort).
+    const anchorCells = new Set<any>();
+    for (const m of milestones) anchorCells.add(m.cell);
+    if (milestones.length > 0) {
+        for (const cell of assignedCells) anchorCells.add(cell);
+    } else {
+        for (const item of contentWithRef) anchorCells.add(item.cell);
+    }
+
+    // Everything else stays attached to the nearest preceding anchor so unplaceable cells
+    // (no-ref TEXT cells, STYLE cells, orphan paratexts, unmatched refs) keep their neighborhood.
+    const attachments = new Map<any, any[]>();
+    const startGroup: any[] = [];
+    let lastAnchor: any = null;
+    for (const cell of cells) {
+        if (anchorCells.has(cell)) {
+            lastAnchor = cell;
+            continue;
+        }
+        if (parentedParatexts.has(cell)) continue;
+        if (lastAnchor) {
+            if (!attachments.has(lastAnchor)) attachments.set(lastAnchor, []);
+            attachments.get(lastAnchor)!.push(cell);
+        } else {
+            startGroup.push(cell);
+        }
     }
 
     const newCells: any[] = [];
-    const consumedParentIds = new Set<string>();
-
-    const emitContentCell = (item: (typeof contentWithRef)[0]) => {
-        const { cell, parsed } = item;
-        const md = cell.metadata || {};
-        const parentId = md.id;
-
-        if (parsed.kind === "range" && !hasUserCellLabelEdit(cell)) {
-            if (md.cellLabel !== parsed.cellLabel) {
-                md.cellLabel = parsed.cellLabel;
-                mutated = true;
-            }
-            if (md.chapterNumber === undefined || md.chapterNumber === null) {
-                md.chapterNumber = String(parsed.chapter);
-                mutated = true;
-            }
-            cell.metadata = md;
-        }
-
-        if (typeof parentId === "string") {
-            const before = paratextBeforeParent.get(parentId);
+    const emitted = new Set<any>();
+    const emitCell = (cell: any) => {
+        if (!cell || emitted.has(cell)) return;
+        emitted.add(cell);
+        const id = cell?.metadata?.id;
+        if (typeof id === "string") {
+            const before = paratextBeforeParent.get(id);
             if (before) {
-                for (const pt of before) newCells.push(pt);
-                consumedParentIds.add(parentId);
+                for (const pt of before) emitCell(pt);
             }
         }
         newCells.push(cell);
+        const trailing = attachments.get(cell);
+        if (trailing) {
+            for (const attached of trailing) emitCell(attached);
+        }
     };
 
-    for (const { cell, chapter } of milestones) {
-        newCells.push(cell);
-        if (chapter != null) {
-            const keysToDelete: string[] = [];
-            for (const [key, items] of contentByChapter.entries()) {
-                const [, chapStr] = key.split("\t");
-                if (parseInt(chapStr, 10) === chapter) {
-                    for (const item of items) emitContentCell(item);
-                    keysToDelete.push(key);
-                }
-            }
-            for (const k of keysToDelete) contentByChapter.delete(k);
+    for (const cell of startGroup) emitCell(cell);
+
+    if (milestones.length > 0) {
+        for (const milestone of milestones) {
+            emitCell(milestone.cell);
+            for (const item of milestone.assigned) emitCell(item.cell);
         }
+    } else {
+        // No milestones: emit all ref cells in canonical (book, chapter, verse) order. This is
+        // the original migration behavior for milestone-less files with verse-range cells.
+        const sorted = [...contentWithRef].sort(
+            (a, b) =>
+                a.sortKey.book.localeCompare(b.sortKey.book) ||
+                a.sortKey.chapter - b.sortKey.chapter ||
+                a.sortKey.verse - b.sortKey.verse
+        );
+        for (const item of sorted) emitCell(item.cell);
     }
 
-    // Emit remaining content-with-ref (chapter not matched to any milestone) in deterministic order.
-    const remaining: typeof contentWithRef = [];
-    for (const items of contentByChapter.values()) remaining.push(...items);
-    remaining.sort(
-        (a, b) =>
-            a.sortKey.book.localeCompare(b.sortKey.book) ||
-            a.sortKey.chapter - b.sortKey.chapter ||
-            a.sortKey.verse - b.sortKey.verse
-    );
-    for (const item of remaining) emitContentCell(item);
+    // Safety net: never drop a cell. Anything not yet emitted is appended in original order.
+    for (const cell of cells) emitCell(cell);
 
-    // Emit content-without-ref cells, attaching any paratexts whose parent matches.
-    for (const { cell } of contentWithoutRef) {
-        const parentId = cell.metadata?.id;
-        if (typeof parentId === "string") {
-            const before = paratextBeforeParent.get(parentId);
-            if (before) {
-                for (const pt of before) newCells.push(pt);
-                consumedParentIds.add(parentId);
-            }
-        }
-        newCells.push(cell);
+    if (newCells.length !== cells.length) {
+        // Duplicate cell instances in the input (pathological) collapse in the emitted set.
+        // Refuse to reorder rather than change the cell count during a merge.
+        return { cells, mutated, orderChanged: false };
     }
 
-    // Any paratext buckets we didn't consume (parent existed but was filtered out, e.g. as a
-    // style cell) get appended in the same relative order they appeared originally so they
-    // aren't lost.
-    const leftoverBuckets: Array<{ cell: any; originalIndex: number; }> = [];
-    for (const [parentId, bucket] of paratextBeforeParent) {
-        if (consumedParentIds.has(parentId)) continue;
-        for (const pt of bucket) {
-            const originalIndex = (() => {
-                const id = pt.metadata?.id;
-                return typeof id === "string"
-                    ? originalIndexById.get(id) ?? Number.MAX_SAFE_INTEGER
-                    : Number.MAX_SAFE_INTEGER;
-            })();
-            leftoverBuckets.push({ cell: pt, originalIndex });
+    let orderChanged = false;
+    for (let i = 0; i < cells.length; i++) {
+        if (newCells[i] !== cells[i]) {
+            orderChanged = true;
+            break;
         }
     }
-
-    // Style/other and orphan paratexts retain their relative ordering by original index.
-    const tail: Array<{ cell: any; originalIndex: number; }> = [
-        ...styleOrOther,
-        ...orphanParatexts,
-        ...leftoverBuckets,
-    ];
-    tail.sort((a, b) => a.originalIndex - b.originalIndex);
-    for (const { cell } of tail) newCells.push(cell);
-
-    const oldIds = cells.map((c) => c?.metadata?.id ?? "").join(",");
-    const newIds = newCells.map((c) => c?.metadata?.id ?? "").join(",");
-    const orderChanged = oldIds !== newIds;
 
     return { cells: newCells, mutated, orderChanged };
 }
 
+type SortKey = { book: string; chapter: number; verse: number; };
+
 /**
- * Extracts a chapter number from a milestone cell's value (e.g. "John 4", "4", "GEN 2").
- * Mirrors the local helper in migrationUtils so the helper file has no circular import.
+ * Extracts the inclusive chapter range from a milestone cell's value.
+ * "John 4" / "4" -> 4..4; "Job 4-31" -> 4..31; no usable number -> null.
  */
-function extractChapterNumberFromMilestoneValue(value: string | undefined): number | null {
+function extractChapterRangeFromMilestoneValue(value: string | undefined): ChapterRange | null {
     if (value == null || typeof value !== "string") return null;
+    const rangeMatch = value.match(/(\d+)\s*[-–—]\s*(\d+)\s*$/);
+    if (rangeMatch) {
+        const start = parseInt(rangeMatch[1], 10);
+        const end = parseInt(rangeMatch[2], 10);
+        if (!isNaN(start) && !isNaN(end) && start > 0 && start <= end) {
+            return { start, end };
+        }
+        return null;
+    }
     const matches = value.match(/(\d+)(?!.*\d)/);
     if (matches?.[1]) {
         const n = parseInt(matches[1], 10);
-        return !isNaN(n) && n > 0 ? n : null;
+        return !isNaN(n) && n > 0 ? { start: n, end: n } : null;
     }
     const parsed = parseInt(value, 10);
-    return !isNaN(parsed) && parsed > 0 ? parsed : null;
+    return !isNaN(parsed) && parsed > 0 ? { start: parsed, end: parsed } : null;
+}
+
+/**
+ * Resolves the book portion of a milestone value ("Job 4-31" -> "JOB") against the Bible book
+ * lookup. Returns null when the leading text is empty or doesn't match a known book name,
+ * abbreviation, or OSIS id. Only consulted for multi-book files.
+ */
+function resolveBookAbbrFromMilestoneValue(value: string | undefined): string | null {
+    if (value == null || typeof value !== "string") return null;
+    const candidate = value.replace(/\s*\d+\s*([-–—]\s*\d+)?\s*$/, "").trim();
+    if (!candidate) return null;
+    const normalized = candidate.replace(/\.$/, "").toLowerCase();
+    for (const book of bibleData as any[]) {
+        if (typeof book?.abbr !== "string") continue;
+        if (
+            book.abbr.toLowerCase() === normalized ||
+            (typeof book.name === "string" && book.name.toLowerCase() === normalized) ||
+            (typeof book.osisId === "string" && book.osisId.toLowerCase() === normalized) ||
+            (Array.isArray(book.abbreviations) &&
+                book.abbreviations.some(
+                    (a: any) => typeof a === "string" && a.replace(/\.$/, "").toLowerCase() === normalized
+                ))
+        ) {
+            return book.abbr.toUpperCase();
+        }
+    }
+    return null;
 }

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -2117,21 +2117,6 @@ function getLocalizedBookName(bookAbbr: string): string {
 }
 
 /**
- * Extracts chapter number from a milestone value (e.g. "John 4", "4", "GEN 2").
- * Used for verse-range migration to associate milestones with content chapters.
- */
-function extractChapterNumberFromMilestoneValue(value: string | undefined): number | null {
-    if (value == null || typeof value !== "string") return null;
-    const matches = value.match(/(\d+)(?!.*\d)/);
-    if (matches?.[1]) {
-        const n = parseInt(matches[1], 10);
-        return !isNaN(n) && n > 0 ? n : null;
-    }
-    const parsed = parseInt(value, 10);
-    return !isNaN(parsed) && parsed > 0 ? parsed : null;
-}
-
-/**
  * Creates a milestone cell with book name and chapter number derived from the cell below it.
  * Format: "BookName ChapterNumber" (e.g., "Isaiah 1")
  * @param cell - The cell to derive chapter information from
@@ -3219,7 +3204,9 @@ export async function migrateVerseRangeLabelsAndPositionsForFile(
         // ---- Reorder + relabel pass ----------------------------------------------------------
         // Delegated to the shared helper so the codex merge resolver can run the same logic and
         // keep the migrated ordering / cellLabel after every git sync.
-        const reordered = reorderVerseRangeCells(cells);
+        const reordered = reorderVerseRangeCells(cells, {
+            importerType: notebookData?.metadata?.importerType,
+        });
         const newCells = reordered.cells;
         const orderChanged = reordered.orderChanged;
         if (reordered.mutated) hasChanges = true;

--- a/src/test/suite/resolveCodexCustomMerge.test.ts
+++ b/src/test/suite/resolveCodexCustomMerge.test.ts
@@ -482,4 +482,190 @@ suite("Codex Custom Merge - Verse Range Order Preservation Across Sync", () => {
         const range = JSON.parse(merged).cells.find((c: any) => c.metadata?.id === "RANGE");
         assert.strictEqual(range.metadata.cellLabel, customLabel, "Resolver must not overwrite a user-edited cellLabel");
     });
+
+    test("merge preserves interleaved milestone order when text cells have book-only globalReferences", async () => {
+        // IDML-imported files carry book-only refs like ["JOB"], which parseVerseRef cannot
+        // parse. The reorder helper used to hoist every milestone to the top of the file and
+        // append all text cells after the last milestone, so each section appeared empty in
+        // the editor after a sync merge.
+        const milestone = (id: string, value: string) => ({
+            kind: 2,
+            languageId: "html",
+            value,
+            metadata: { id, type: "milestone", edits: [] },
+        });
+        const bookOnlyText = (id: string, value: string) => ({
+            kind: 2,
+            languageId: "scripture",
+            value,
+            metadata: {
+                id,
+                type: "text",
+                data: { globalReferences: ["JOB"] },
+                edits: [],
+            },
+        });
+        const content = JSON.stringify({
+            cells: [
+                milestone("M1", "Job 1"),
+                bookOnlyText("T1", "<span>section one a</span>"),
+                bookOnlyText("T2", "<span>section one b</span>"),
+                milestone("M2", "Job 2"),
+                bookOnlyText("T3", "<span>section two</span>"),
+                milestone("M3", "Job 3"),
+                bookOnlyText("T4", "<span>section three</span>"),
+            ],
+            metadata: { id: "TEST", originalName: "TEST" },
+        });
+
+        const merged1 = await resolveCodexCustomMerge(content, content);
+        const ids = JSON.parse(merged1).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            ["M1", "T1", "T2", "M2", "T3", "M3", "T4"],
+            "Milestones must stay interleaved with their text cells"
+        );
+
+        // And the result must be stable across repeated sync merges
+        const merged2 = await resolveCodexCustomMerge(merged1, merged1);
+        const ids2 = JSON.parse(merged2).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(ids2, ids, "Repeated merges must not change the cell order");
+    });
+
+    test("merge preserves order when milestones are chapter ranges like 'Job 4-31'", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "html",
+                value: "Job 1-3",
+                metadata: { id: "M1", type: "milestone", edits: [] },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "<span>1:1</span>",
+                metadata: {
+                    id: "T1",
+                    type: "text",
+                    data: { globalReferences: ["JOB 1:1"] },
+                    edits: [],
+                },
+            },
+            {
+                kind: 2,
+                languageId: "html",
+                value: "Job 4-31",
+                metadata: { id: "M2", type: "milestone", edits: [] },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "<span>4:1</span>",
+                metadata: {
+                    id: "T2",
+                    type: "text",
+                    data: { globalReferences: ["JOB 4:1"] },
+                    edits: [],
+                },
+            },
+        ];
+        const content = JSON.stringify({
+            cells,
+            metadata: { id: "TEST", originalName: "TEST" },
+        });
+
+        const merged = await resolveCodexCustomMerge(content, content);
+        const ids = JSON.parse(merged).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            ["M1", "T1", "M2", "T2"],
+            "Content chapters must stay under their covering range milestone"
+        );
+    });
+
+    test("merge keeps USFM heading/marker cells (empty globalReferences) next to their verses", async () => {
+        // The USFM importer writes section headings and paragraph markers as TEXT cells with
+        // empty globalReferences, interleaved between verse cells. A sync merge must not move
+        // them to the end of the file.
+        const verse = (id: string, ref: string) => ({
+            kind: 2,
+            languageId: "scripture",
+            value: `<span>${ref}</span>`,
+            metadata: { id, type: "text", data: { globalReferences: [ref] }, edits: [] },
+        });
+        const marker = (id: string, value: string) => ({
+            kind: 2,
+            languageId: "html",
+            value,
+            metadata: { id, type: "text", data: { globalReferences: [] }, edits: [] },
+        });
+        const content = JSON.stringify({
+            cells: [
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "Genesis 1",
+                    metadata: { id: "M1", type: "milestone", edits: [] },
+                },
+                marker("H1", "<span>The Creation</span>"),
+                verse("V1", "GEN 1:1"),
+                marker("P1", "<span></span>"),
+                verse("V2", "GEN 1:2"),
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "Genesis 2",
+                    metadata: { id: "M2", type: "milestone", edits: [] },
+                },
+                marker("H2", "<span>The Garden</span>"),
+                verse("V3", "GEN 2:1"),
+            ],
+            metadata: { id: "TEST", originalName: "TEST", importerType: "usfm" },
+        });
+
+        const merged = await resolveCodexCustomMerge(content, content);
+        const ids = JSON.parse(merged).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            ["M1", "H1", "V1", "P1", "V2", "M2", "H2", "V3"],
+            "Headings and markers must stay anchored next to their verses"
+        );
+    });
+
+    test("merge of a non-Bible importer notebook (markdown with citations) never reorders", async () => {
+        const para = (id: string, value: string, ref?: string) => ({
+            kind: 2,
+            languageId: "html",
+            value,
+            metadata: {
+                id,
+                type: "text",
+                data: { globalReferences: ref ? [ref] : [] },
+                edits: [],
+            },
+        });
+        const content = JSON.stringify({
+            cells: [
+                {
+                    kind: 2,
+                    languageId: "html",
+                    value: "1",
+                    metadata: { id: "M1", type: "milestone", edits: [] },
+                },
+                para("P1", "<span>intro</span>"),
+                para("P2", "<span>see Genesis 1:5</span>", "GEN 1:5"),
+                para("P3", "<span>middle</span>"),
+                para("P4", "<span>see Genesis 1:2</span>", "GEN 1:2"),
+            ],
+            metadata: { id: "TEST", originalName: "TEST", importerType: "markdown" },
+        });
+
+        const merged = await resolveCodexCustomMerge(content, content);
+        const ids = JSON.parse(merged).cells.map((c: any) => c.metadata?.id);
+        assert.deepStrictEqual(
+            ids,
+            ["M1", "P1", "P2", "P3", "P4"],
+            "Document notebooks must keep their paragraph order regardless of citations"
+        );
+    });
 });

--- a/src/test/suite/verseRangeReorder.test.ts
+++ b/src/test/suite/verseRangeReorder.test.ts
@@ -1,0 +1,491 @@
+import * as assert from "assert";
+import { reorderVerseRangeCells } from "../../projectManager/utils/merge/utils/verseRangeReorder";
+import { CodexCellTypes } from "../../../types/enums";
+
+function milestoneCell(id: string, value: string) {
+    return {
+        kind: 2,
+        languageId: "html",
+        value,
+        metadata: { id, type: CodexCellTypes.MILESTONE, edits: [] },
+    };
+}
+
+function textCell(id: string, value: string, globalRef?: string) {
+    return {
+        kind: 2,
+        languageId: "scripture",
+        value,
+        metadata: {
+            id,
+            type: CodexCellTypes.TEXT,
+            data: { globalReferences: globalRef === undefined ? [] : [globalRef] },
+            edits: [],
+        },
+    };
+}
+
+function styleCell(id: string, value: string) {
+    return {
+        kind: 2,
+        languageId: "html",
+        value,
+        metadata: { id, type: CodexCellTypes.STYLE, data: { globalReferences: [] }, edits: [] },
+    };
+}
+
+function paratextCell(id: string, value: string, parentId: string) {
+    return {
+        kind: 2,
+        languageId: "html",
+        value,
+        metadata: { id, type: CodexCellTypes.PARATEXT, parentId, data: {}, edits: [] },
+    };
+}
+
+function cellIds(cells: any[]): string[] {
+    return cells.map((c) => c?.metadata?.id);
+}
+
+suite("reorderVerseRangeCells - bail-outs for unmatchable content", () => {
+    test("book-only globalReferences (IDML import): original interleaved order is preserved", () => {
+        // Every text cell carries a book-only ref like ["JOB"], which parseVerseRef cannot
+        // parse. Reordering used to hoist all milestones to the top and append every text
+        // cell after them, making each section appear empty in the editor.
+        const cells = [
+            milestoneCell("M1", "Job 1"),
+            textCell("T1", "<span>section one a</span>", "JOB"),
+            textCell("T2", "<span>section one b</span>", "JOB"),
+            milestoneCell("M2", "Job 2"),
+            textCell("T3", "<span>section two</span>", "JOB"),
+            milestoneCell("M3", "Job 3"),
+            textCell("T4", "<span>section three</span>", "JOB"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "T2", "M2", "T3", "M3", "T4"]);
+        assert.strictEqual(result.orderChanged, false);
+        assert.strictEqual(result.mutated, false);
+    });
+
+    test("empty globalReferences (docx/subtitles/tms shape): original order is preserved", () => {
+        const cells = [
+            milestoneCell("M1", "1"),
+            textCell("T1", "<span>para one</span>"),
+            textCell("T2", "<span>para two</span>"),
+            textCell("T3", "<span>para three</span>"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "T2", "T3"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("milestones whose chapters match no content chapter: original order is preserved", () => {
+        const cells = [
+            milestoneCell("M1", "John 4"),
+            textCell("T1", "<span>5:1</span>", "JHN 5:1"),
+            textCell("T2", "<span>5:2</span>", "JHN 5:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "T2"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("unparseable milestone values (no digits): original order is preserved", () => {
+        const cells = [
+            milestoneCell("M1", "Introduction"),
+            textCell("T1", "<span>1:1</span>", "GEN 1:1"),
+            milestoneCell("M2", "Main Part"),
+            textCell("T2", "<span>2:1</span>", "GEN 2:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "M2", "T2"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+});
+
+suite("reorderVerseRangeCells - importerType gate", () => {
+    test("known non-Bible importer (markdown) with verse citations: strict no-op", () => {
+        // Markdown extracts Bible citations from anywhere in the text, so document cells can
+        // carry parseable refs. The importer type tells us this is a document, not scripture.
+        const cells = [
+            milestoneCell("M1", "1"),
+            textCell("P1", "<span>intro paragraph</span>"),
+            textCell("P2", "<span>see Genesis 1:5</span>", "GEN 1:5"),
+            textCell("P3", "<span>middle paragraph</span>"),
+            textCell("P4", "<span>see Genesis 1:2</span>", "GEN 1:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells, { importerType: "markdown" });
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "P1", "P2", "P3", "P4"]);
+        assert.strictEqual(result.orderChanged, false);
+        assert.strictEqual(result.mutated, false);
+    });
+
+    test("Bible importer type (usfm) still reorders", () => {
+        const cells = [
+            milestoneCell("M1", "John 4"),
+            textCell("V2", "<span>v2</span>", "JHN 4:2"),
+            textCell("V1", "<span>v1</span>", "JHN 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells, { importerType: "usfm" });
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "V2"]);
+        assert.strictEqual(result.orderChanged, true);
+    });
+
+    test("unknown importer type falls back to content heuristics", () => {
+        const cells = [
+            milestoneCell("M1", "John 4"),
+            textCell("V2", "<span>v2</span>", "JHN 4:2"),
+            textCell("V1", "<span>v1</span>", "JHN 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells, { importerType: undefined });
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "V2"]);
+    });
+});
+
+suite("reorderVerseRangeCells - chapter-range milestones", () => {
+    test("content chapters are matched to range milestones like 'Job 4-31'", () => {
+        const cells = [
+            milestoneCell("M1", "Job 1-3"),
+            textCell("T1", "<span>1:1</span>", "JOB 1:1"),
+            textCell("T2", "<span>2:1</span>", "JOB 2:1"),
+            milestoneCell("M2", "Job 4-31"),
+            textCell("T3", "<span>4:1</span>", "JOB 4:1"),
+            textCell("T4", "<span>31:1</span>", "JOB 31:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "T2", "M2", "T3", "T4"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("content under a range milestone is restored from shuffled order", () => {
+        // Chapter 5 content drifted in front of chapter 4 inside the "Job 4-31" section.
+        const cells = [
+            milestoneCell("M1", "Job 1-3"),
+            textCell("T1", "<span>1:1</span>", "JOB 1:1"),
+            milestoneCell("M2", "Job 4-31"),
+            textCell("T3", "<span>5:1</span>", "JOB 5:1"),
+            textCell("T2", "<span>4:1</span>", "JOB 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "T1", "M2", "T2", "T3"]);
+        assert.strictEqual(result.orderChanged, true);
+    });
+
+    test("mixed single-chapter and range milestones place each chapter correctly", () => {
+        const cells = [
+            milestoneCell("M1", "Job 1"),
+            textCell("T1", "<span>1:1</span>", "JOB 1:1"),
+            milestoneCell("M2", "Job 2"),
+            textCell("T2", "<span>2:1</span>", "JOB 2:1"),
+            milestoneCell("M3", "Job 3-31"),
+            textCell("T3", "<span>3:1</span>", "JOB 3:1"),
+            textCell("T4", "<span>10:1</span>", "JOB 10:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(
+            cellIds(result.cells),
+            ["M1", "T1", "M2", "T2", "M3", "T3", "T4"]
+        );
+        assert.strictEqual(result.orderChanged, false);
+    });
+});
+
+suite("reorderVerseRangeCells - multi-book files", () => {
+    test("milestones only claim chapters of their own book despite chapter-number collisions", () => {
+        // JOB 4 and SNG 4 both exist; "Job 4" must not capture Song of Songs content.
+        const cells = [
+            milestoneCell("MJ", "Job 4"),
+            textCell("J1", "<span>job 4:1</span>", "JOB 4:1"),
+            milestoneCell("MS", "Song of Songs 4"),
+            textCell("S1", "<span>sng 4:1</span>", "SNG 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["MJ", "J1", "MS", "S1"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("multi-book content with unresolvable milestone books is left untouched", () => {
+        // Milestone values are bare numbers; with two books in the file there is no safe way
+        // to decide which book each milestone covers, so nothing may move.
+        const cells = [
+            milestoneCell("M1", "4"),
+            textCell("J1", "<span>job 4:1</span>", "JOB 4:1"),
+            milestoneCell("M2", "4"),
+            textCell("S1", "<span>sng 4:1</span>", "SNG 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "J1", "M2", "S1"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+});
+
+suite("reorderVerseRangeCells - unplaceable cells stay anchored", () => {
+    test("USFM shape: heading and marker TEXT cells with empty refs keep their position", () => {
+        // The USFM importer writes section headings and paragraph markers as TEXT cells with
+        // empty globalReferences, interleaved between verse cells. They must not be moved to
+        // the end of the file.
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("H1", "<span>The Creation</span>"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            textCell("P1", "<span></span>"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+            milestoneCell("M2", "Genesis 2"),
+            textCell("H2", "<span>The Garden</span>"),
+            textCell("V3", "<span>v1</span>", "GEN 2:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(
+            cellIds(result.cells),
+            ["M1", "H1", "V1", "P1", "V2", "M2", "H2", "V3"]
+        );
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("marker cells follow their verse when verses are reordered", () => {
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+            textCell("P1", "<span>marker after v2</span>"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "V2", "P1"]);
+        assert.strictEqual(result.orderChanged, true);
+    });
+
+    test("style cells keep their position", () => {
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            styleCell("ST1", "<span data-tag='b'></span>"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "ST1", "V2"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("orphan paratext (missing parent) stays in place", () => {
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            paratextCell("ORPH", "<span>orphan note</span>", "missing-id"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "ORPH", "V2"]);
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("ref cells whose chapter matches no milestone stay anchored (with other matches present)", () => {
+        // Chapter 7 has no milestone; its cell must not jump to the end of the file.
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            textCell("X7", "<span>stray 7:1</span>", "GEN 7:1"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        // V1 and V2 sort under M1; X7 is unplaceable and follows its preceding anchor (V1).
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "X7", "V2"]);
+    });
+});
+
+suite("reorderVerseRangeCells - real-world USFM structures", () => {
+    test("double milestones per chapter (bare '1' then 'Luke 1'): verses stay under the nearest one", () => {
+        // usfm-experimental files emit a bare-number milestone a few cells before the real
+        // "Luke N" milestone. Verses already sitting under "Luke 1" must NOT be yanked up to the
+        // earlier "1" milestone (which covers the same chapter), and the empty cell between the
+        // two milestones must stay put.
+        const cells = [
+            milestoneCell("M0", "0"),
+            textCell("FRONT", "<span>front matter</span>"),
+            milestoneCell("MNUM", "1"),
+            textCell("GAP", "<span></span>"),
+            milestoneCell("MLUKE", "Luke 1"),
+            textCell("V1", "<span>v1</span>", "LUK 1:1"),
+            textCell("V2", "<span>v2</span>", "LUK 1:2"),
+            textCell("V3", "<span>v3</span>", "LUK 1:3"),
+        ];
+
+        const result = reorderVerseRangeCells(cells, { importerType: "usfm-experimental" });
+
+        assert.deepStrictEqual(
+            cellIds(result.cells),
+            ["M0", "FRONT", "MNUM", "GAP", "MLUKE", "V1", "V2", "V3"]
+        );
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("double milestones: out-of-order verses under 'Luke 1' are sorted, not pulled to '1'", () => {
+        const cells = [
+            milestoneCell("MNUM", "1"),
+            textCell("GAP", "<span></span>"),
+            milestoneCell("MLUKE", "Luke 1"),
+            textCell("V2", "<span>v2</span>", "LUK 1:2"),
+            textCell("V1", "<span>v1</span>", "LUK 1:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells, { importerType: "usfm-experimental" });
+
+        // V1/V2 sort under MLUKE (nearest preceding milestone covering ch1), NOT under MNUM.
+        assert.deepStrictEqual(
+            cellIds(result.cells),
+            ["MNUM", "GAP", "MLUKE", "V1", "V2"]
+        );
+        assert.strictEqual(result.orderChanged, true);
+    });
+
+    test("trailing empty duplicate-verse block (no milestone) is NOT pulled into the scripture", () => {
+        // Some translation .codex files carry a populated scripture block followed by a trailing
+        // block of empty duplicate verse cells that has no milestones of its own. Those empty
+        // cells must stay at the end — never leap-frogged up under an early chapter milestone.
+        const cells = [
+            milestoneCell("M1", "John 1"),
+            textCell("V1", "<span>v1</span>", "JHN 1:1"),
+            textCell("V2", "<span>v2</span>", "JHN 1:2"),
+            milestoneCell("M2", "John 2"),
+            textCell("V3", "<span>2:1</span>", "JHN 2:1"),
+            // Trailing duplicate block: empty cells, no milestone precedes them that covers ch1.
+            textCell("E1", "<span></span>", "JHN 1:1"),
+            textCell("E2", "<span></span>", "JHN 1:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(
+            cellIds(result.cells),
+            ["M1", "V1", "V2", "M2", "V3", "E1", "E2"]
+        );
+        assert.strictEqual(result.orderChanged, false);
+    });
+
+    test("verse-range cell drifted just above its milestone is pulled down", () => {
+        // The original migration's core job: a range cell sitting immediately above its chapter
+        // milestone (nothing else between) is pulled under it in verse order.
+        const cells = [
+            textCell("R", "<span>3-5</span>", "JHN 4:3-5"),
+            milestoneCell("M", "John 4"),
+            textCell("V1", "<span>v1</span>", "JHN 4:1"),
+            textCell("V2", "<span>v2</span>", "JHN 4:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M", "V1", "V2", "R"]);
+        assert.strictEqual(result.cells[3].metadata.cellLabel, "3-5");
+    });
+});
+
+suite("reorderVerseRangeCells - core behaviors", () => {
+    test("normal milestone + parseable refs: out-of-order verses are still reordered", () => {
+        const cells = [
+            milestoneCell("M1", "John 4"),
+            textCell("V2", "<span>v2</span>", "JHN 4:2"),
+            textCell("V1", "<span>v1</span>", "JHN 4:1"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "V2"]);
+        assert.strictEqual(result.orderChanged, true);
+    });
+
+    test("paratext with parent present is emitted immediately before its parent", () => {
+        const cells = [
+            milestoneCell("M1", "John 4"),
+            textCell("V1", "<span>v1</span>", "JHN 4:1"),
+            paratextCell("PT", "<span>heading for v2</span>", "V2"),
+            textCell("V2", "<span>v2</span>", "JHN 4:2"),
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.deepStrictEqual(cellIds(result.cells), ["M1", "V1", "PT", "V2"]);
+    });
+
+    test("verse-range cells without milestones still get cellLabel autofill", () => {
+        const cells = [textCell("R1", "<span>v3-5</span>", "JHN 4:3-5")];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.strictEqual(result.cells[0].metadata.cellLabel, "3-5");
+        assert.strictEqual(result.mutated, true);
+    });
+
+    test("reorder is idempotent", () => {
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("H1", "<span>heading</span>"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            styleCell("ST1", "<span></span>"),
+            milestoneCell("M2", "Genesis 2-3"),
+            textCell("V3", "<span>2:1</span>", "GEN 2:1"),
+            paratextCell("PT", "<span>note</span>", "V3"),
+        ];
+
+        const first = reorderVerseRangeCells(cells);
+        const second = reorderVerseRangeCells(first.cells);
+
+        assert.deepStrictEqual(cellIds(second.cells), cellIds(first.cells));
+        assert.strictEqual(second.orderChanged, false);
+    });
+
+    test("never drops or duplicates cells", () => {
+        const cells = [
+            milestoneCell("M1", "Genesis 1"),
+            textCell("H1", "<span>heading</span>"),
+            textCell("V2", "<span>v2</span>", "GEN 1:2"),
+            paratextCell("ORPH", "<span>orphan</span>", "missing"),
+            textCell("V1", "<span>v1</span>", "GEN 1:1"),
+            styleCell("ST1", "<span></span>"),
+            { kind: 2, value: "no metadata cell" },
+        ];
+
+        const result = reorderVerseRangeCells(cells);
+
+        assert.strictEqual(result.cells.length, cells.length);
+        const inputSet = new Set(cells);
+        for (const cell of result.cells) {
+            assert.ok(inputSet.has(cell), "Output must reuse the same cell instances");
+            inputSet.delete(cell);
+        }
+        assert.strictEqual(inputSet.size, 0, "Every input cell must appear exactly once");
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/utils/workflowHelpers.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/utils/workflowHelpers.ts
@@ -8,6 +8,9 @@ import type { CustomNotebookCellData } from 'types';
 import { CodexCellTypes } from 'types/enums';
 import { v4 as uuidv4 } from 'uuid';
 import bibleData from '../../assets/bible-books-lookup.json';
+// Relative path (not @sharedUtils alias) because this file is also bundled by the extension's
+// webpack build, which doesn't define that alias.
+import { isBibleTypeImporter as isBibleTypeImporterShared } from '../../../../../sharedUtils/importerTypeUtils';
 
 /**
  * Creates a progress update object
@@ -443,28 +446,9 @@ function createMilestoneCell(cell: ProcessedCell, milestoneIndex: number, uuid?:
  * Determines if an importer type is Bible-type based on importerType metadata
  */
 function isBibleTypeImporter(importerType: string | undefined): boolean {
-    if (!importerType) {
-        return false;
-    }
-
-    // All entries must be lowercase since we normalize the input
-    const bibleTypeImporters = [
-        'usfm',
-        'usfm-experimental',
-        'paratext',
-        'ebiblecorpus',
-        'ebible',
-        'ebible-download',
-        'maculabible',
-        'macula',
-        'biblica',
-        'obs',
-        'pdf', // PDF can contain Bible content
-        'indesign', // InDesign can contain Bible content
-    ];
-
-    const normalizedType = importerType.toLowerCase().trim();
-    return bibleTypeImporters.includes(normalizedType);
+    // Delegates to the shared list so milestone insertion (here) and the extension host's
+    // verse-range reorder always agree on which notebooks are scripture-shaped.
+    return isBibleTypeImporterShared(importerType);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1051

`reorderVerseRangeCells()` — run by both the verse-range migration and, critically, the codex merge resolver on **every sync merge** — corrupted cell ordering for notebooks whose text cells have unparseable `globalReferences` (e.g. book-only `["JOB"]` from IDML/biblica imports). With no cell yielding a parseable verse ref, every milestone was emitted consecutively at the top of the file and all text cells were appended after the last one. In the editor this made every section appear empty — users perceived their translation as wiped out, even though all values survived.

The fix makes the helper bail out as a no-op when it has nothing to safely reorder, and rewrites the milestone↔content matching so it works correctly across all importer types. The reorder now leaves a correctly-ordered notebook untouched and only fixes genuinely-misplaced cells, so it is safe to keep running on every merge.

## Changes

- **No-op when there is nothing to reorder.** Bail out (preserving original order) when no content cell has a parseable verse ref (book-only/empty `globalReferences`), and when milestones exist but none can be matched to any content chapter.
- **Skip non-scripture notebooks by importer type.** A new shared `isBibleTypeImporter` (`sharedUtils/importerTypeUtils.ts`) gates the helper so document/non-Bible imports (docx, markdown, subtitles, tms, spreadsheet, audio, plaintext) are a strict no-op — verse citations in those files no longer scramble paragraph order. The NewSourceUploader's milestone insertion now uses the same shared list so both sides agree on what counts as scripture.
- **Chapter-range milestones** (e.g. `"Job 4-31"`) are matched as inclusive chapter ranges instead of misreading the trailing number as a single chapter.
- **Adjacent-only milestone assignment.** A verse attaches only to the nearest *preceding* covering milestone (or nearest *following* if nothing precedes), never leap-frogging across intervening milestones. This fixes double-milestone files (a bare `"1"` before `"Luke 1"`) and prevents trailing empty-duplicate-verse blocks from being pulled up into live scripture.
- **Multi-book safety.** In files containing multiple books, a milestone only claims chapters of its own book (resolved against the Bible book lookup), so `"Job 4"` cannot capture `SNG 4:1`.
- **Unplaceable cells stay anchored.** Section headings, markers, style cells, and orphan paratexts keep their original neighborhood instead of being relocated to the end of the file.
- **Never loses data.** Output reuses the same cell instances with no drops or duplicates; the pass is idempotent.
- Removed the now-duplicate `extractChapterNumberFromMilestoneValue` from `migrationUtils.ts`; both call sites (migration + resolver) now pass `importerType`.
- Added a regression test mirroring the existing suite, using milestone cells plus book-only/empty-ref text cells and the double-milestone / range-milestone / multi-book structures found in real projects.

## Testing Checklist

### Correctness — the bug
- [ ] A notebook whose text cells have book-only `globalReferences` (`["JOB"]`) keeps its interleaved milestone/content order through a merge (sections are no longer emptied).
- [ ] The real-world repro file (`JOB-SNG`, biblica) is a no-op when run through the helper/resolver.
- [ ] Running a merge twice on the same file is byte-stable (idempotent).

### Importer coverage
- [ ] usfm / usfm-experimental files (including the double `"1"` + `"Luke 1"` milestone shape) are not reordered when already in order.
- [ ] biblica / ebible / macula / obs / paratext scripture files reorder only genuinely out-of-order verses.
- [ ] docx / markdown / subtitles / tms notebooks are never reordered, even when cells carry verse-like citations.

### Structural edge cases
- [ ] Chapter-range milestones (`"Job 4-31"`) keep their chapters' content grouped under them.
- [ ] Multi-book files don't cross-assign content between books with colliding chapter numbers.
- [ ] Trailing empty-duplicate-verse blocks stay at the end, not interleaved with populated verses.
- [ ] Section headings / markers / style / orphan paratext cells keep their position.

### Non-regression
- [ ] No cell is dropped or duplicated by a merge (cell count and instances preserved).
- [ ] Verse-range cell `cellLabel`/`chapterNumber` autofill still applies, and user-edited labels are not overwritten.
- [ ] Existing reorder/merge/migration test suites pass; webview build and NewSourceUploader tests pass.