### PR TITLE
1076 feature audio track selector for video player

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
@@ -447,6 +447,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                                 size="sm"
                                 className="gap-1.5 bg-black/60 text-white hover:bg-black/80 backdrop-blur-sm"
                                 title="Audio language"
+                                data-testid="audio-language-selector"
                             >
                                 <Languages className="size-4" />
                                 {audioLanguageLabel}

--- a/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
@@ -1,8 +1,25 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import ReactPlayer from "react-player";
+import { Languages } from "lucide-react";
 import { useSubtitleData } from "./utils/vttUtils";
 import { QuillCellContent } from "../../../../types";
 import type { ReactPlayerRef } from "./types/reactPlayerTypes";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuTrigger,
+} from "../components/ui/dropdown-menu";
+import { Button } from "../components/ui/button";
+
+/** A selectable audio (dub) track exposed by an HLS stream. */
+interface AudioTrackOption {
+    id: string;
+    label: string;
+    language: string;
+}
 
 interface VideoPlayerProps {
     playerRef: React.RefObject<ReactPlayerRef>;
@@ -40,8 +57,18 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     const [volume, setVolume] = useState(1);
     const lastVideoElementForVolumeRef = useRef<HTMLVideoElement | null>(null);
 
+    // Alternate audio (dub) tracks carried by an HLS stream, plus which one is active.
+    // These belong to the source video itself and are independent of the per-cell
+    // recorded audio attachments (those play via separate <audio> elements and only
+    // mute this <video>, so switching the source language here never touches them).
+    const [audioTracks, setAudioTracks] = useState<AudioTrackOption[]>([]);
+    const [activeAudioTrackId, setActiveAudioTrackId] = useState<string | null>(null);
+
     // Check if the URL is a YouTube URL
     const isYouTubeUrl = videoUrl?.includes("youtube.com") || videoUrl?.includes("youtu.be");
+
+    // HLS streams (.m3u8) are the only sources that expose alternate audio tracks.
+    const isHlsUrl = /\.m3u8(\?|#|$)/i.test(videoUrl || "");
 
     const handleError = (error: any) => {
         console.error("Video player error:", error);
@@ -169,6 +196,105 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         return null;
     }, [playerRef]);
 
+    // For HLS, react-player renders an <hls-video> custom element whose ref carries a
+    // standard AudioTrackList (populated by hls.js as the manifest parses). That element
+    // is what we read alternate audio tracks from and toggle to switch languages — not the
+    // inner <video>, which only sees the single track hls.js is currently feeding it.
+    const getAudioTrackHost = useCallback((): (HTMLElement & { audioTracks?: any }) | null => {
+        const node = playerRef.current as any;
+        if (!node) return null;
+        if (node.audioTracks && typeof node.audioTracks.addEventListener === "function") {
+            return node;
+        }
+        // Fallback in case the ref points at a wrapper rather than the custom element.
+        const host =
+            node.querySelector?.("hls-video") || node.parentElement?.querySelector?.("hls-video");
+        if (host?.audioTracks && typeof host.audioTracks.addEventListener === "function") {
+            return host;
+        }
+        return null;
+    }, [playerRef]);
+
+    // Subscribe to the stream's audio tracks. The custom element and the manifest both
+    // resolve asynchronously, so poll briefly until the AudioTrackList is reachable, then
+    // let its addtrack/removetrack/change events keep our state in sync.
+    useEffect(() => {
+        if (!isHlsUrl) {
+            setAudioTracks([]);
+            setActiveAudioTrackId(null);
+            return;
+        }
+
+        let trackList: (EventTarget & { length: number }) | null = null;
+        let pollId: ReturnType<typeof setInterval> | null = null;
+        let stopId: ReturnType<typeof setTimeout> | null = null;
+
+        const syncFromList = () => {
+            if (!trackList) return;
+            const next: AudioTrackOption[] = [];
+            let active: string | null = null;
+            for (const t of Array.from(trackList as any) as any[]) {
+                const id = String(t.id);
+                next.push({ id, label: t.label || t.language || id, language: t.language || "" });
+                if (t.enabled) active = id;
+            }
+            setAudioTracks(next);
+            setActiveAudioTrackId(active);
+        };
+
+        const detach = () => {
+            if (!trackList) return;
+            trackList.removeEventListener("addtrack", syncFromList);
+            trackList.removeEventListener("removetrack", syncFromList);
+            trackList.removeEventListener("change", syncFromList);
+            trackList = null;
+        };
+
+        const tryAttach = (): boolean => {
+            const list = getAudioTrackHost()?.audioTracks;
+            if (!list) return false;
+            trackList = list;
+            list.addEventListener("addtrack", syncFromList);
+            list.addEventListener("removetrack", syncFromList);
+            list.addEventListener("change", syncFromList);
+            syncFromList();
+            return true;
+        };
+
+        if (!tryAttach()) {
+            pollId = setInterval(() => {
+                if (tryAttach() && pollId) {
+                    clearInterval(pollId);
+                    pollId = null;
+                }
+            }, 200);
+            // Give up polling after a while; a stream with no audio tracks is fine.
+            stopId = setTimeout(() => {
+                if (pollId) clearInterval(pollId);
+            }, 10000);
+        }
+
+        return () => {
+            if (pollId) clearInterval(pollId);
+            if (stopId) clearTimeout(stopId);
+            detach();
+        };
+    }, [isHlsUrl, videoUrl, getAudioTrackHost]);
+
+    // Enable exactly the chosen track; the <hls-video> element relays this to hls.js.
+    const handleSelectAudioTrack = useCallback(
+        (id: string) => {
+            const list = getAudioTrackHost()?.audioTracks;
+            if (!list) return;
+            for (const t of Array.from(list) as any[]) {
+                const shouldEnable = String(t.id) === id;
+                if (t.enabled !== shouldEnable) t.enabled = shouldEnable;
+            }
+            setActiveAudioTrackId(id);
+        },
+        [getAudioTrackHost]
+    );
+
     // Own volume and re-apply on every render so it sticks despite something resetting the element.
     // Sync from native control via volumechange so user adjustments are kept in state.
     useEffect(() => {
@@ -267,6 +393,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         }
     }, [videoUrl]);
 
