### PR TITLE
1075 patani malay project formatting issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -472,6 +472,11 @@
                 "category": "Codex Maintenance"
             },
             {
+                "command": "codex-editor-extension.repairVerseRangeDuplication",
+                "title": "Codex: Repair Duplicated Verse Cells",
+                "category": "Codex Maintenance"
+            },
+            {
                 "command": "codex-editor-extension.runCommentsMigration",
                 "title": "Codex: Migrate Legacy Comments",
                 "category": "Codex Maintenance"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
     migration_addGlobalReferences,
     migration_verseRangeLabelsAndPositions,
     migration_recoverMissingMergedChildren,
+    migration_repairVerseRangeDuplication,
     migration_cellIdsToUuid,
     migration_recoverTempFilesAndMergeDuplicates,
 } from "./projectManager/utils/migrationUtils";
@@ -1160,6 +1161,25 @@ export async function activate(context: vscode.ExtensionContext) {
                     console.error("Missing merged children recovery failed:", error);
                     await vscode.window.showErrorMessage(
                         `Missing merged children recovery failed: ${msg}`
+                    );
+                }
+            }
+        )
+    );
+
+    // Command: Repair verse-range duplication (one-off recovery for issue #848 — verse-RANGE
+    // cells coexisting with SINGLE-verse cells; idempotent and prompts before writing).
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            "codex-editor-extension.repairVerseRangeDuplication",
+            async () => {
+                try {
+                    await migration_repairVerseRangeDuplication();
+                } catch (error) {
+                    const msg = error instanceof Error ? error.message : String(error);
+                    console.error("Verse-range duplication repair failed:", error);
+                    await vscode.window.showErrorMessage(
+                        `Verse-range duplication repair failed: ${msg}`
                     );
                 }
             }

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -23,6 +23,7 @@ import {
     insertUniqueCellsPreservingRelativePositions,
 } from "./utils/positionPreservationUtils";
 import { reorderVerseRangeCells } from "./utils/verseRangeReorder";
+import { applyVerseDuplicationRepair } from "./utils/verseDuplicationRepair";
 
 const DEBUG_MODE = false;
 function debugLog(...args: any[]): void {
@@ -1282,6 +1283,17 @@ export async function resolveCodexCustomMerge(
             }
         }
     }
+
+    // Collapse verse-range/single duplication (issue #848) so two versifications of the same
+    // verses cannot both survive a merge and accumulate across syncs. Soft-deletes ONLY empty
+    // duplicate cells (never content); overlapping-content conflicts are left untouched. No-op
+    // for known non-Bible importer types. Runs before reorder so the survivors get re-sorted.
+    applyVerseDuplicationRepair(resultCells, {
+        importerType:
+            mergedMetadata?.importerType ??
+            ourMetadata?.importerType ??
+            theirMetadata?.importerType,
+    });
 
     // Re-apply verse-range reordering (and idempotent cellLabel/chapterNumber autofill) so
     // that the migrated cell ordering survives git syncs regardless of which side is "ours".

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -23,7 +23,6 @@ import {
     insertUniqueCellsPreservingRelativePositions,
 } from "./utils/positionPreservationUtils";
 import { reorderVerseRangeCells } from "./utils/verseRangeReorder";
-import { applyVerseDuplicationRepair } from "./utils/verseDuplicationRepair";
 
 const DEBUG_MODE = false;
 function debugLog(...args: any[]): void {
@@ -1283,17 +1282,6 @@ export async function resolveCodexCustomMerge(
             }
         }
     }
-
-    // Collapse verse-range/single duplication (issue #848) so two versifications of the same
-    // verses cannot both survive a merge and accumulate across syncs. Soft-deletes ONLY empty
-    // duplicate cells (never content); overlapping-content conflicts are left untouched. No-op
-    // for known non-Bible importer types. Runs before reorder so the survivors get re-sorted.
-    applyVerseDuplicationRepair(resultCells, {
-        importerType:
-            mergedMetadata?.importerType ??
-            ourMetadata?.importerType ??
-            theirMetadata?.importerType,
-    });
 
     // Re-apply verse-range reordering (and idempotent cellLabel/chapterNumber autofill) so
     // that the migrated cell ordering survives git syncs regardless of which side is "ours".

--- a/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
+++ b/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
@@ -39,6 +39,53 @@ export function verseRepairHasContent(value: unknown): boolean {
     return text.length > 0;
 }
 
+/**
+ * True when a cell carries a non-deleted attachment (recorded audio, etc.) that must not be
+ * silently dropped. Mirrors the app's "has live audio" check (an attachment whose `isDeleted`
+ * flag is not set); treats ANY live attachment as preservable so no recorded media is lost, even
+ * when the underlying file is currently missing locally.
+ */
+function cellHasLiveAttachment(cell: any): boolean {
+    const attachments = cell?.metadata?.attachments;
+    if (!attachments || typeof attachments !== "object") return false;
+    for (const key of Object.keys(attachments)) {
+        const att = attachments[key];
+        if (att && att.isDeleted !== true) return true;
+    }
+    return false;
+}
+
+/** A cell holds data worth preserving when it has real text OR a live attachment (e.g. audio). */
+function cellHasPreservableContent(cell: any): boolean {
+    return verseRepairHasContent(cell?.value) || cellHasLiveAttachment(cell);
+}
+
+/** True when a cell carries live (non-deleted) audio specifically — used to label conflicts. */
+function cellHasLiveAudio(cell: any): boolean {
+    const attachments = cell?.metadata?.attachments;
+    if (!attachments || typeof attachments !== "object") return false;
+    for (const key of Object.keys(attachments)) {
+        const att = attachments[key];
+        if (att && att.type === "audio" && att.isDeleted !== true) return true;
+    }
+    return false;
+}
+
+/** Concise passage label for a conflict cluster, e.g. "MAT 8:14-15". */
+function conflictLabel(cluster: VerseRepairCell[]): string {
+    const book = cluster[0]?.book ?? "";
+    const chapter = cluster[0]?.chapter ?? "";
+    let minV = Infinity;
+    let maxV = -Infinity;
+    for (const c of cluster)
+        for (const v of c.verses) {
+            if (v < minV) minV = v;
+            if (v > maxV) maxV = v;
+        }
+    if (!Number.isFinite(minV)) return `${book} ${chapter}`.trim();
+    return maxV > minV ? `${book} ${chapter}:${minV}-${maxV}` : `${book} ${chapter}:${minV}`;
+}
+
 function verseRepairIsCoveredByKept(
     v: number,
     cluster: VerseRepairCell[],
@@ -117,7 +164,7 @@ function classifyVerseCluster(
 
 export interface VerseDuplicationRepairPlan {
     tombstoneIds: string[];
-    conflicts: Array<{ chapter: number; refs: string[] }>;
+    conflicts: Array<{ chapter: number; refs: string[]; hasAudio: boolean; label: string }>;
 }
 
 /**
@@ -127,7 +174,7 @@ export interface VerseDuplicationRepairPlan {
  */
 export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepairPlan {
     const tombstoneIds: string[] = [];
-    const conflicts: Array<{ chapter: number; refs: string[] }> = [];
+    const conflicts: Array<{ chapter: number; refs: string[]; hasAudio: boolean; label: string }> = [];
     if (!Array.isArray(cells) || cells.length === 0) return { tombstoneIds, conflicts };
 
     // Live text cells with a parseable ref, grouped by BOOK + chapter. Grouping by book is
@@ -161,7 +208,7 @@ export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepair
             chapter: parsed.chapter,
             verses,
             isRange: parsed.kind === "range",
-            content: verseRepairHasContent(cell.value),
+            content: cellHasPreservableContent(cell),
         });
         byBookChapter.set(key, arr);
     }
