### PR TITLE
Add a button to mirror timestamp to source

### DIFF
--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -24,6 +24,11 @@ import { mergeAudioFiles } from "../../utils/audioMerger";
 import { getAttachmentDocumentSegmentFromUri } from "../../utils/attachmentFolderUtils";
 import { deleteLocalVideoFiles, isHttpVideoUrl, processVideoUrl, getVideoWorkspaceRelativePath, resolveVideoAvailability, type VideoAvailability } from "./utils/videoUtils";
 import { parsePointerFile, isPointerFile } from "../../utils/lfsHelpers";
+import {
+    enrichSourceCellMapWithTimestamps,
+    getSourceCellTimestamps,
+    type SourceCellMapEntry,
+} from "./utils/sourceCellTimestampsUtils";
 
 // Enable debug logging if needed
 const DEBUG_MODE = false;
@@ -686,13 +691,17 @@ export async function sendMilestoneRefreshToWebview(
         const cells = document.getCellsForMilestone(currentPosition.milestoneIndex, currentPosition.subsectionIndex, cellsPerPage);
         const processedCells = provider.mergeRangesAndProcess(cells, provider.isCorrectionEditorMode, isSourceText);
 
-        const sourceCellMap: { [k: string]: { content: string; versions: string[]; }; } = {};
+        const sourceCellMap: Record<string, SourceCellMapEntry> = {};
         for (const cell of cells) {
             const cellId = cell.cellMarkers?.[0];
             if (cellId && document._sourceCellMap[cellId]) {
                 sourceCellMap[cellId] = document._sourceCellMap[cellId];
             }
         }
+        const enrichedSourceCellMap = await enrichSourceCellMapWithTimestamps(
+            document,
+            sourceCellMap
+        );
 
         const authApi = await provider.getAuthApi();
         const userInfo = await authApi?.getUserInfo();
@@ -707,7 +716,7 @@ export async function sendMilestoneRefreshToWebview(
             currentMilestoneIndex: currentPosition.milestoneIndex,
             currentSubsectionIndex: currentPosition.subsectionIndex,
             isSourceText: isSourceText,
-            sourceCellMap: sourceCellMap,
+            sourceCellMap: enrichedSourceCellMap,
             username: username,
             validationCount: validationCount,
             validationCountAudio: validationCountAudio,
@@ -3296,6 +3305,38 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         }
     },
 
+    requestSourceCellTimestamps: async ({ event, document, webviewPanel, provider }) => {
+        const typedEvent = event as Extract<EditorPostMessages, { command: "requestSourceCellTimestamps"; }>;
+        const cellId = typedEvent.content.cellId;
+
+        try {
+            const timestamps = await getSourceCellTimestamps(document, cellId);
+
+            if (!timestamps) {
+                vscode.window.showWarningMessage(
+                    `Could not find source timestamps for cell ${cellId}.`
+                );
+            }
+
+            provider.postMessageToWebview(webviewPanel, {
+                type: "providerSendsSourceCellTimestamps",
+                content: {
+                    cellId,
+                    timestamps,
+                },
+            });
+        } catch (error) {
+            console.error("Error fetching source cell timestamps:", error);
+            provider.postMessageToWebview(webviewPanel, {
+                type: "providerSendsSourceCellTimestamps",
+                content: {
+                    cellId,
+                    timestamps: undefined,
+                },
+            });
+        }
+    },
+
     saveAudioAttachment: async ({ event, document, webviewPanel, provider }) => {
         const typedEvent = event as Extract<EditorPostMessages, { command: "saveAudioAttachment"; }>;
         const requestId = typedEvent.requestId;
@@ -4574,13 +4615,17 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             );
 
             // Build source cell map for these cells
-            const sourceCellMap: { [k: string]: { content: string; versions: string[]; }; } = {};
+            const sourceCellMap: Record<string, SourceCellMapEntry> = {};
             for (const cell of cells) {
                 const cellId = cell.cellMarkers?.[0];
                 if (cellId && document._sourceCellMap[cellId]) {
                     sourceCellMap[cellId] = document._sourceCellMap[cellId];
                 }
             }