+    const audioLanguageLabel =
+        audioTracks.find((track) => track.id === activeAudioTrackId)?.label ?? "Audio";
+
     return (
         <div style={{ position: "relative" }}>
             <div
@@ -309,6 +438,39 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                     />
                 )}
             </div>
+            {videoUrl && !error && audioTracks.length > 1 && (
+                <div style={{ position: "absolute", top: 8, right: 8, zIndex: 2 }}>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                className="gap-1.5 bg-black/60 text-white hover:bg-black/80 backdrop-blur-sm"
+                                title="Audio language"
+                            >
+                                <Languages className="size-4" />
+                                {audioLanguageLabel}
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                            align="end"
+                            className="max-h-72 overflow-y-auto"
+                        >
+                            <DropdownMenuLabel>Audio language</DropdownMenuLabel>
+                            <DropdownMenuRadioGroup
+                                value={activeAudioTrackId ?? ""}
+                                onValueChange={handleSelectAudioTrack}
+                            >
+                                {audioTracks.map((track) => (
+                                    <DropdownMenuRadioItem key={track.id} value={track.id}>
+                                        {track.label}
+                                    </DropdownMenuRadioItem>
+                                ))}
+                            </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            )}
         </div>
     );
 };

--- a/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/VideoPlayer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import ReactPlayer from "react-player";
 import { Languages } from "lucide-react";
 import { useSubtitleData } from "./utils/vttUtils";
+import { resolveVideoElement } from "./utils/videoElement";
 import { QuillCellContent } from "../../../../types";
 import type { ReactPlayerRef } from "./types/reactPlayerTypes";
 import {
@@ -55,6 +56,13 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     const [error, setError] = useState<string | null>(null);
     const [playing, setPlaying] = useState(false);
     const [volume, setVolume] = useState(1);
+    // `muted` must be a controlled prop on ReactPlayer. The underlying media element (a
+    // <video>, or for HLS an <hls-video> whose React wrapper re-applies element props on every
+    // render) otherwise gets muted reset to the prop's default (false) on each re-render —
+    // stomping the imperative `videoElement.muted = true` that "Play Video" and the multi-cell
+    // overlay use to silence the video while recorded audio plays. We sync this from the
+    // element's volumechange events (see the volume effect) so imperative mutes stick.
+    const [muted, setMuted] = useState(false);
     const lastVideoElementForVolumeRef = useRef<HTMLVideoElement | null>(null);
 
     // Alternate audio (dub) tracks carried by an HLS stream, plus which one is active.
@@ -159,42 +167,12 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         };
     }
 