@@ -210,7 +257,12 @@ export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepair
 
             const result = classifyVerseCluster(cluster, dominantForm);
             if (result.conflict) {
-                conflicts.push({ chapter, refs: cluster.map((c) => c.ref) });
+                conflicts.push({
+                    chapter,
+                    refs: cluster.map((c) => c.ref),
+                    hasAudio: cluster.some((c) => cellHasLiveAudio(c.cell)),
+                    label: conflictLabel(cluster),
+                });
                 continue;
             }
             for (const id of result.tombstone) tombstoneIds.push(id);
@@ -258,7 +310,7 @@ export function applyVerseDuplicationRepair(
         if (!cell) continue;
         const md = cell.metadata || (cell.metadata = {});
         if (md.data?.deleted === true) continue;
-        if (verseRepairHasContent(cell.value)) continue; // never delete content
+        if (cellHasPreservableContent(cell)) continue; // never delete text or audio/attachments
         md.data = md.data || {};
         md.data.deleted = true;
         md.edits = md.edits || [];

--- a/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
+++ b/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
@@ -21,6 +21,8 @@ interface VerseRepairCell {
     cell: any;
     id: string;
     ref: string;
+    book: string;
+    chapter: number;
     verses: number[];
     isRange: boolean;
     content: boolean;
@@ -128,8 +130,10 @@ export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepair
     const conflicts: Array<{ chapter: number; refs: string[] }> = [];
     if (!Array.isArray(cells) || cells.length === 0) return { tombstoneIds, conflicts };
 
-    // Live text cells with a parseable ref, grouped by chapter.
-    const byChapter = new Map<number, VerseRepairCell[]>();
+    // Live text cells with a parseable ref, grouped by BOOK + chapter. Grouping by book is
+    // essential for multi-book notebooks (e.g. a "GEN-DEU" study-bible file): without it, GEN 1:1
+    // and EXO 1:1 share the same chapter:verse and would be wrongly treated as duplicates.
+    const byBookChapter = new Map<string, VerseRepairCell[]>();
     for (const cell of cells) {
         const md = cell?.metadata;
         if (md?.type !== CodexCellTypes.TEXT) continue;
@@ -147,19 +151,24 @@ export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepair
             verses.push(parsed.verse);
         }
         if (verses.length === 0) continue;
-        const arr = byChapter.get(parsed.chapter) || [];
+        const key = `${parsed.book} ${parsed.chapter}`;
+        const arr = byBookChapter.get(key) || [];
         arr.push({
             cell,
             id,
             ref,
+            book: parsed.book,
+            chapter: parsed.chapter,
             verses,
             isRange: parsed.kind === "range",
             content: verseRepairHasContent(cell.value),
         });
-        byChapter.set(parsed.chapter, arr);
+        byBookChapter.set(key, arr);
     }
 
-    for (const [chapter, chCells] of byChapter) {
+    for (const groupCells of byBookChapter.values()) {
+        const chCells = groupCells;
+        const chapter = chCells[0].chapter;
         // Dominant structural form among CONTENT cells in this chapter.
         let rangeCount = 0;
         let singleCount = 0;
@@ -191,6 +200,13 @@ export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepair
                         }
             }
             if (cluster.length < 2) continue; // no duplication
+
+            // Only the verse-RANGE/single duplication pattern (issue #848) is eligible: a cluster
+            // must contain at least one range cell. Pure-single overlaps — e.g. a study bible with
+            // many note cells sharing one verse ref, or any other repeated single ref — are left
+            // entirely untouched (neither tombstoned nor flagged), since they are not the merge
+            // duplication this repair targets and may be legitimate.
+            if (!cluster.some((c) => c.isRange)) continue;
 
             const result = classifyVerseCluster(cluster, dominantForm);
             if (result.conflict) {

--- a/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
+++ b/src/projectManager/utils/merge/utils/verseDuplicationRepair.ts
@@ -1,0 +1,261 @@
+import { CodexCellTypes, EditType } from "../../../../../types/enums";
+import { EditMapUtils } from "../../../../utils/editMapUtils";
+import { parseVerseRef } from "../../../../utils/verseRefUtils";
+import { isBibleTypeImporter } from "../../../../../sharedUtils/importerTypeUtils";
+
+/**
+ * Verse-range duplication repair (issue #848 / Pattani Malay).
+ *
+ * When a book exists in two versifications at once — verse-RANGE cells ("MAT 8:14-15")
+ * coexisting with SINGLE-verse cells ("MAT 8:14", "MAT 8:15") — the codex merge resolver keeps
+ * BOTH (it dedupes by metadata.id, and the two forms carry different ids), so the duplicates
+ * accumulate with translated content stranded across the two forms. This module collapses the
+ * duplication WITHOUT losing content or imposing a versification, and is shared by:
+ *   - the one-off repair migration (migration_repairVerseRangeDuplication), and
+ *   - the codex merge resolver (so duplication self-heals on every git sync and can't recur).
+ *
+ * Pure (no vscode); safe to unit-test standalone.
+ */
+
+interface VerseRepairCell {
+    cell: any;
+    id: string;
+    ref: string;
+    verses: number[];
+    isRange: boolean;
+    content: boolean;
+}
+
+/** True when a cell value carries real text once HTML tags / whitespace are stripped. */
+export function verseRepairHasContent(value: unknown): boolean {
+    if (typeof value !== "string" || value.length === 0) return false;
+    const text = value
+        .replace(/<[^>]*>/g, "")
+        .replace(/&nbsp;/gi, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    return text.length > 0;
+}
+
+function verseRepairIsCoveredByKept(
+    v: number,
+    cluster: VerseRepairCell[],
+    keep: Set<string>
+): boolean {
+    for (const c of cluster) if (keep.has(c.id) && c.verses.includes(v)) return true;
+    return false;
+}
+
+/**
+ * Decide which cells in one coverage cluster to keep vs tombstone.
+ *   - Every cell with content is KEPT.
+ *   - A CONFLICT (two content cells sharing a verse) returns `conflict: true` and tombstones
+ *     nothing — the repair never auto-removes translated text.
+ *   - Empty cells are kept only to cover verses no content cell covers, preferring the chapter's
+ *     dominant structural form; the rest are tombstoned.
+ *   - If the kept set does not cover every cluster verse exactly once, bail out (tombstone none).
+ */
+function classifyVerseCluster(
+    cluster: VerseRepairCell[],
+    dominantForm: "range" | "single"
+): { conflict: boolean; tombstone: string[] } {
+    const content = cluster.filter((c) => c.content);
+
+    const seenVerse = new Set<number>();
+    for (const c of content) {
+        for (const v of c.verses) {
+            if (seenVerse.has(v)) return { conflict: true, tombstone: [] };
+            seenVerse.add(v);
+        }
+    }
+
+    const keep = new Set<string>(content.map((c) => c.id));
+    const coveredByContent = new Set<number>();
+    for (const c of content) for (const v of c.verses) coveredByContent.add(v);
+
+    const allVerses = new Set<number>();
+    for (const c of cluster) for (const v of c.verses) allVerses.add(v);
+    const need = new Set<number>([...allVerses].filter((v) => !coveredByContent.has(v)));
+
+    if (need.size > 0) {
+        const empties = cluster.filter((c) => !c.content);
+        const formRank = (c: VerseRepairCell) =>
+            dominantForm === "single" ? (c.isRange ? 1 : 0) : c.isRange ? 0 : 1;
+        empties.sort((a, b) => formRank(a) - formRank(b) || a.verses.length - b.verses.length);
+        for (const c of empties) {
+            if (keep.has(c.id)) continue;
+            const coversNeeded = c.verses.some((v) => need.has(v));
+            const overlapsKept = c.verses.some(
+                (v) =>
+                    !need.has(v) &&
+                    (coveredByContent.has(v) || verseRepairIsCoveredByKept(v, cluster, keep))
+            );
+            if (coversNeeded && !overlapsKept) {
+                keep.add(c.id);
+                for (const v of c.verses) need.delete(v);
+            }
+            if (need.size === 0) break;
+        }
+    }
+
+    // Sanity: kept cells must cover every cluster verse exactly once, else leave it for review.
+    const cover = new Map<number, number>();
+    for (const c of cluster) {
+        if (!keep.has(c.id)) continue;
+        for (const v of c.verses) cover.set(v, (cover.get(v) || 0) + 1);
+    }
+    for (const v of allVerses) {
+        if ((cover.get(v) || 0) !== 1) return { conflict: false, tombstone: [] };
+    }
+
+    // Defensive: never tombstone a content cell (content is always in `keep` above).
+    const tombstone = cluster.filter((c) => !keep.has(c.id) && !c.content).map((c) => c.id);
+    return { conflict: false, tombstone };
+}
+
+export interface VerseDuplicationRepairPlan {
+    tombstoneIds: string[];
+    conflicts: Array<{ chapter: number; refs: string[] }>;
+}
+
+/**
+ * Build a repair plan for a notebook's cells: which empty duplicate cells to soft-delete and
+ * which overlapping-content conflicts to leave for manual review. Pure + idempotent (only live
+ * cells are considered, so a clean or already-repaired notebook yields an empty plan).
+ */
+export function planVerseDuplicationRepair(cells: any[]): VerseDuplicationRepairPlan {
+    const tombstoneIds: string[] = [];
+    const conflicts: Array<{ chapter: number; refs: string[] }> = [];
+    if (!Array.isArray(cells) || cells.length === 0) return { tombstoneIds, conflicts };
+
+    // Live text cells with a parseable ref, grouped by chapter.
+    const byChapter = new Map<number, VerseRepairCell[]>();
+    for (const cell of cells) {
+        const md = cell?.metadata;
+        if (md?.type !== CodexCellTypes.TEXT) continue;
+        if (md?.data?.deleted === true) continue;
+        const id = md?.id;
+        if (typeof id !== "string" || id.length === 0) continue;
+        const ref = md?.data?.globalReferences?.[0];
+        if (typeof ref !== "string") continue;
+        const parsed = parseVerseRef(ref);
+        if (!parsed) continue;
+        const verses: number[] = [];
+        if (parsed.kind === "range") {
+            for (let v = parsed.verseStart; v <= parsed.verseEnd; v++) verses.push(v);
+        } else {
+            verses.push(parsed.verse);
+        }
+        if (verses.length === 0) continue;
+        const arr = byChapter.get(parsed.chapter) || [];
+        arr.push({
+            cell,
+            id,
+            ref,
+            verses,
+            isRange: parsed.kind === "range",
+            content: verseRepairHasContent(cell.value),
+        });
+        byChapter.set(parsed.chapter, arr);
+    }
+
+    for (const [chapter, chCells] of byChapter) {
+        // Dominant structural form among CONTENT cells in this chapter.
+        let rangeCount = 0;
+        let singleCount = 0;
+        for (const c of chCells) if (c.content) c.isRange ? rangeCount++ : singleCount++;
+        const dominantForm: "range" | "single" = rangeCount > singleCount ? "range" : "single";
+
+        // Connected components by shared verse coverage.
+        const verseMap = new Map<number, VerseRepairCell[]>();
+        for (const c of chCells)
+            for (const v of c.verses) {
+                const arr = verseMap.get(v) || [];
+                arr.push(c);
+                verseMap.set(v, arr);
+            }
+        const seen = new Set<string>();
+        for (const startCell of chCells) {
+            if (seen.has(startCell.id)) continue;
+            const cluster: VerseRepairCell[] = [];
+            const stack = [startCell];
+            seen.add(startCell.id);
+            while (stack.length) {
+                const cur = stack.pop()!;
+                cluster.push(cur);
+                for (const v of cur.verses)
+                    for (const neighbor of verseMap.get(v) || [])
+                        if (!seen.has(neighbor.id)) {
+                            seen.add(neighbor.id);
+                            stack.push(neighbor);
+                        }
+            }
+            if (cluster.length < 2) continue; // no duplication
+
+            const result = classifyVerseCluster(cluster, dominantForm);
+            if (result.conflict) {
+                conflicts.push({ chapter, refs: cluster.map((c) => c.ref) });
+                continue;
+            }
+            for (const id of result.tombstone) tombstoneIds.push(id);
+        }
+    }
+
+    return { tombstoneIds, conflicts };
+}
+
+/**
+ * Plan + apply the repair to a cell array in place. Soft-deletes empty duplicate cells with a
+ * MIGRATION edit (row + history preserved so the deletion wins on later merges). Conflicts are
+ * left untouched. Idempotent. No-op for known non-Bible importer types (mirrors
+ * {@link reorderVerseRangeCells}). Returns how many cells were tombstoned and how many
+ * overlapping-content conflicts were left for manual review.
+ */
+export function applyVerseDuplicationRepair(
+    cells: any[],
+    options?: { importerType?: string | null }
+): { tombstoned: number; conflicts: number } {
+    const importerType = options?.importerType;
+    if (
+        typeof importerType === "string" &&
+        importerType.trim() &&
+        !isBibleTypeImporter(importerType)
+    ) {
+        return { tombstoned: 0, conflicts: 0 };
+    }
+
+    const plan = planVerseDuplicationRepair(cells);
+    if (plan.tombstoneIds.length === 0) {
+        return { tombstoned: 0, conflicts: plan.conflicts.length };
+    }
+
+    const cellById = new Map<string, any>();
+    for (const c of cells) {
+        const id = c?.metadata?.id;
+        if (typeof id === "string") cellById.set(id, c);
+    }
+
+    const timestamp = Date.now();
+    let tombstoned = 0;
+    for (const id of plan.tombstoneIds) {
+        const cell = cellById.get(id);
+        if (!cell) continue;
+        const md = cell.metadata || (cell.metadata = {});
+        if (md.data?.deleted === true) continue;
+        if (verseRepairHasContent(cell.value)) continue; // never delete content
+        md.data = md.data || {};
+        md.data.deleted = true;
+        md.edits = md.edits || [];
+        md.edits.push({
+            editMap: EditMapUtils.dataDeleted(),
+            value: true,
+            timestamp,
+            type: EditType.MIGRATION,
+            author: "system",
+            validatedBy: [],
+        });
+        tombstoned++;
+    }
+
+    return { tombstoned, conflicts: plan.conflicts.length };
+}

--- a/src/projectManager/utils/merge/utils/verseRangeReorder.ts
+++ b/src/projectManager/utils/merge/utils/verseRangeReorder.ts
@@ -36,6 +36,14 @@ export interface VerseRangeReorderOptions {
      * not structural verse cells. Missing/unknown types fall back to the content checks.
      */
     importerType?: string | null;
+    /**
+     * Repair mode (default false). When true, a verse cell with no *adjacent* covering milestone
+     * is still pulled to its chapter's milestone even across intervening milestones — used by the
+     * one-time duplication repair to rescue content singles stranded at the end of the file after
+     * de-duplication. Sync/migration leave this off so the conservative adjacency rule applies and
+     * empty duplicates are never hoisted into live scripture.
+     */
+    repairMode?: boolean;
 }
 
 /** Inclusive chapter range a milestone covers ("John 4" -> 4..4, "Job 4-31" -> 4..31). */
@@ -102,6 +110,7 @@ export function reorderVerseRangeCells(
     if (typeof importerType === "string" && importerType.trim() && !isBibleTypeImporter(importerType)) {
         return { cells, mutated: false, orderChanged: false };
     }
+    const repairMode = options?.repairMode === true;
 
     // First pass: cheap detection so we can no-op on non-scripture notebooks.
     let hasMilestone = false;
@@ -291,6 +300,13 @@ export function reorderVerseRangeCells(
                 chosen = milestones[precedingM];
             } else if (nextM < milestones.length && covers(milestones[nextM], item)) {
                 chosen = milestones[nextM];
+            } else if (repairMode) {
+                // Repair only: no adjacent milestone covers this cell (e.g. a content single left
+                // stranded at the end of the file after de-duplication). Pull it to the first
+                // milestone that covers its chapter, even across intervening milestones.
+                for (const m of milestones) {
+                    if (covers(m, item)) { chosen = m; break; }
+                }
             }
             if (chosen) {
                 chosen.assigned.push(item);

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -18,6 +18,11 @@ import {
 import bibleData from "../../../webviews/codex-webviews/src/assets/bible-books-lookup.json";
 import { resolveCodexCustomMerge, mergeDuplicateCellsUsingResolverLogic } from "./merge/resolvers";
 import { reorderVerseRangeCells } from "./merge/utils/verseRangeReorder";
+import {
+    planVerseDuplicationRepair,
+    applyVerseDuplicationRepair,
+} from "./merge/utils/verseDuplicationRepair";
+import { isBibleTypeImporter } from "../../../sharedUtils/importerTypeUtils";
 import { recoverMergedChildrenForFile } from "./recoveryUtils";
 import { atomicWriteUriText } from "../../utils/notebookSafeSaveUtils";
 import { normalizeNotebookFileText, formatJsonForNotebookFile } from "../../utils/notebookFileFormattingUtils";
@@ -3474,6 +3479,205 @@ export const migration_recoverMissingMergedChildren = async (): Promise<void> =>
         );
     } catch (error) {
         console.error("Error running missing merged children recovery:", error);
+        throw error;
+    }
+};
+
+/**
+ * Apply the verse-duplication repair to a single .codex/.source file (issue #848). Plans + applies
+ * via the shared {@link applyVerseDuplicationRepair} helper — soft-deletes empty duplicate cells
+ * (row + history preserved) and leaves overlapping-content conflicts untouched. Idempotent; a
+ * no-op for known non-Bible importer types.
+ */
+export async function repairVerseRangeDuplicationForFile(
+    fileUri: vscode.Uri,
+    options?: { dryRun?: boolean }
+): Promise<{ changed: boolean; tombstoned: number; conflicts: number }> {
+    const dryRun = options?.dryRun ?? false;
+    try {
+        const fileContent = await vscode.workspace.fs.readFile(fileUri);
+        const serializer = new CodexContentSerializer();
+        const notebookData: any = await serializer.deserializeNotebook(
+            fileContent,
+            new vscode.CancellationTokenSource().token
+        );
+        const cells: any[] = notebookData.cells || [];
+        if (cells.length === 0) return { changed: false, tombstoned: 0, conflicts: 0 };
+
+        const importerType: string | null | undefined = notebookData?.metadata?.importerType;
+        const isNonBibleDoc =
+            typeof importerType === "string" &&
+            importerType.trim().length > 0 &&
+            !isBibleTypeImporter(importerType);
+        if (isNonBibleDoc) return { changed: false, tombstoned: 0, conflicts: 0 };
+
+        if (dryRun) {
+            const plan = planVerseDuplicationRepair(cells);
+            // Also flag files that are already de-duplicated but still have stranded cells.
+            const reordered = reorderVerseRangeCells(cells, { importerType, repairMode: true });
+            return {
+                changed: plan.tombstoneIds.length > 0 || reordered.orderChanged,
+                tombstoned: plan.tombstoneIds.length,
+                conflicts: plan.conflicts.length,
+            };
+        }
+
+        const { tombstoned, conflicts } = applyVerseDuplicationRepair(cells, { importerType });
+
+        // Reposition content cells stranded out of their chapter section (e.g. duplicate singles
+        // parked at the end of the file). repairMode pulls them to their chapter even across
+        // intervening milestones — safe here because the empty duplicates were just soft-deleted.
+        const reordered = reorderVerseRangeCells(cells, { importerType, repairMode: true });
+        const changed = tombstoned > 0 || reordered.orderChanged;
+        if (!changed) return { changed: false, tombstoned, conflicts };
+
+        notebookData.cells = reordered.cells;
+        const updatedContent = await serializer.serializeNotebook(
+            notebookData,
+            new vscode.CancellationTokenSource().token
+        );
+        await vscode.workspace.fs.writeFile(fileUri, updatedContent);
+        return { changed: true, tombstoned, conflicts };
+    } catch (error) {
+        console.error(`Error repairing verse-range duplication for ${fileUri.fsPath}:`, error);
+        return { changed: false, tombstoned: 0, conflicts: 0 };
+    }
+}
+
+/**
+ * One-off recovery for projects damaged by the verse-range duplication bug (issue #848).
+ * Two-pass with a confirmation modal between passes (dry-run scan -> confirm -> apply), mirroring
+ * {@link migration_recoverMissingMergedChildren}. Manual, idempotent, never auto-run. Soft-deletes
+ * only empty duplicates; overlapping-content conflicts are reported for manual resolution.
+ */
+export const migration_repairVerseRangeDuplication = async (): Promise<void> => {
+    try {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) return;
+
+        debug("Running verse-range duplication repair scan...");
+        const workspaceFolder = workspaceFolders[0];
+        const codexFiles = await vscode.workspace.findFiles(
+            new vscode.RelativePattern(workspaceFolder, "**/*.codex")
+        );
+        const sourceFiles = await vscode.workspace.findFiles(
+            new vscode.RelativePattern(workspaceFolder, "**/*.source")
+        );
+        const allFiles = [...codexFiles, ...sourceFiles];
+        if (allFiles.length === 0) return;
+
+        const affected: Array<{ uri: vscode.Uri; tombstoned: number; }> = [];
+        let totalTombstones = 0;
+        let totalConflicts = 0;
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Scanning for duplicated verse cells",
+                cancellable: false,
+            },
+            async (progress) => {
+                for (let i = 0; i < allFiles.length; i++) {
+                    const file = allFiles[i];
+                    progress.report({
+                        message: path.basename(file.fsPath),
+                        increment: 100 / allFiles.length,
+                    });
+                    try {
+                        const report = await repairVerseRangeDuplicationForFile(file, {
+                            dryRun: true,
+                        });
+                        if (report.changed && report.tombstoned > 0) {
+                            affected.push({ uri: file, tombstoned: report.tombstoned });
+                            totalTombstones += report.tombstoned;
+                        }
+                        totalConflicts += report.conflicts;
+                    } catch (error) {
+                        console.error(`Error scanning ${file.fsPath} for verse duplication:`, error);
+                    }
+                }
+            }
+        );
+
+        if (affected.length === 0) {
+            await vscode.window.showInformationMessage(
+                totalConflicts > 0
+                    ? `No auto-repairable duplicated verse cells found. ${totalConflicts} overlapping-content conflict(s) need manual review.`
+                    : "No duplicated verse cells detected."
+            );
+            return;
+        }
+
+        const previewLimit = 10;
+        const previewLines = affected
+            .slice(0, previewLimit)
+            .map((r) => `  • ${path.basename(r.uri.fsPath)} (${r.tombstoned})`)
+            .join("\n");
+        const moreLine =
+            affected.length > previewLimit
+                ? `\n  …and ${affected.length - previewLimit} more file(s)`
+                : "";
+        const conflictLine =
+            totalConflicts > 0
+                ? `\n\n${totalConflicts} overlapping-content conflict(s) will be LEFT untouched for manual review.`
+                : "";
+        const detail = `Empty duplicate cells will be soft-deleted (recoverable). No translated text is removed.\n\nFiles:\n${previewLines}${moreLine}${conflictLine}`;
+
+        const choice = await vscode.window.showWarningMessage(
+            `Found ${totalTombstones} empty duplicate verse cell(s) across ${affected.length} file(s). Apply repair?`,
+            { modal: true, detail },
+            "Apply"
+        );
+        if (choice !== "Apply") return;
+
+        const appliedFilePaths: string[] = [];
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Repairing duplicated verse cells",
+                cancellable: false,
+            },
+            async (progress) => {
+                for (let i = 0; i < affected.length; i++) {
+                    const { uri } = affected[i];
+                    progress.report({
+                        message: path.basename(uri.fsPath),
+                        increment: 100 / affected.length,
+                    });
+                    try {
+                        const report = await repairVerseRangeDuplicationForFile(uri, {
+                            dryRun: false,
+                        });
+                        if (report.changed) appliedFilePaths.push(uri.fsPath);
+                    } catch (error) {
+                        console.error(`Error repairing ${uri.fsPath}:`, error);
+                    }
+                }
+            }
+        );
+
+        if (appliedFilePaths.length > 0) {
+            try {
+                const { GlobalProvider } = await import("../../globalProvider");
+                const provider = GlobalProvider.getInstance().getProvider("codex-cell-editor") as {
+                    refreshWebviewsForFiles?: (
+                        paths: string[],
+                        options?: { isSourceAndCodexFiles?: boolean; }
+                    ) => Promise<void>;
+                };
+                if (provider?.refreshWebviewsForFiles) {
+                    await provider.refreshWebviewsForFiles(appliedFilePaths);
+                }
+            } catch (error) {
+                console.warn("Failed to refresh webviews after verse-duplication repair:", error);
+            }
+        }
+
+        await vscode.window.showInformationMessage(
+            `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
+        );
+    } catch (error) {
+        console.error("Error running verse-range duplication repair:", error);
         throw error;
     }
 };

--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -3492,7 +3492,12 @@ export const migration_recoverMissingMergedChildren = async (): Promise<void> =>
 export async function repairVerseRangeDuplicationForFile(
     fileUri: vscode.Uri,
     options?: { dryRun?: boolean }
-): Promise<{ changed: boolean; tombstoned: number; conflicts: number }> {
+): Promise<{
+    changed: boolean;
+    tombstoned: number;
+    conflicts: number;
+    conflictPassages: Array<{ label: string; hasAudio: boolean }>;
+}> {
     const dryRun = options?.dryRun ?? false;
     try {
         const fileContent = await vscode.workspace.fs.readFile(fileUri);
@@ -3502,14 +3507,14 @@ export async function repairVerseRangeDuplicationForFile(
             new vscode.CancellationTokenSource().token
         );
         const cells: any[] = notebookData.cells || [];
-        if (cells.length === 0) return { changed: false, tombstoned: 0, conflicts: 0 };
+        if (cells.length === 0) return { changed: false, tombstoned: 0, conflicts: 0, conflictPassages: [] };
 
         const importerType: string | null | undefined = notebookData?.metadata?.importerType;
         const isNonBibleDoc =
             typeof importerType === "string" &&
             importerType.trim().length > 0 &&
             !isBibleTypeImporter(importerType);
-        if (isNonBibleDoc) return { changed: false, tombstoned: 0, conflicts: 0 };
+        if (isNonBibleDoc) return { changed: false, tombstoned: 0, conflicts: 0, conflictPassages: [] };
 
         if (dryRun) {
             const plan = planVerseDuplicationRepair(cells);
@@ -3519,6 +3524,7 @@ export async function repairVerseRangeDuplicationForFile(
                 changed: plan.tombstoneIds.length > 0 || reordered.orderChanged,
                 tombstoned: plan.tombstoneIds.length,
                 conflicts: plan.conflicts.length,
+                conflictPassages: plan.conflicts.map((c) => ({ label: c.label, hasAudio: c.hasAudio })),
             };
         }
 
@@ -3529,7 +3535,7 @@ export async function repairVerseRangeDuplicationForFile(
         // intervening milestones — safe here because the empty duplicates were just soft-deleted.
         const reordered = reorderVerseRangeCells(cells, { importerType, repairMode: true });
         const changed = tombstoned > 0 || reordered.orderChanged;
-        if (!changed) return { changed: false, tombstoned, conflicts };
+        if (!changed) return { changed: false, tombstoned, conflicts, conflictPassages: [] };
 
         notebookData.cells = reordered.cells;
         const updatedContent = await serializer.serializeNotebook(
@@ -3537,10 +3543,10 @@ export async function repairVerseRangeDuplicationForFile(
             new vscode.CancellationTokenSource().token
         );
         await vscode.workspace.fs.writeFile(fileUri, updatedContent);
-        return { changed: true, tombstoned, conflicts };
+        return { changed: true, tombstoned, conflicts, conflictPassages: [] };
     } catch (error) {
         console.error(`Error repairing verse-range duplication for ${fileUri.fsPath}:`, error);
-        return { changed: false, tombstoned: 0, conflicts: 0 };
+        return { changed: false, tombstoned: 0, conflicts: 0, conflictPassages: [] };
     }
 }
 
@@ -3567,6 +3573,7 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
         if (allFiles.length === 0) return;
 
         const affected: Array<{ uri: vscode.Uri; tombstoned: number; }> = [];
+        const conflictPassages: Array<{ label: string; hasAudio: boolean }> = [];
         let totalTombstones = 0;
         let totalConflicts = 0;
 
@@ -3592,6 +3599,7 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
                             totalTombstones += report.tombstoned;
                         }
                         totalConflicts += report.conflicts;
+                        conflictPassages.push(...report.conflictPassages);
                     } catch (error) {
                         console.error(`Error scanning ${file.fsPath} for verse duplication:`, error);
                     }
@@ -3599,12 +3607,41 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
             }
         );
 
+        // Non-modal toast listing the specific passages that need manual review (both forms carry
+        // content — e.g. audio recorded into a duplicated cell). Shown after the confirm modal so
+        // it survives past it, and logged in full for reference.
+        const showConflictToast = () => {
+            if (conflictPassages.length === 0) return;
+            const audioCount = conflictPassages.filter((c) => c.hasAudio).length;
+            const LIMIT = 12;
+            const list = conflictPassages
+                .slice(0, LIMIT)
+                .map((c) => (c.hasAudio ? `${c.label} (audio)` : c.label))
+                .join(", ");
+            const more =
+                conflictPassages.length > LIMIT
+                    ? ` …and ${conflictPassages.length - LIMIT} more`
+                    : "";
+            const audioNote =
+                audioCount > 0
+                    ? ` ${audioCount} contain recorded audio — resolve manually so it isn't lost.`
+                    : "";
+            void vscode.window.showWarningMessage(
+                `Verse-duplication repair: ${conflictPassages.length} passage(s) need manual review (both forms have content).${audioNote} ${list}${more}`
+            );
+            console.log(
+                "[verse-duplication repair] conflicts needing manual review:",
+                conflictPassages.map((c) => (c.hasAudio ? `${c.label} (audio)` : c.label)).join(", ")
+            );
+        };
+
         if (affected.length === 0) {
             await vscode.window.showInformationMessage(
-                totalConflicts > 0
-                    ? `No auto-repairable duplicated verse cells found. ${totalConflicts} overlapping-content conflict(s) need manual review.`
+                conflictPassages.length > 0
+                    ? "No auto-repairable duplicated verse cells found."
                     : "No duplicated verse cells detected."
             );
+            showConflictToast();
             return;
         }
 