+            const enrichedSourceCellMap = await enrichSourceCellMapWithTimestamps(
+                document,
+                sourceCellMap
+            );
 
             // Store the current milestone/subsection for this document to preserve position during updates
             provider.currentMilestoneSubsectionMap.set(document.uri.toString(), {
@@ -4596,7 +4641,7 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 subsectionIndex,
                 cells: processedCells,
                 allCellsInMilestone: processedAllCellsInMilestone,
-                sourceCellMap,
+                sourceCellMap: enrichedSourceCellMap,
             });
 
             debug(`Sent cells for milestone ${milestoneIndex}, subsection ${subsectionIndex}: ${processedCells.length} cells`);

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -50,6 +50,10 @@ import {
 } from "../../utils/fileTypeUtils";
 import { getCorrespondingSourceUri } from "../../utils/codexNotebookUtils";
 import { convertCellToQuillContent } from "./utils/cellUtils";
+import {
+    enrichSourceCellMapWithTimestamps,
+    type SourceCellMapEntry,
+} from "./utils/sourceCellTimestampsUtils";
 
 // Enable debug logging if needed
 const DEBUG_MODE = false;
@@ -977,13 +981,17 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                 const processedInitialCells = this.mergeRangesAndProcess(initialCells, this.isCorrectionEditorMode, isSourceText);
 
                 // Build source cell map for the initial cells only
-                const initialSourceCellMap: { [k: string]: { content: string; versions: string[]; }; } = {};
+                const initialSourceCellMap: Record<string, SourceCellMapEntry> = {};
                 for (const cell of initialCells) {
                     const cellId = cell.cellMarkers?.[0];
                     if (cellId && document._sourceCellMap[cellId]) {
                         initialSourceCellMap[cellId] = document._sourceCellMap[cellId];
                     }
                 }
+                const enrichedInitialSourceCellMap = await enrichSourceCellMapWithTimestamps(
+                    document,
+                    initialSourceCellMap
+                );
 
                 // Fetch user role/access level if authenticated
                 let userAccessLevel: number | undefined = undefined;
@@ -1135,7 +1143,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                     currentMilestoneIndex: initialMilestoneIndex,
                     currentSubsectionIndex: initialSubsectionIndex,
                     isSourceText: isSourceText,
-                    sourceCellMap: initialSourceCellMap,
+                    sourceCellMap: enrichedInitialSourceCellMap,
                     username: username,
                     validationCount: validationCount,
                     validationCountAudio: validationCountAudio,
@@ -2823,13 +2831,17 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         const processedInitialCells = this.mergeRangesAndProcess(initialCells, this.isCorrectionEditorMode, isSourceText);
 
         // Build source cell map for the initial cells only
-        const initialSourceCellMap: { [k: string]: { content: string; versions: string[]; }; } = {};
+        const initialSourceCellMap: Record<string, SourceCellMapEntry> = {};
         for (const cell of initialCells) {
             const cellId = cell.cellMarkers?.[0];
             if (cellId && document._sourceCellMap[cellId]) {
                 initialSourceCellMap[cellId] = document._sourceCellMap[cellId];
             }
         }