-    // Helper function to get the actual video element from ReactPlayer ref
-    const getVideoElement = useCallback((): HTMLVideoElement | null => {
-        if (!playerRef.current) return null;
-
-        // ReactPlayer v3 may return the video element directly, or we need to get it via getInternalPlayer
-        const internalPlayer = playerRef.current.getInternalPlayer?.();
-        if (internalPlayer instanceof HTMLVideoElement) {
-            return internalPlayer;
-        }
-
-        // If getInternalPlayer returns an object, try to find the video element
-        if (internalPlayer && typeof internalPlayer === "object") {
-            const foundVideo =
-                (internalPlayer as any).querySelector?.("video") ||
-                (internalPlayer as any).video ||
-                internalPlayer;
-            if (foundVideo instanceof HTMLVideoElement) {
-                return foundVideo;
-            }
-        }
-
-        // Check if playerRef.current itself is a video element
-        if (playerRef.current instanceof HTMLVideoElement) {
-            return playerRef.current;
-        }
-
-        // Try to find video element in the DOM near the ref
-        const wrapper = playerRef.current as any;
-        const foundVideo =
-            wrapper.querySelector?.("video") || wrapper.parentElement?.querySelector?.("video");
-        if (foundVideo instanceof HTMLVideoElement) {
-            return foundVideo;
-        }
-
-        return null;
-    }, [playerRef]);
+    // Helper function to get the actual video element from ReactPlayer ref. For HLS this
+    // reaches into the <hls-video> custom element's shadow DOM (see resolveVideoElement).
+    const getVideoElement = useCallback(
+        (): HTMLVideoElement | null => resolveVideoElement(playerRef.current),
+        [playerRef]
+    );
 
     // For HLS, react-player renders an <hls-video> custom element whose ref carries a
     // standard AudioTrackList (populated by hls.js as the manifest parses). That element
@@ -296,7 +274,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     );
 
     // Own volume and re-apply on every render so it sticks despite something resetting the element.