@@ -3628,6 +3665,9 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
             { modal: true, detail },
             "Apply"
         );
+        // Surface the manual-review passages as a persistent (non-modal) toast the moment the
+        // modal closes — shown whether or not the user applies the repair.
+        showConflictToast();
         if (choice !== "Apply") return;
 
         const appliedFilePaths: string[] = [];
@@ -3673,7 +3713,7 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
             }
         }
 
-        await vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
         );
     } catch (error) {

--- a/src/test/suite/verseDuplicationRepair.test.ts
+++ b/src/test/suite/verseDuplicationRepair.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "assert";
+import { planVerseDuplicationRepair } from "../../projectManager/utils/merge/utils/verseDuplicationRepair";
+import { CodexCellTypes } from "../../../types/enums";
+
+// Builds a live (or soft-deleted) verse text cell with a globalReference.
+function vCell(id: string, globalRef: string, value: string, deleted = false) {
+    return {
+        kind: 2,
+        languageId: "scripture",
+        value,
+        metadata: {
+            id,
+            type: CodexCellTypes.TEXT,
+            data: {
+                globalReferences: [globalRef],
+                ...(deleted ? { deleted: true } : {}),
+            },
+            edits: [],
+        },
+    };
+}
+
+suite("planVerseDuplicationRepair - issue #848 verse-range/single duplication", () => {
+    test("content in the RANGE, empty singles -> tombstone the empty singles", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 8:14-15", "<p>translated</p>"),
+            vCell("s14", "MAT 8:14", ""),
+            vCell("s15", "MAT 8:15", ""),
+        ]);
+        assert.deepStrictEqual(plan.tombstoneIds.sort(), ["s14", "s15"]);
+        assert.strictEqual(plan.conflicts.length, 0);
+    });
+
+    test("content in the SINGLES, empty range -> tombstone the empty range", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 13:1-2", ""),
+            vCell("s1", "MAT 13:1", "<p>a</p>"),
+            vCell("s2", "MAT 13:2", "<p>b</p>"),
+        ]);
+        assert.deepStrictEqual(plan.tombstoneIds, ["r"]);
+        assert.strictEqual(plan.conflicts.length, 0);
+    });
+
+    test("content in BOTH forms (overlap) -> reported as a conflict, nothing tombstoned", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 12:46-47", "<p>both verses</p>"),
+            vCell("s46", "MAT 12:46", "<p>first</p>"),
+            vCell("s47", "MAT 12:47", "<p>second</p>"),
+        ]);
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+        assert.strictEqual(plan.conflicts.length, 1);
+        assert.strictEqual(plan.conflicts[0].chapter, 12);
+    });
+
+    test("both forms empty -> keep the chapter's dominant form (single), drop the empty range", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("c1", "MAT 1:1", "<p>content</p>"), // makes single the dominant form in ch1
+            vCell("r", "MAT 1:5-6", ""),
+            vCell("s5", "MAT 1:5", ""),
+            vCell("s6", "MAT 1:6", ""),
+        ]);
+        assert.deepStrictEqual(plan.tombstoneIds, ["r"]);
+    });
+
+    test("no duplication (distinct verses) -> empty plan", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("a", "MAT 1:1", "<p>a</p>"),
+            vCell("b", "MAT 1:2", "<p>b</p>"),
+        ]);
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+        assert.strictEqual(plan.conflicts.length, 0);
+    });
+
+    test("idempotent: already soft-deleted duplicates are ignored", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 8:14-15", "<p>translated</p>"),
+            vCell("s14", "MAT 8:14", "", true),
+            vCell("s15", "MAT 8:15", "", true),
+        ]);
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+        assert.strictEqual(plan.conflicts.length, 0);
+    });
+
+    test("never tombstones a content cell even across a 3-way mixed cluster", () => {
+        // Range has content; one single empty, one single has its own content. The
+        // empty single is covered by the range, but the content single overlaps the
+        // range -> conflict guard fires, so nothing is tombstoned.
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 5:1-2", "<p>combined</p>"),
+            vCell("s1", "MAT 5:1", ""),
+            vCell("s2", "MAT 5:2", "<p>verse 2</p>"),
+        ]);
+        assert.strictEqual(plan.conflicts.length, 1);
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+    });
+});