+        const enrichedInitialSourceCellMap = await enrichSourceCellMapWithTimestamps(
+            document,
+            initialSourceCellMap
+        );
 
         // Schedule updates to wait for webview ready signal
         this.scheduleWebviewUpdate(document.uri.toString(), () => {
@@ -2841,7 +2853,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                 currentMilestoneIndex: initialMilestoneIndex,
                 currentSubsectionIndex: initialSubsectionIndex,
                 isSourceText: isSourceText,
-                sourceCellMap: initialSourceCellMap,
+                sourceCellMap: enrichedInitialSourceCellMap,
                 username: username,
                 validationCount: validationCount,
                 validationCountAudio: validationCountAudio,

--- a/src/providers/codexCellEditorProvider/utils/sourceCellTimestampsUtils.ts
+++ b/src/providers/codexCellEditorProvider/utils/sourceCellTimestampsUtils.ts
@@ -1,0 +1,122 @@
+import * as vscode from "vscode";
+import path from "path";
+import type { Timestamps } from "../../../../types";
+import type { CodexCellDocument } from "../codexDocument";
+import { getCorrespondingSourceUri } from "../../../utils/codexNotebookUtils";
+
+export type SourceCellMapEntry = {
+    content: string;
+    versions: string[];
+    timestamps?: Timestamps;
+};
+
+export function resolveSourceUriForTargetDocument(
+    targetDocument: CodexCellDocument
+): vscode.Uri | null {
+    if (targetDocument.uri.fsPath.toLowerCase().endsWith(".source")) {
+        return targetDocument.uri;
+    }
+
+    const fromPair = getCorrespondingSourceUri(targetDocument.uri);
+    if (fromPair) {
+        return fromPair;
+    }
+
+    const metadata = targetDocument.getNotebookMetadata();
+    if (metadata?.sourceFsPath) {
+        return metadata.sourceFsPath.startsWith("file:")
+            ? vscode.Uri.parse(metadata.sourceFsPath)
+            : vscode.Uri.file(metadata.sourceFsPath);
+    }
+
+    return null;
+}
+
+export async function getSourceTimestampsForCellIds(
+    targetDocument: CodexCellDocument,
+    cellIds: string[]
+): Promise<Record<string, Timestamps>> {
+    if (cellIds.length === 0) {
+        return {};
+    }
+
+    const sourceUri = resolveSourceUriForTargetDocument(targetDocument);
+    if (!sourceUri) {
+        return {};
+    }
+
+    try {
+        const bytes = await vscode.workspace.fs.readFile(sourceUri);
+        const notebook = JSON.parse(new TextDecoder().decode(bytes)) as {
+            cells?: Array<{ metadata?: { id?: string; data?: Timestamps; }; }>;
+        };
+
+        const cellIdSet = new Set(cellIds);
+        const result: Record<string, Timestamps> = {};
+
+        for (const cell of notebook.cells ?? []) {
+            const id = cell.metadata?.id;
+            if (!id || !cellIdSet.has(id)) {
+                continue;
+            }
+
+            const data = cell.metadata?.data;
+            if (
+                !data ||
+                typeof data.startTime !== "number" ||
+                typeof data.endTime !== "number"
+            ) {
+                continue;
+            }
+
+            result[id] = {
+                startTime: data.startTime,
+                endTime: data.endTime,
+            };
+        }
+
+        return result;
+    } catch (error) {
+        console.warn(
+            `Failed to read source timestamps from ${sourceUri.fsPath}:`,
+            error
+        );
+        return {};
+    }
+}
+
+export async function enrichSourceCellMapWithTimestamps(
+    targetDocument: CodexCellDocument,
+    sourceCellMap: Record<string, SourceCellMapEntry>
+): Promise<Record<string, SourceCellMapEntry>> {
+    const cellIds = Object.keys(sourceCellMap);
+    if (cellIds.length === 0) {
+        return sourceCellMap;
+    }
+
+    const timestampsByCellId = await getSourceTimestampsForCellIds(
+        targetDocument,
+        cellIds
+    );
+
+    const enriched: Record<string, SourceCellMapEntry> = {};
+    for (const [cellId, entry] of Object.entries(sourceCellMap)) {
+        enriched[cellId] = {
+            ...entry,
+            timestamps: timestampsByCellId[cellId],
+        };
+    }
+
+    return enriched;
+}
+
+export async function getSourceCellTimestamps(
+    targetDocument: CodexCellDocument,
+    cellId: string
+): Promise<Timestamps | undefined> {
+    const timestampsByCellId = await getSourceTimestampsForCellIds(
+        targetDocument,
+        [cellId]
+    );
+    return timestampsByCellId[cellId];
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -373,6 +373,14 @@ type SourceCellVersions = {
     notebookId: string;
 };
 
+type SourceCellMapEntry = {
+    content: string;
+    versions: string[];
+    timestamps?: Timestamps;
+};
+
+type SourceCellMap = { [k: string]: SourceCellMapEntry };
+
 type EditorCellContent = {
     cellMarkers: string[];
     cellContent: string;
@@ -521,6 +529,7 @@ export type EditorPostMessages =
     // removed: requestAudioAttachments
     | { command: "requestAudioForCell"; content: { cellId: string; audioId?: string; }; }
     | { command: "requestCellAudioTimestamps"; content: { cellId: string; }; }
+    | { command: "requestSourceCellTimestamps"; content: { cellId: string; }; }
     | { command: "getCommentsForCell"; content: { cellId: string; }; }
     | { command: "getCommentsForCells"; content: { cellIds: string[]; }; }
     | {
@@ -1977,7 +1986,7 @@ type EditorReceiveMessages =
         type: "providerSendsInitialContent";
         content: QuillCellContent[];
         isSourceText: boolean;
-        sourceCellMap: { [k: string]: { content: string; versions: string[]; }; };
+        sourceCellMap: SourceCellMap;
         username?: string;
         validationCount?: number;
         validationCountAudio?: number;
@@ -1996,7 +2005,7 @@ type EditorReceiveMessages =
         currentMilestoneIndex: number;
         currentSubsectionIndex: number;
         isSourceText: boolean;
-        sourceCellMap: { [k: string]: { content: string; versions: string[]; }; };
+        sourceCellMap: SourceCellMap;
         username?: string;
         validationCount?: number;
         validationCountAudio?: number;
@@ -2013,7 +2022,7 @@ type EditorReceiveMessages =
         milestoneIndex: number;
         subsectionIndex: number;
         cells: QuillCellContent[];
-        sourceCellMap: { [k: string]: { content: string; versions: string[]; }; };
+        sourceCellMap: SourceCellMap;
     }
     | {
         type: "providerSendsSubsectionProgress";
@@ -2403,6 +2412,13 @@ type EditorReceiveMessages =
         content: {
             cellId: string;
             audioTimestamps?: Timestamps;
+        };
+    }
+    | {
+        type: "providerSendsSourceCellTimestamps";
+        content: {
+            cellId: string;
+            timestamps?: Timestamps;
         };
     }
     | {

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -500,6 +500,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
     const userRequestedRecorderAtRef = useRef<number>(0);
     const [isAudioLoading, setIsAudioLoading] = useState(false);
     const [isPlayAudioLoading, setIsPlayAudioLoading] = useState(false);
+    const [isMirrorSourceTimeLoading, setIsMirrorSourceTimeLoading] = useState(false);
     const [hasAudioHistory, setHasAudioHistory] = useState<boolean>(false);
     const [audioHistoryCount, setAudioHistoryCount] = useState<number>(0);
     const [audioWarning, setAudioWarning] = useState<string | null>(null);
@@ -1918,6 +1919,80 @@ const CellEditor: React.FC<CellEditorProps> = ({
             }, 2000); // 2 second debounce
         };
     }, []);
+
+    const requestSourceCellTimestamps = useCallback((cellId: string): Promise<Timestamps | null> => {
+        return new Promise((resolve) => {
+            let resolved = false;
+            const timeout = setTimeout(() => {
+                if (!resolved) {
+                    resolved = true;
+                    window.removeEventListener("message", handler);
+                    resolve(null);
+                }
+            }, 5000);
+
+            const handler = (event: MessageEvent) => {
+                const message = event.data;
+
+                if (
+                    message?.type === "providerSendsSourceCellTimestamps" &&
+                    message.content?.cellId === cellId
+                ) {
+                    if (!resolved) {
+                        resolved = true;
+                        clearTimeout(timeout);
+                        window.removeEventListener("message", handler);
+                        resolve(message.content.timestamps || null);
+                    }
+                }
+            };
+
+            window.addEventListener("message", handler);
+            window.vscodeApi.postMessage({
+                command: "requestSourceCellTimestamps",
+                content: { cellId },
+            } as EditorPostMessages);
+        });
+    }, []);
+
+    const handleMirrorSourceTime = useCallback(async () => {
+        setIsMirrorSourceTimeLoading(true);
+        try {
+            const cellId = cellMarkers[0];
+            let sourceTimestamps =
+                sourceCellMap?.[cellId]?.timestamps ??
+                (await requestSourceCellTimestamps(cellId));
+
+            if (
+                !sourceTimestamps ||
+                typeof sourceTimestamps.startTime !== "number" ||
+                typeof sourceTimestamps.endTime !== "number"
+            ) {
+                return;
+            }
+
+            setContentBeingUpdated({
+                ...contentBeingUpdatedRef.current,
+                cellMarkers: contentBeingUpdatedRef.current.cellMarkers ?? cellMarkers,
+                cellTimestamps: {
+                    startTime: sourceTimestamps.startTime,
+                    endTime: sourceTimestamps.endTime,
+                },
+                cellChanged: true,
+            });
+            setUnsavedChanges(true);
+            debouncedInvalidateCombinedAudio();
+        } finally {
+            setIsMirrorSourceTimeLoading(false);
+        }
+    }, [
+        cellMarkers,
+        sourceCellMap,
+        debouncedInvalidateCombinedAudio,
+        requestSourceCellTimestamps,
+        setContentBeingUpdated,
+        setUnsavedChanges,
+    ]);
 
     // Handler to play audio blob with synchronized video playback
     const handlePlayAudioWithVideo = useCallback(async () => {
@@ -5765,6 +5840,25 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     <RotateCcw className="mr-1 h-4 w-4" />
                                                     Revert
                                                 </Button>
+                                                {!isSourceText && (
+                                                    <Button
+                                                        onClick={handleMirrorSourceTime}
+                                                        variant="outline"
+                                                        size="sm"
+                                                        disabled={
+                                                            isCellLocked ||
+                                                            isMirrorSourceTimeLoading
+                                                        }
+                                                        title="Copy timestamps from the matching source cell"
+                                                    >
+                                                        {isMirrorSourceTimeLoading ? (
+                                                            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                                                        ) : (
+                                                            <Copy className="mr-1 h-4 w-4" />
+                                                        )}
+                                                        Mirror Source Time
+                                                    </Button>
+                                                )}
                                             </div>
                                             {isSubtitlesType && shouldShowVideoPlayer && (
                                                 <div className="flex items-center gap-2">

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -1176,9 +1176,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
         if (!micUnavailable) {
             return;
         }
-        const reason = micPermissionDenied
-            ? "Microphone access denied"
-            : "No microphone detected";
+        const reason = micPermissionDenied ? "Microphone access denied" : "No microphone detected";
 
         if (countdown !== null || isStartingRecording) {
             clearRecordingCountdownTimer();
@@ -1921,48 +1919,50 @@ const CellEditor: React.FC<CellEditorProps> = ({
         };
     }, []);
 
-    const requestSourceCellTimestamps = useCallback((cellId: string): Promise<Timestamps | null> => {
-        return new Promise((resolve) => {
-            let resolved = false;
-            const timeout = setTimeout(() => {
-                if (!resolved) {
-                    resolved = true;
-                    window.removeEventListener("message", handler);
-                    resolve(null);
-                }
-            }, 5000);
-
-            const handler = (event: MessageEvent) => {
-                const message = event.data;
-
-                if (
-                    message?.type === "providerSendsSourceCellTimestamps" &&
-                    message.content?.cellId === cellId
-                ) {
+    const requestSourceCellTimestamps = useCallback(
+        (cellId: string): Promise<Timestamps | null> => {
+            return new Promise((resolve) => {
+                let resolved = false;
+                const timeout = setTimeout(() => {
                     if (!resolved) {
                         resolved = true;
-                        clearTimeout(timeout);
                         window.removeEventListener("message", handler);
-                        resolve(message.content.timestamps || null);
+                        resolve(null);
                     }
-                }
-            };
+                }, 5000);
 
-            window.addEventListener("message", handler);
-            window.vscodeApi.postMessage({
-                command: "requestSourceCellTimestamps",
-                content: { cellId },
-            } as EditorPostMessages);
-        });
-    }, []);
+                const handler = (event: MessageEvent) => {
+                    const message = event.data;
+
+                    if (
+                        message?.type === "providerSendsSourceCellTimestamps" &&
+                        message.content?.cellId === cellId
+                    ) {
+                        if (!resolved) {
+                            resolved = true;
+                            clearTimeout(timeout);
+                            window.removeEventListener("message", handler);
+                            resolve(message.content.timestamps || null);
+                        }
+                    }
+                };
+
+                window.addEventListener("message", handler);
+                window.vscodeApi.postMessage({
+                    command: "requestSourceCellTimestamps",
+                    content: { cellId },
+                } as EditorPostMessages);
+            });
+        },
+        []
+    );
 
     const handleMirrorSourceTime = useCallback(async () => {
         setIsMirrorSourceTimeLoading(true);
         try {
             const cellId = cellMarkers[0];
             let sourceTimestamps =
-                sourceCellMap?.[cellId]?.timestamps ??
-                (await requestSourceCellTimestamps(cellId));
+                sourceCellMap?.[cellId]?.timestamps ?? (await requestSourceCellTimestamps(cellId));
 
             if (
                 !sourceTimestamps ||
@@ -2440,8 +2440,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
             // started here — no audio and the video isn't playing (not found, or
             // play() was rejected) — that transition never happens, so clear it
             // now to avoid leaving the overlay suppressed.
-            const videoPlaying =
-                !!videoElementRef.current && !videoElementRef.current.paused;
+            const videoPlaying = !!videoElementRef.current && !videoElementRef.current.paused;
             if (!videoPlaying && !audioElementRef.current) {
                 globalAudioController.setVideoPreviewActive(false);
             }
@@ -3164,9 +3163,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
         // sees the latest value rather than its captured render-time copy.
         if (micUnavailableRef.current) {
             setRecordingStatus(
-                micPermissionDenied
-                    ? "Microphone access denied"
-                    : "No microphone detected"
+                micPermissionDenied ? "Microphone access denied" : "No microphone detected"
             );
             return;
         }
@@ -4073,9 +4070,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                     // so we self-correct if the broadcast really was right.
                     let __localAudioId: string | null = null;
                     try {
-                        __localAudioId = sessionStorage.getItem(
-                            `audio-id-${cellMarkers[0]}`
-                        );
+                        __localAudioId = sessionStorage.getItem(`audio-id-${cellMarkers[0]}`);
                     } catch {
                         /* ignore */
                     }
@@ -4359,9 +4354,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         // until providerSendsAudioData re-hydrates it.
                         let localAudioId: string | null = null;
                         try {
-                            localAudioId = sessionStorage.getItem(
-                                `audio-id-${cellMarkers[0]}`
-                            );
+                            localAudioId = sessionStorage.getItem(`audio-id-${cellMarkers[0]}`);
                         } catch {
                             /* ignore */
                         }
@@ -5017,20 +5010,15 @@ const CellEditor: React.FC<CellEditorProps> = ({
                         <DialogTitle>Recording interrupted</DialogTitle>
                     </DialogHeader>
                     <div className="text-sm text-muted-foreground">
-                        Your microphone became unavailable while recording, so we
-                        stopped early. Do you want to keep what was captured up to
-                        that point, or discard it and try again?
+                        Your microphone became unavailable while recording, so we stopped early. Do
+                        you want to keep what was captured up to that point, or discard it and try
+                        again?
                     </div>
                     <DialogFooter>
-                        <Button
-                            variant="destructive"
-                            onClick={handleDiscardInterruptedRecording}
-                        >
+                        <Button variant="destructive" onClick={handleDiscardInterruptedRecording}>
                             Discard
                         </Button>
-                        <Button onClick={handleKeepInterruptedRecording}>
-                            Keep recording
-                        </Button>
+                        <Button onClick={handleKeepInterruptedRecording}>Keep recording</Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
@@ -5548,7 +5536,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             />
                                                             <div className="flex min-w-max text-xs text-muted-foreground">
                                                                 <span>
-                                                                    End: {formatTimecode(prevEndTime)}
+                                                                    End:{" "}
+                                                                    {formatTimecode(prevEndTime)}
                                                                 </span>
                                                             </div>
                                                         </div>
@@ -5798,27 +5787,29 @@ const CellEditor: React.FC<CellEditorProps> = ({
 
                                         <div className="flex justify-between">
                                             <div className="flex gap-2">
-                                                {isSubtitlesType && shouldShowVideoPlayer && videoUrl && (
-                                                    <Button
-                                                        onClick={handlePlayAudioWithVideo}
-                                                        variant="default"
-                                                        size="sm"
-                                                        disabled={
-                                                            (effectiveTimestamps?.endTime ?? 0) -
-                                                                (effectiveTimestamps?.startTime ??
-                                                                    0) <=
-                                                                0 ||
-                                                            isPlayAudioLoading
-                                                        }
-                                                    >
-                                                        {isPlayAudioLoading ? (
-                                                            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                                                        ) : (
-                                                            <Play className="mr-1 h-4 w-4" />
-                                                        )}
-                                                        Play Video
-                                                    </Button>
-                                                )}
+                                                {isSubtitlesType &&
+                                                    shouldShowVideoPlayer &&
+                                                    videoUrl && (
+                                                        <Button
+                                                            onClick={handlePlayAudioWithVideo}
+                                                            variant="default"
+                                                            size="sm"
+                                                            disabled={
+                                                                (effectiveTimestamps?.endTime ??
+                                                                    0) -
+                                                                    (effectiveTimestamps?.startTime ??
+                                                                        0) <=
+                                                                    0 || isPlayAudioLoading
+                                                            }
+                                                        >
+                                                            {isPlayAudioLoading ? (
+                                                                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                                                            ) : (
+                                                                <Play className="mr-1 h-4 w-4" />
+                                                            )}
+                                                            Play Video
+                                                        </Button>
+                                                    )}
                                                 <Button
                                                     onClick={() => {
                                                         // Clear both cell-range and audio-range
@@ -5950,13 +5941,13 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                     const recordAffordanceLabel = micPermissionDenied
                                         ? "Microphone access denied"
                                         : noMicDetected
-                                          ? "No microphone detected"
-                                          : "Re-record";
+                                        ? "No microphone detected"
+                                        : "Re-record";
                                     const recordAffordanceTitle = isCellLocked
                                         ? "Cannot record: cell is locked"
                                         : micUnavailable
-                                          ? `${recordAffordanceLabel} — you can still upload an audio file`
-                                          : "Re-record / Upload New";
+                                        ? `${recordAffordanceLabel} — you can still upload an audio file`
+                                        : "Re-record / Upload New";
 
                                     const renderUploadHistoryRow = () => (
                                         <div className="flex flex-wrap items-center justify-center gap-2 mt-3 px-2">
@@ -6011,7 +6002,9 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                     "var(--vscode-badge-background)",
                                                                 color: "var(--vscode-badge-foreground)",
                                                             }}
-                                                            aria-label={`${audioHistoryCount} audio recording${audioHistoryCount === 1 ? "" : "s"} in history`}
+                                                            aria-label={`${audioHistoryCount} audio recording${
+                                                                audioHistoryCount === 1 ? "" : "s"
+                                                            } in history`}
                                                         >
                                                             {audioHistoryCount}
                                                         </Badge>
@@ -6098,11 +6091,17 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             ? audioDuration ?? undefined
                                                             : undefined
                                                     }
-                                                    transcriptionLanguageLabel={transcriptionBadgeLabel}
+                                                    transcriptionLanguageLabel={
+                                                        transcriptionBadgeLabel
+                                                    }
                                                     showAdvancedAsrMenu={!isSourceText}
-                                                    asrLanguageMode={asrConfig?.languageMode ?? "project"}
+                                                    asrLanguageMode={
+                                                        asrConfig?.languageMode ?? "project"
+                                                    }
                                                     asrScriptPref={asrConfig?.scriptPref ?? "auto"}
-                                                    projectLanguageName={asrConfig?.projectLanguageName}
+                                                    projectLanguageName={
+                                                        asrConfig?.projectLanguageName
+                                                    }
                                                     onChangeAsrLanguageMode={(mode) => {
                                                         window.vscodeApi.postMessage({
                                                             command: "setAsrLanguageMode",
@@ -6207,25 +6206,25 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                                 </Button>
                                                             ) : (
                                                                 <Button
-                                                                onClick={() => {
-                                                                    setIsAudioLoading(true);
-                                                                    setAudioFetchPending(true);
-                                                                    setAudioDownloading(
-                                                                        cellMarkers[0],
-                                                                        true
-                                                                    );
-                                                                    const messageContent: EditorPostMessages =
-                                                                        {
-                                                                            command:
-                                                                                "requestAudioForCell",
-                                                                            content: {
-                                                                                cellId: cellMarkers[0],
-                                                                            },
-                                                                        };
-                                                                    window.vscodeApi.postMessage(
-                                                                        messageContent
-                                                                    );
-                                                                }}
+                                                                    onClick={() => {
+                                                                        setIsAudioLoading(true);
+                                                                        setAudioFetchPending(true);
+                                                                        setAudioDownloading(
+                                                                            cellMarkers[0],
+                                                                            true
+                                                                        );
+                                                                        const messageContent: EditorPostMessages =
+                                                                            {
+                                                                                command:
+                                                                                    "requestAudioForCell",
+                                                                                content: {
+                                                                                    cellId: cellMarkers[0],
+                                                                                },
+                                                                            };
+                                                                        window.vscodeApi.postMessage(
+                                                                            messageContent
+                                                                        );
+                                                                    }}
                                                                     className="h-9 px-3 text-sm"
                                                                 >
                                                                     <i className="codicon codicon-cloud-download mr-1" />
@@ -6385,9 +6384,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                             // vertical centering. The `!` (important) prefixes are needed
                                                             // because the base Alert variant pins the SVG with
                                                             // `[&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4`.
-                                                            <Alert
-                                                                className="w-fit flex items-center gap-2 border-yellow-500 bg-yellow-50 dark:bg-yellow-950 [&>svg]:!static [&>svg+div]:!translate-y-0 [&>svg~*]:!pl-0"
-                                                            >
+                                                            <Alert className="w-fit flex items-center gap-2 border-yellow-500 bg-yellow-50 dark:bg-yellow-950 [&>svg]:!static [&>svg+div]:!translate-y-0 [&>svg~*]:!pl-0">
                                                                 <AlertCircle className="h-4 w-4 shrink-0 !text-yellow-600 dark:!text-yellow-400" />
                                                                 <AlertDescription className="text-yellow-800 dark:text-yellow-200">
                                                                     {micPermissionDenied

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -5850,7 +5850,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     size="sm"
                                                 >
                                                     <RotateCcw className="mr-1 h-4 w-4" />
-                                                    Revert
+                                                    Undo
                                                 </Button>
                                                 {!isSourceText && (
                                                     <Button

--- a/webviews/codex-webviews/src/CodexCellEditor/contextProviders/SourceCellContext.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/contextProviders/SourceCellContext.tsx
@@ -1,10 +1,9 @@
 import React from "react";
+import type { SourceCellMap } from "../../../../types";
 
 interface SourceCellContextProps {
-    sourceCellMap: { [k: string]: { content: string; versions: string[] } };
-    setSourceCellMap: React.Dispatch<
-        React.SetStateAction<{ [k: string]: { content: string; versions: string[] } }>
-    >;
+    sourceCellMap: SourceCellMap;
+    setSourceCellMap: React.Dispatch<React.SetStateAction<SourceCellMap>>;
 }
 
 const SourceCellContext = React.createContext<SourceCellContextProps>({


### PR DESCRIPTION
Also make the feature to correctly save the change of the timestamp after accepting changes.

## PR Title
Format:
1081-Timestamp-mismatch-fix

## Summary
Closes #1081

Added a button to cell edit for timestamp time, next to the revert button with a name "Mirror Source", by clicking this it will mirror the timestamp time of the source cell with that number.

## Changes
Test on multiple files if the mirror button is working and will set the timestamp value the same as the source cell.
Change the timestamp time, save the cell and then try hitting the mirror button.