-    // Sync from native control via volumechange so user adjustments are kept in state.
+    // volumechange also fires when `muted` changes, so we mirror both volume and muted into state.
+    // Capturing muted here is what lets imperative mutes (Play Video / multi-cell overlay) survive:
+    // it flows into the controlled `muted` prop below instead of being reset on the next render.
     useEffect(() => {
         const videoElement = getVideoElement();
         if (!videoElement) return;
@@ -305,7 +285,12 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         if (isNewElement) {
             lastVideoElementForVolumeRef.current = videoElement;
             videoElement.volume = volume;
-            const onVolumeChange = () => setVolume(videoElement.volume);
+            // Mirror volume *and* muted (volumechange fires for both) so imperative mutes from
+            // "Play Video" / the multi-cell overlay flow into the controlled `muted` prop and stick.
+            const onVolumeChange = () => {
+                setVolume(videoElement.volume);
+                setMuted(videoElement.muted);
+            };
             videoElement.addEventListener("volumechange", onVolumeChange);
             return () => {
                 videoElement.removeEventListener("volumechange", onVolumeChange);
@@ -315,7 +300,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         videoElement.volume = volume;
     });
 
-    // Add subtitle tracks for local videos (React Player v3 uses standard HTML video elements)
+    // Add subtitle tracks for local videos (React Player v3 uses standard HTML video elements).
+    // subtitleUrl is a fresh blob URL whenever the cell text changes, so this re-runs on every
+    // edit and must make the *new* cue actually display.
     useEffect(() => {
         if (subtitleUrl && showSubtitles && !isYouTubeUrl) {
             // Use a small delay to ensure ReactPlayer has mounted and the ref is available
@@ -332,9 +319,23 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                 track.kind = "subtitles";
                 track.src = subtitleUrl;
                 track.srclang = "en"; // FIXME: make this dynamic
-                track.label = "English"; // FIXME: make this dynamic
+                // Distinct label so this editor-content caption is identifiable in the native
+                // menu, which for HLS streams is otherwise crowded with the stream's own
+                // (often 100+) embedded subtitle renditions. FIXME: localize.
+                track.label = "Your translation";
                 track.default = true;
+
+                // A dynamically inserted <track> starts as mode "disabled", and the `default`
+                // attribute is only honored during the media element's initial track selection —
+                // not for tracks added after load. So without this, the first caption shows but
+                // edits never replace it (the stale cue just lingers). Force the new track to
+                // display, both immediately and once it has loaded (engines differ on timing).
+                const showTrack = () => {
+                    if (track.track) track.track.mode = "showing";
+                };
+                track.addEventListener("load", showTrack, { once: true });
                 videoElement.appendChild(track);
+                showTrack();
             }, 100);
 
             return () => clearTimeout(timeoutId);
@@ -418,6 +419,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                         playing={playing}
                         controls={true}
                         volume={volume}
+                        muted={muted}
                         width="100%"
                         height={playerHeight}
                         onError={handleError}

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.audioTracks.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.audioTracks.test.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// --- Fakes mirroring the AudioTrackList contract that <hls-video> exposes ---
+// Real tracks carry id/label/language/enabled and live on an EventTarget that fires
+// addtrack/removetrack/change; the player reads and toggles exactly that surface.
+interface FakeTrackInit {
+    id: string;
+    label: string;
+    language: string;
+    enabled?: boolean;
+}
+
+class FakeAudioTrack {
+    id: string;
+    label: string;
+    language: string;
+    kind = "alternative";
+    list: FakeAudioTrackList | null = null;
+    private _enabled: boolean;
+
+    constructor(init: FakeTrackInit) {
+        this.id = init.id;
+        this.label = init.label;
+        this.language = init.language;
+        this._enabled = init.enabled ?? false;
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    // Toggling enabled is how a language switch is applied; the real list emits "change".
+    set enabled(value: boolean) {
+        if (this._enabled === value) return;
+        this._enabled = value;
+        this.list?.dispatchEvent(new Event("change"));
+    }
+}
+
+class FakeAudioTrackList extends EventTarget {
+    private tracks: FakeAudioTrack[] = [];
+
+    get length() {
+        return this.tracks.length;
+    }
+
+    [Symbol.iterator]() {
+        return this.tracks[Symbol.iterator]();
+    }
+
+    addTrack(init: FakeTrackInit) {
+        const track = new FakeAudioTrack(init);
+        track.list = this;
+        this.tracks.push(track);
+        this.dispatchEvent(new Event("addtrack"));
+        return track;
+    }
+}
+
+// The element react-player hands back via its ref for an HLS source: a DOM node that
+// carries the AudioTrackList. Recreated per test so state never leaks between cases.
+let mockAudioTracks: FakeAudioTrackList;
+let mockHost: HTMLElement & { audioTracks: FakeAudioTrackList };
+
+// react-player is heavy (it lazy-loads the hls custom element); stub it and forward the
+// ref to our fake host, mirroring how the real player assigns its media element to the ref.
+vi.mock("react-player", () => ({
+    default: React.forwardRef((_props: any, ref: any) => {
+        React.useEffect(() => {
+            if (typeof ref === "function") ref(mockHost);
+            else if (ref) ref.current = mockHost;
+        });
+        return <div data-testid="react-player" />;
+    }),
+}));
+
+// Subtitle generation calls URL.createObjectURL, which jsdom lacks; it is irrelevant here.
+vi.mock("../utils/vttUtils", () => ({
+    useSubtitleData: () => ({ subtitleUrl: "", subtitleData: "" }),
+}));
+
+import VideoPlayer from "../VideoPlayer";
+import type { ReactPlayerRef } from "../types/reactPlayerTypes";
+
+const HLS_URL = "https://cdn.example.com/videos/abc/master.m3u8";
+const MP4_URL = "https://cdn.example.com/videos/abc/video.mp4";
+
+const renderPlayer = (videoUrl: string) => {
+    const playerRef = React.createRef<ReactPlayerRef>();
+    return render(
+        <VideoPlayer
+            playerRef={playerRef as React.RefObject<ReactPlayerRef>}
+            videoUrl={videoUrl}
+            translationUnitsForSection={[]}
+            autoPlay={false}
+            playerHeight={360}
+        />
+    );
+};
+
+describe("VideoPlayer audio language selector", () => {
+    beforeAll(() => {
+        // Radix DropdownMenu touches pointer/scroll APIs that jsdom does not implement.
+        const proto = Element.prototype as any;
+        proto.hasPointerCapture ??= () => false;
+        proto.setPointerCapture ??= () => {};
+        proto.releasePointerCapture ??= () => {};
+        proto.scrollIntoView ??= () => {};
+        // jsdom has no PointerEvent; Radix opens its menu on pointerdown, so provide one.
+        if (typeof (globalThis as any).PointerEvent === "undefined") {
+            class PointerEventPolyfill extends MouseEvent {
+                pointerType: string;
+                constructor(type: string, params: any = {}) {
+                    super(type, params);
+                    this.pointerType = params.pointerType ?? "mouse";
+                }
+            }
+            (globalThis as any).PointerEvent = PointerEventPolyfill;
+        }
+    });
+
+    beforeEach(() => {
+        mockAudioTracks = new FakeAudioTrackList();
+        mockHost = Object.assign(document.createElement("div"), {
+            audioTracks: mockAudioTracks,
+        });
+    });
+
+    it("hides the selector when the HLS stream has only one audio track", async () => {
+        mockAudioTracks.addTrack({ id: "0", label: "English", language: "en", enabled: true });
+        renderPlayer(HLS_URL);
+
+        await screen.findByTestId("react-player");
+        expect(screen.queryByTestId("audio-language-selector")).not.toBeInTheDocument();
+    });
+
+    it("hides the selector for a non-HLS source even when multiple tracks exist", async () => {
+        mockAudioTracks.addTrack({ id: "0", label: "English", language: "en", enabled: true });
+        mockAudioTracks.addTrack({ id: "1", label: "Spanish", language: "es" });
+        renderPlayer(MP4_URL);
+
+        await screen.findByTestId("react-player");
+        expect(screen.queryByTestId("audio-language-selector")).not.toBeInTheDocument();
+    });
+
+    it("shows the selector labeled with the active language for a multi-track HLS stream", async () => {
+        mockAudioTracks.addTrack({ id: "0", label: "English", language: "en", enabled: true });
+        mockAudioTracks.addTrack({ id: "1", label: "Spanish", language: "es" });
+        mockAudioTracks.addTrack({ id: "2", label: "French", language: "fr" });
+        renderPlayer(HLS_URL);
+
+        const trigger = await screen.findByTestId("audio-language-selector");
+        expect(trigger).toHaveTextContent("English");
+    });
+
+    it("reveals the selector once tracks load asynchronously via addtrack events", async () => {
+        renderPlayer(HLS_URL);
+
+        await screen.findByTestId("react-player");
+        expect(screen.queryByTestId("audio-language-selector")).not.toBeInTheDocument();
+
+        // The manifest parses after mount, populating the track list.
+        act(() => {
+            mockAudioTracks.addTrack({ id: "0", label: "English", language: "en", enabled: true });
+            mockAudioTracks.addTrack({ id: "1", label: "Hindi", language: "hi" });
+        });
+
+        expect(await screen.findByTestId("audio-language-selector")).toBeInTheDocument();
+    });
+
+    it("switches the enabled audio track when a different language is selected", async () => {
+        const en = mockAudioTracks.addTrack({
+            id: "0",
+            label: "English",
+            language: "en",
+            enabled: true,
+        });
+        const es = mockAudioTracks.addTrack({ id: "1", label: "Spanish", language: "es" });
+        renderPlayer(HLS_URL);
+
+        const trigger = await screen.findByTestId("audio-language-selector");
+        fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
+
+        const spanishItem = await screen.findByRole("menuitemradio", { name: "Spanish" });
+        fireEvent.click(spanishItem);
+
+        await waitFor(() => {
+            expect(es.enabled).toBe(true);
+            expect(en.enabled).toBe(false);
+        });
+        expect(screen.getByTestId("audio-language-selector")).toHaveTextContent("Spanish");
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.mute.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.mute.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// Capture the props ReactPlayer receives so we can assert the controlled `muted` prop.
+// The mock forwards its ref to a real <video> so VideoPlayer's getVideoElement resolves it
+// and attaches the volumechange listener that mirrors muted into state.
+let lastPlayerProps: Record<string, any> = {};
+vi.mock("react-player", () => ({
+    default: React.forwardRef((props: any, ref: any) => {
+        lastPlayerProps = props;
+        return (
+            <video
+                data-testid="native-video"
+                ref={(node: HTMLVideoElement | null) => {
+                    if (typeof ref === "function") ref(node);
+                    else if (ref) ref.current = node;
+                }}
+            />
+        );
+    }),
+}));
+
+// Avoid URL.createObjectURL (not in jsdom); subtitles are irrelevant to muting.
+vi.mock("../utils/vttUtils", () => ({
+    useSubtitleData: () => ({ subtitleUrl: "", subtitleData: "" }),
+}));
+
+import VideoPlayer from "../VideoPlayer";
+import type { ReactPlayerRef } from "../types/reactPlayerTypes";
+
+const renderPlayer = () => {
+    const playerRef = React.createRef<ReactPlayerRef>();
+    return render(
+        <VideoPlayer
+            playerRef={playerRef as React.RefObject<ReactPlayerRef>}
+            videoUrl="https://example.com/video.mp4"
+            translationUnitsForSection={[]}
+            autoPlay={false}
+            playerHeight={360}
+        />
+    );
+};
+
+describe("VideoPlayer keeps mute as a controlled prop", () => {
+    beforeEach(() => {
+        lastPlayerProps = {};
+    });
+
+    it("starts unmuted", async () => {
+        renderPlayer();
+        await screen.findByTestId("native-video");
+        expect(lastPlayerProps.muted).toBe(false);
+    });
+
+    it("reflects an imperative mute into the controlled muted prop (so it can't be reset on re-render)", async () => {
+        renderPlayer();
+        const video = (await screen.findByTestId("native-video")) as HTMLVideoElement;
+
+        // Simulate what "Play Video" / the multi-cell overlay do: mute the element directly.
+        // Setting .muted fires volumechange, which VideoPlayer listens to.
+        act(() => {
+            video.muted = true;
+            video.dispatchEvent(new Event("volumechange"));
+        });
+
+        await waitFor(() => expect(lastPlayerProps.muted).toBe(true));
+    });
+
+    it("reflects unmuting back into the prop", async () => {
+        renderPlayer();
+        const video = (await screen.findByTestId("native-video")) as HTMLVideoElement;
+
+        act(() => {
+            video.muted = true;
+            video.dispatchEvent(new Event("volumechange"));
+        });
+        await waitFor(() => expect(lastPlayerProps.muted).toBe(true));
+
+        act(() => {
+            video.muted = false;
+            video.dispatchEvent(new Event("volumechange"));
+        });
+        await waitFor(() => expect(lastPlayerProps.muted).toBe(false));
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.subtitles.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/VideoPlayer.subtitles.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { generateVttData } from "../utils/vttUtils";
+import type { QuillCellContent } from "../../../../types";
+
+// react-player is heavy; render a real <video> and forward the ref to it so the component's
+// getVideoElement() resolves a genuine HTMLVideoElement and appends subtitle <track>s to it.
+vi.mock("react-player", () => ({
+    default: React.forwardRef((_props: any, ref: any) => (
+        <video
+            data-testid="native-video"
+            ref={(node: HTMLVideoElement | null) => {
+                if (typeof ref === "function") ref(node);
+                else if (ref) ref.current = node;
+            }}
+        />
+    )),
+}));
+
+import VideoPlayer from "../VideoPlayer";
+import type { ReactPlayerRef } from "../types/reactPlayerTypes";
+
+const makeUnit = (content: string, marker = "MRK 1:1"): QuillCellContent =>
+    ({
+        cellMarkers: [marker],
+        cellContent: content,
+        editHistory: [],
+        timestamps: { startTime: 0, endTime: 2 },
+    } as unknown as QuillCellContent);
+
+describe("generateVttData reflects edited cell content", () => {
+    it("includes the cell text in the generated cue", () => {
+        const vtt = generateVttData([makeUnit("Hello world")], true);
+        expect(vtt).toContain("WEBVTT");
+        expect(vtt).toContain("Hello world");
+    });
+
+    it("produces different output when the text changes (e.g. an appended suffix)", () => {
+        const before = generateVttData(
+            [makeUnit("Յոթ օրը մեկ: Ինչո՞ւ այդքան հաճախ, Սավթա:")],
+            true
+        );
+        const after = generateVttData(
+            [makeUnit("Յոթ օրը մեկ: Ինչո՞ւ այդքան հաճախ, Սավթա:ddd")],
+            true
+        );
+
+        expect(after).not.toEqual(before);
+        expect(after).toContain("Սավթա:ddd");
+        expect(before).not.toContain("Սավթա:ddd");
+    });
+});
+
+describe("VideoPlayer subtitle track refresh", () => {
+    let urlCounter = 0;
+
+    beforeAll(() => {
+        // jsdom implements neither of these; the component mints/uses blob URLs per edit.
+        (URL as any).createObjectURL = vi.fn(() => `blob:mock/${++urlCounter}`);
+        (URL as any).revokeObjectURL = vi.fn();
+    });
+
+    beforeEach(() => {
+        urlCounter = 0;
+    });
+
+    const renderPlayer = (units: QuillCellContent[]) => {
+        const playerRef = React.createRef<ReactPlayerRef>();
+        return render(
+            <VideoPlayer
+                playerRef={playerRef as React.RefObject<ReactPlayerRef>}
+                videoUrl="https://example.com/video.mp4"
+                translationUnitsForSection={units}
+                autoPlay={false}
+                playerHeight={360}
+            />
+        );
+    };
+
+    it("re-applies the subtitle track with a fresh URL when the cell text changes", async () => {
+        const { rerender } = renderPlayer([makeUnit("original text")]);
+
+        const video = screen.getByTestId("native-video");
+        // The effect appends the track after a short mount delay.
+        await waitFor(() => expect(video.querySelector("track")).not.toBeNull());
+
+        const firstSrc = video.querySelector("track")!.getAttribute("src");
+        expect(firstSrc).toBeTruthy();
+
+        // Simulate the user editing the cell: the merged units feed a new VTT blob URL.
+        const playerRef = React.createRef<ReactPlayerRef>();
+        rerender(
+            <VideoPlayer
+                playerRef={playerRef as React.RefObject<ReactPlayerRef>}
+                videoUrl="https://example.com/video.mp4"
+                translationUnitsForSection={[makeUnit("original text edited")]}
+                autoPlay={false}
+                playerHeight={360}
+            />
+        );
+
+        // A single, refreshed track should now point at a different blob URL.
+        await waitFor(() => {
+            const tracks = video.querySelectorAll("track");
+            expect(tracks).toHaveLength(1);
+            expect(tracks[0].getAttribute("src")).not.toEqual(firstSrc);
+        });
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/resolveVideoElement.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/resolveVideoElement.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { resolveVideoElement } from "../utils/videoElement";
+
+describe("resolveVideoElement", () => {
+    it("returns null for a missing player", () => {
+        expect(resolveVideoElement(null)).toBeNull();
+        expect(resolveVideoElement(undefined)).toBeNull();
+    });
+
+    it("returns the element directly when the ref is a <video> (plain file sources)", () => {
+        const video = document.createElement("video");
+        expect(resolveVideoElement(video)).toBe(video);
+    });
+
+    it("resolves the shadow-DOM <video> via nativeEl for a custom element (HLS streams)", () => {
+        // Simulates <hls-video>, whose real <video> lives in shadow DOM and is exposed as nativeEl.
+        const hlsVideo = document.createElement("div");
+        const nativeEl = document.createElement("video");
+        (hlsVideo as any).nativeEl = nativeEl;
+
+        expect(resolveVideoElement(hlsVideo)).toBe(nativeEl);
+    });
+
+    it("falls back to shadowRoot.querySelector when nativeEl is absent", () => {
+        const host = document.createElement("div");
+        const shadow = host.attachShadow({ mode: "open" });
+        const nativeEl = document.createElement("video");
+        shadow.appendChild(nativeEl);
+
+        expect(resolveVideoElement(host)).toBe(nativeEl);
+    });
+
+    it("finds a light-DOM child <video> via querySelector", () => {
+        const wrapper = document.createElement("div");
+        const video = document.createElement("video");
+        wrapper.appendChild(video);
+
+        expect(resolveVideoElement(wrapper)).toBe(video);
+    });
+
+    it("uses getInternalPlayer when it returns a video element", () => {
+        const video = document.createElement("video");
+        const player = { getInternalPlayer: () => video };
+
+        expect(resolveVideoElement(player)).toBe(video);
+    });
+
+    it("returns null when no video can be found anywhere", () => {
+        expect(resolveVideoElement(document.createElement("div"))).toBeNull();
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useMultiCellAudioPlayback.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useMultiCellAudioPlayback.ts
@@ -3,6 +3,7 @@ import { QuillCellContent } from "../../../../../types";
 import { WebviewApi } from "vscode-webview";
 import type { ReactPlayerRef } from "../types/reactPlayerTypes";
 import { globalAudioController, AudioControllerEvent } from "../../lib/audioController";
+import { resolveVideoElement } from "../utils/videoElement";
 import { getCachedAudioDataUrl, setCachedAudioDataUrl } from "../../lib/audioCache";
 import { EditorPostMessages } from "../../../../../types";
 import type { AudioAvailability } from "../utils/audioViewMode";
@@ -48,35 +49,13 @@ export function useMultiCellAudioPlayback({
     const messageHandlerRef = useRef<((event: MessageEvent) => void) | null>(null);
     const isCleaningUpRef = useRef<boolean>(false);
 
-    // Get video element helper
-    const getVideoElement = useCallback((): HTMLVideoElement | null => {
-        if (!playerRef.current) return null;
-
-        const internalPlayer = playerRef.current.getInternalPlayer?.();
-        if (internalPlayer instanceof HTMLVideoElement) {
-            return internalPlayer;
-        }
-
-        if (internalPlayer && typeof internalPlayer === "object") {
-            const foundVideo =
-                (internalPlayer as any).querySelector?.("video") ||
-                (internalPlayer as any).video ||
-                internalPlayer;
-            if (foundVideo instanceof HTMLVideoElement) {
-                return foundVideo;
-            }
-        }
-
-        // Last resort: Try to find video element in the DOM
-        const wrapper = playerRef.current as any;
-        const foundVideo =
-            wrapper.querySelector?.("video") || wrapper.parentElement?.querySelector?.("video");
-        if (foundVideo instanceof HTMLVideoElement) {
-            return foundVideo;
-        }
-
-        return null;
-    }, [playerRef]);
+    // Get video element helper. For HLS this reaches into the <hls-video> custom element's
+    // shadow DOM; otherwise muting the video while recorded audio plays no-ops (see
+    // resolveVideoElement).
+    const getVideoElement = useCallback(
+        (): HTMLVideoElement | null => resolveVideoElement(playerRef.current),
+        [playerRef]
+    );
 
     // Clean up audio elements
     const cleanupAudioElements = useCallback(() => {

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/videoElement.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/videoElement.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolve the underlying HTMLVideoElement from a react-player v3 ref.
+ *
+ * react-player exposes different shapes depending on the source:
+ *  - plain files: the ref *is* the <video> element
+ *  - HLS (.m3u8): the ref is an <hls-video> custom element that keeps the real <video> inside
+ *    its shadow DOM and exposes it via `nativeEl`. querySelector cannot pierce the shadow
+ *    boundary, so the `nativeEl` / `shadowRoot` branches are required — without them every
+ *    feature that needs the media element (mute, volume sync, subtitle <track> injection)
+ *    silently no-ops for HLS streams.
+ *
+ * Shared by VideoPlayer and useMultiCellAudioPlayback so the resolution logic can't drift.
+ */
+export function resolveVideoElement(player: unknown): HTMLVideoElement | null {
+    if (!player) return null;
+    const node = player as any;
+
+    // react-player v2-style escape hatch (harmless if absent in v3).
+    const internalPlayer = node.getInternalPlayer?.();
+    if (internalPlayer instanceof HTMLVideoElement) {
+        return internalPlayer;
+    }
+    if (internalPlayer && typeof internalPlayer === "object") {
+        const found =
+            internalPlayer.querySelector?.("video") || internalPlayer.video || internalPlayer;
+        if (found instanceof HTMLVideoElement) {
+            return found;
+        }
+    }
+
+    // The ref is already the <video> (plain file sources).
+    if (node instanceof HTMLVideoElement) {
+        return node;
+    }
+
+    // Custom media element (e.g. <hls-video>): the <video> lives in shadow DOM behind a slot.
+    if (node.nativeEl instanceof HTMLVideoElement) {
+        return node.nativeEl;
+    }
+
+    const found =
+        node.querySelector?.("video") ||
+        node.shadowRoot?.querySelector?.("video") ||
+        node.parentElement?.querySelector?.("video");
+    if (found instanceof HTMLVideoElement) {
+        return found;
+    }
+
+    return null;
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/vttUtils.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/vttUtils.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { QuillCellContent } from "../../../../../types";
 import { removeHtmlTags, formatTimecode } from "@sharedUtils";
 
@@ -11,6 +11,12 @@ export const useSubtitleData = (translationUnits: QuillCellContent[]) => {
         [subtitleData]
     );
     const subtitleUrl = useMemo(() => URL.createObjectURL(subtitleBlob), [subtitleBlob]);
+
+    // A new object URL is minted on every edit (each keystroke changes the cue text). Revoke
+    // the previous one when it changes and on unmount so editing sessions don't leak blobs.
+    useEffect(() => {
+        return () => URL.revokeObjectURL(subtitleUrl);
+    }, [subtitleUrl]);
 
     return { subtitleUrl, subtitleData };
 };


### PR DESCRIPTION
## Summary
Closes #1076

Adds an audio language selector to the top-right corner of the video if it has multiple audio tracks. If only one track exists, it is not shown.

## Changes
- [x] When a video source exposes more than one audio track (HLS `.m3u8` with multiple dubs), an **Audio language** selector appears on the player.
- [x] The selector lists each available audio track by its language/name from the stream manifest, with the currently active track indicated.
- [x] Selecting a language switches the spoken audio without restarting or breaking playback.
- [x] The selector is **hidden** for sources with a single audio track (e.g. plain MP4s), so nothing changes for existing single-track videos.
- [x] Switching the audio-language track has **no effect on user-recorded per-cell dub audio**; recording and dub playback continue to work as before.
- [x] The control is visually unobtrusive (floats over the player, doesn't overlap the native transport controls) and matches the existing UI style.

## Test Checklist
* [x] Import a multi-dub HLS link and confirm the Audio language selector appears and lists 100+ languages.
* [x] Switch from the default language to another (e.g. English → Spanish) and confirm the spoken audio changes and playback continues smoothly.
* [x] Confirm the active language is shown/checked in the menu and persists while scrubbing/playing.
* [x] Open a single-track video (plain MP4) and confirm the Audio language selector does **not** appear.
* [x] Record or play a per-cell dub on top of the video; confirm it still mutes the video and plays correctly regardless of which audio-language track is selected.
* [x] Toggle captions and audio language independently; confirm they don't interfere with each other.
* [x] Switch audio language, then change cells/sections, and confirm the player and audio tracks stay in sync without errors.