--- a/src/test/suite/verseDuplicationRepair.test.ts
+++ b/src/test/suite/verseDuplicationRepair.test.ts
@@ -115,4 +115,48 @@ suite("planVerseDuplicationRepair - issue #848 verse-range/single duplication", 
         assert.strictEqual(plan.tombstoneIds.length, 0);
         assert.strictEqual(plan.conflicts.length, 0);
     });
+
+    test("audio recorded in a duplicate cell is preserved (treated as content, flagged not tombstoned)", () => {
+        const audioCell = {
+            kind: 2,
+            languageId: "scripture",
+            value: "", // empty text, but the translator recorded audio into it
+            metadata: {
+                id: "aud",
+                type: CodexCellTypes.TEXT,
+                data: { globalReferences: ["MAT 8:14"] },
+                attachments: { "audio-1": { url: "x.wav", type: "audio", isDeleted: false } },
+                edits: [],
+            },
+        };
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 8:14-15", "<p>combined translation</p>"),
+            audioCell,
+            vCell("s15", "MAT 8:15", ""),
+        ]);
+        assert.strictEqual(plan.tombstoneIds.includes("aud"), false); // audio cell must never be tombstoned
+        assert.strictEqual(plan.tombstoneIds.length, 0); // conflict defers the whole cluster to manual review
+        assert.strictEqual(plan.conflicts.length, 1); // warned, exactly like text-vs-text
+    });
+
+    test("a deleted audio attachment does NOT protect an otherwise-empty duplicate", () => {
+        const staleAudioCell = {
+            kind: 2,
+            languageId: "scripture",
+            value: "",
+            metadata: {
+                id: "s14",
+                type: CodexCellTypes.TEXT,
+                data: { globalReferences: ["MAT 8:14"] },
+                attachments: { "audio-1": { url: "x.wav", type: "audio", isDeleted: true } },
+                edits: [],
+            },
+        };
+        const plan = planVerseDuplicationRepair([
+            vCell("r", "MAT 8:14-15", "<p>combined</p>"),
+            staleAudioCell,
+            vCell("s15", "MAT 8:15", ""),
+        ]);
+        assert.deepStrictEqual(plan.tombstoneIds.sort(), ["s14", "s15"]); // deleted audio = empty
+    });
 });

--- a/src/test/suite/verseDuplicationRepair.test.ts
+++ b/src/test/suite/verseDuplicationRepair.test.ts
@@ -93,4 +93,26 @@ suite("planVerseDuplicationRepair - issue #848 verse-range/single duplication", 
         assert.strictEqual(plan.conflicts.length, 1);
         assert.strictEqual(plan.tombstoneIds.length, 0);
     });
+
+    test("multi-book file: same chapter:verse in different books are NOT treated as duplicates", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("g", "GEN 1:1", "<p>in the beginning</p>"),
+            vCell("e", "EXO 1:1", "<p>these are the names</p>"),
+            vCell("er", "EXO 1:1-2", "<p>names range</p>"), // range only collides within EXO
+        ]);
+        // GEN 1:1 must not collide with EXO 1:1; the EXO range+single overlap is a conflict (both content).
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+        assert.strictEqual(plan.conflicts.length, 1);
+        assert.strictEqual(plan.conflicts[0].refs.every((r) => r.startsWith("EXO")), true);
+    });
+
+    test("pure-single overlap with no range cell (e.g. study notes) is left untouched", () => {
+        const plan = planVerseDuplicationRepair([
+            vCell("a", "MAT 1:1", "<p>verse</p>"),
+            vCell("b", "MAT 1:1", "<p>study note on the verse</p>"),
+            vCell("c", "MAT 1:1", ""), // empty cell sharing the ref — must NOT be tombstoned
+        ]);
+        assert.strictEqual(plan.tombstoneIds.length, 0);
+        assert.strictEqual(plan.conflicts.length, 0);
+    });
 });

--- a/src/test/suite/verseRangeReorder.test.ts
+++ b/src/test/suite/verseRangeReorder.test.ts
@@ -489,3 +489,26 @@ suite("reorderVerseRangeCells - core behaviors", () => {
         assert.strictEqual(inputSet.size, 0, "Every input cell must appear exactly once");
     });
 });
+
+suite("reorderVerseRangeCells - repairMode rescues stranded cells", () => {
+    const buildStranded = () => [
+        milestoneCell("m14", "Matthew 14"),
+        textCell("v14_5", "five", "MAT 14:5"),
+        milestoneCell("m15", "Matthew 15"),
+        textCell("v15_1", "x", "MAT 15:1"),
+        // A content single parked after the ch15 milestone (the post-dedup damage shape).
+        textCell("v14_6", "six", "MAT 14:6"),
+    ];
+
+    test("conservative mode leaves a cell stranded past a later milestone (sync behavior)", () => {
+        const res = reorderVerseRangeCells(buildStranded(), {});
+        assert.deepStrictEqual(cellIds(res.cells), ["m14", "v14_5", "m15", "v15_1", "v14_6"]);
+        assert.strictEqual(res.orderChanged, false);
+    });
+
+    test("repairMode pulls the stranded cell back into its chapter, in verse order", () => {
+        const res = reorderVerseRangeCells(buildStranded(), { repairMode: true });
+        assert.deepStrictEqual(cellIds(res.cells), ["m14", "v14_5", "v14_6", "m15", "v15_1"]);
+        assert.strictEqual(res.orderChanged, true);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #1075

The Pattani Malay project showed verses merged contrary to source versification, recent translations appearing "missing," and cells stranded out of order. Root cause (traced to #848): a book can end up stored in **two versifications at once** — verse-**range** cells (e.g. `MAT 8:14-15`) coexisting with **single**-verse cells (`MAT 8:14`, `MAT 8:15`). The codex merge resolver dedupes cells by ID, and the two forms have different IDs, so both survive a merge and translated content gets stranded across them (and the empty duplicates pile up at the end of the file).

This PR adds a **manual, opt-in repair command** — **"Codex: Repair Duplicated Verse Cells"** — that collapses this duplication and repositions stranded cells **without losing content and without changing sync behavior**. The merge/sync path is intentionally left unchanged.

## Changes
- **Verses display in separate cells matching source versification** — the repair keeps whichever form actually holds the translation and repositions stranded verse cells into canonical (book, chapter, verse) order under their chapter milestone, via an opt-in `repairMode` reorder that can pull cells back across intervening milestones.
- **No silent data loss; deletions/changes tracked in edit history** — only **empty** duplicate cells are removed, via **soft-delete** with a `MIGRATION` edit entry (row + history preserved, fully recoverable). Content cells are never deleted. Overlapping-content conflicts (both forms translated, e.g. `MAT 12:46-47`) are **left untouched and reported** for manual review.
- **Identify root cause; restore affected passages** — root cause identified (range/single merge-union, #848); the command restores affected passages in already-damaged projects. Validated on Pattani Malay MAT: 35 empty duplicates removed, every translation preserved, chapters 8/13/14/15 re-ordered correctly.
- **Safe across project types** — the repair is **book-aware** (multi-book study bibles don't cross-collide `GEN 1:1` with `EXO 1:1`), **range-restricted** (study-bible note structures / repeated single refs are ignored), and a no-op for non-Bible importer types.

**Not covered by this PR (tracked separately):**
- **Removed headings/paratext reappearing** — needs separate git-history tracing; not included here.
- **Automatic recurrence prevention** — deliberately **not** added to sync. A resolver-level dedup
  was prototyped and then removed so the merge/sync path stays byte-identical to today; recurrence
  is addressed by running the manual command (and existing delete-wins propagation keeps a repaired
  project fixed across peers once synced).
- **"pmsue" cannot update / binary-version check** — a separate client/version issue, out of scope.

## Test Checklist
### Repair correctness
- [x] Running "Codex: Repair Duplicated Verse Cells" on a damaged project collapses each verse to a single cell.
- [x] Stranded verse cells are repositioned into canonical order (Pattani MAT 14 renders 14:5 → 14:6 → 14:7 → 14:8).
- [x] Content in either form (range or singles) is preserved; no translated text is deleted.
- [x] Overlapping-content conflicts are left untouched and reported, not auto-merged.
- [x] Re-running the command is a no-op (idempotent).

### Safety / no sync regression
- [x] A sync/merge produces the same result as before this change (the repair never runs on sync).
- [x] Healthy single-verse projects are untouched by the command.
- [x] Multi-book files (study bibles) do not cross-collide verses from different books.
- [x] Study-bible note structures (many cells sharing one verse ref) are left untouched.
- [x] Non-Bible importer projects (docx/subtitles/spreadsheets) are a no-op.