### PR TITLE
Add Resolve function to Sparkle process

### DIFF
--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -3594,7 +3594,10 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
                         const report = await repairVerseRangeDuplicationForFile(file, {
                             dryRun: true,
                         });
-                        if (report.changed && report.tombstoned > 0) {
+                        // Include reposition-only files (tombstoned === 0): duplicates may already
+                        // be soft-deleted while their live counterparts are still stranded out of
+                        // their chapter (e.g. after a sync merge reverted an earlier repair).
+                        if (report.changed) {
                             affected.push({ uri: file, tombstoned: report.tombstoned });
                             totalTombstones += report.tombstoned;
                         }
@@ -3648,7 +3651,10 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
         const previewLimit = 10;
         const previewLines = affected
             .slice(0, previewLimit)
-            .map((r) => `  • ${path.basename(r.uri.fsPath)} (${r.tombstoned})`)
+            .map(
+                (r) =>
+                    `  • ${path.basename(r.uri.fsPath)} (${r.tombstoned > 0 ? r.tombstoned : "reposition only"})`
+            )
             .join("\n");
         const moreLine =
             affected.length > previewLimit
@@ -3658,10 +3664,14 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
             totalConflicts > 0
                 ? `\n\n${totalConflicts} overlapping-content conflict(s) will be LEFT untouched for manual review.`
                 : "";
-        const detail = `Empty duplicate cells will be soft-deleted (recoverable). No translated text is removed.\n\nFiles:\n${previewLines}${moreLine}${conflictLine}`;
+        const detail = `Empty duplicate cells will be soft-deleted (recoverable) and stranded verse cells moved back to their chapter. No translated text is removed.\n\nFiles:\n${previewLines}${moreLine}${conflictLine}`;
 
+        const headline =
+            totalTombstones > 0
+                ? `Found ${totalTombstones} empty duplicate verse cell(s) across ${affected.length} file(s). Apply repair?`
+                : `Found ${affected.length} file(s) with verse cells stranded out of their chapter. Apply repair?`;
         const choice = await vscode.window.showWarningMessage(
-            `Found ${totalTombstones} empty duplicate verse cell(s) across ${affected.length} file(s). Apply repair?`,
+            headline,
             { modal: true, detail },
             "Apply"
         );
@@ -3714,7 +3724,9 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
         }
 
         void vscode.window.showInformationMessage(
-            `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
+            totalTombstones > 0
+                ? `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
+                : `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, stranded cells repositioned.`
         );
     } catch (error) {
         console.error("Error running verse-range duplication repair:", error);

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -1743,12 +1743,11 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         const cellId = typedEvent.content.cellId;
 
         try {
-            const sourceCell = (await vscode.commands.executeCommand(
-                "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells",
-                cellId
-            )) as { cellId: string; content: string; } | null;
+            const sourceHtml = await (
+                await import("./utils/htmlStructureResolver")
+            ).getSourceCellContent(cellId);
 
-            if (!sourceCell?.content) {
+            if (!sourceHtml) {
                 vscode.window.showWarningMessage("Could not find source cell content to resolve structure.");
                 return;
             }
@@ -1759,39 +1758,14 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 return;
             }
 
-            const { callLLM, fetchCompletionConfig } = await import("../../utils/llmUtils");
+            const { fetchCompletionConfig } = await import("../../utils/llmUtils");
+            const { resolveHtmlStructureWithLLM } = await import("./utils/htmlStructureResolver");
             const config = await fetchCompletionConfig();
-            const prompt = [
-                {
-                    role: "system" as const,
-                    content:
-                        "You fix structural mismatches between a source text and its translation. " +
-                        "The translation is missing some non-translatable elements that exist in the source. These can be:\n" +
-                        "1. USFM markers in angle brackets: <\\f + \\fr 1:7. \\ft>, <\\xt>, <11:44\\xt*>, <\\f*>\n" +
-                        "2. Line breaks: <br/>, <br>\n" +
-                        "3. Formatting tags: <strong>, </strong>, <em>, </em>, <b>, </b>, <i>, </i>, " +
-                        "<sup>, </sup>, <sub>, </sub>\n" +
-                        "4. Semantic spans: <span data-tag=\"...\"> and </span> (for bold, italic, small-caps, etc.)\n" +
-                        "5. Headings: <h1>–<h4> and their closing tags\n" +
-                        "6. Paragraph tags: <p>, </p>\n" +
-                        "Copy ALL missing elements EXACTLY from the source and place them at the corresponding position in the translation. " +
-                        "Keep ALL translated text unchanged. Do NOT revert any translated words back to the source language. " +
-                        "Return ONLY the corrected translation, no explanation.",
-                },
-                {
-                    role: "user" as const,
-                    content: `Source (with structural elements):\n${sourceCell.content}\n\nTranslation (missing elements):\n${targetCell.cellContent}\n\nReturn the translation with ALL missing structural elements inserted:`,
-                },
-            ];
-
-            const llmResult = await callLLM(prompt, config);
-
-            // Strip markdown code fences that LLMs often wrap around HTML output
-            let resolved = llmResult.content.trim();
-            const fenceMatch = resolved.match(/^```(?:html)?\s*\n?([\s\S]*?)\n?\s*```$/);
-            if (fenceMatch) {
-                resolved = fenceMatch[1].trim();
-            }
+            const resolved = await resolveHtmlStructureWithLLM(
+                sourceHtml,
+                targetCell.cellContent,
+                config,
+            );
 
             // Persist the resolved content to the document so it survives reload
             await document.updateCellContent(cellId, resolved, EditType.LLM_GENERATION);

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -1752,31 +1752,18 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
         const cellId = typedEvent.content.cellId;
 
         try {
-            const sourceHtml = await (
-                await import("./utils/htmlStructureResolver")
-            ).getSourceCellContent(cellId);
+            const { resolveCellHtmlStructure } = await import("./utils/htmlStructureResolver");
+            const resolved = await resolveCellHtmlStructure(cellId, document);
 
-            if (!sourceHtml) {
-                vscode.window.showWarningMessage("Could not find source cell content to resolve structure.");
+            if (!resolved) {
+                vscode.window.showWarningMessage("Could not find source or target cell content to resolve structure.");
+                provider.postMessageToWebview(webviewPanel, {
+                    type: "providerSendsResolvedHtmlStructure",
+                    content: { cellId, resolvedContent: "" },
+                });
                 return;
             }
 
-            const targetCell = document.getCellContent(cellId);
-            if (!targetCell) {
-                vscode.window.showWarningMessage("Could not find target cell.");
-                return;
-            }
-
-            const { fetchCompletionConfig } = await import("../../utils/llmUtils");
-            const { resolveHtmlStructureWithLLM } = await import("./utils/htmlStructureResolver");
-            const config = await fetchCompletionConfig();
-            const resolved = await resolveHtmlStructureWithLLM(
-                sourceHtml,
-                targetCell.cellContent,
-                config,
-            );
-
-            // Persist the resolved content to the document so it survives reload
             await document.updateCellContent(cellId, resolved, EditType.LLM_GENERATION);
             await provider.saveCustomDocument(document, new vscode.CancellationTokenSource().token);
 
@@ -1789,11 +1776,26 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             vscode.window.showErrorMessage(
                 `Failed to resolve HTML structure: ${error instanceof Error ? error.message : String(error)}`
             );
-            // Signal failure so the webview can reset the loading state
             provider.postMessageToWebview(webviewPanel, {
                 type: "providerSendsResolvedHtmlStructure",
                 content: { cellId, resolvedContent: "" },
             });
+        }
+    },
+
+    requestResolveHtmlStructureBatch: async ({ event, document, webviewPanel, provider }) => {
+        const typedEvent = event as Extract<EditorPostMessages, { command: "requestResolveHtmlStructureBatch"; }>;
+        await provider.performResolveHtmlStructureBatch(
+            document,
+            webviewPanel,
+            typedEvent.content.cellIds,
+        );
+    },
+
+    stopResolveHtmlStructureBatch: ({ provider }) => {
+        const cancelled = provider.cancelResolveHtmlStructureBatch();
+        if (cancelled) {
+            vscode.window.showInformationMessage("Structure resolve operation stopped.");
         }
     },
 

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -16,6 +16,7 @@ import {
     MilestoneIndex,
 } from "../../../types";
 import { CodexCellDocument } from "./codexDocument";
+import { maybeAutoResolveHtmlStructure } from "./utils/htmlStructureResolver";
 import {
     handleGlobalMessage,
     handleMessages,
@@ -3903,11 +3904,24 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                             const allIdentical = variants.every((v: string) => normalize(v) === normalize(variants[0]));
                             if (allIdentical) {
                                 const singleCompletion = variants[0] ?? "";
-                                progress.report({ message: "Updating document...", increment: 40 });
+                                progress.report({ message: "Checking HTML structure...", increment: 10 });
+                                const finalContent = await maybeAutoResolveHtmlStructure(
+                                    currentCellId,
+                                    singleCompletion,
+                                    currentDocument,
+                                    {
+                                        config: completionConfig,
+                                        onResolving: () => progress.report({
+                                            message: "Resolving HTML structure...",
+                                            increment: 10,
+                                        }),
+                                    },
+                                );
+                                progress.report({ message: "Updating document...", increment: 20 });
                                 this.updateSingleCellTranslation(0.9);
                                 currentDocument.updateCellContent(
                                     currentCellId,
-                                    singleCompletion,
+                                    finalContent,
                                     EditType.LLM_GENERATION,
                                     shouldUpdateValue,
                                     false,
@@ -3915,8 +3929,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                                     completionResult.generationId
                                 );
                                 this.updateSingleCellTranslation(1.0);
-                                debug("LLM completion result (identical variants)", { completion: singleCompletion?.slice?.(0, 80) });
-                                return singleCompletion;
+                                debug("LLM completion result (identical variants)", { completion: finalContent?.slice?.(0, 80) });
+                                return finalContent;
                             }
                         } catch (e) {
                             debug("Error comparing variants for identity; proceeding with A/B UI", { error: e });
@@ -3961,7 +3975,21 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                     // Otherwise, handle as a single completion using the first variant
                     const singleCompletion = (completionResult as any)?.variants?.[0] ?? "";
 
-                    progress.report({ message: "Updating document...", increment: 40 });
+                    progress.report({ message: "Checking HTML structure...", increment: 10 });
+                    const finalContent = await maybeAutoResolveHtmlStructure(
+                        currentCellId,
+                        singleCompletion,
+                        currentDocument,
+                        {
+                            config: completionConfig,
+                            onResolving: () => progress.report({
+                                message: "Resolving HTML structure...",
+                                increment: 10,
+                            }),
+                        },
+                    );
+
+                    progress.report({ message: "Updating document...", increment: 20 });
 
                     // Update progress in state
                     this.updateSingleCellTranslation(0.9);
@@ -3969,7 +3997,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                     // Update content and metadata atomically - only if not cancelled
                     currentDocument.updateCellContent(
                         currentCellId,
-                        singleCompletion,
+                        finalContent,
                         EditType.LLM_GENERATION,
                         shouldUpdateValue,
                         false,
@@ -3989,8 +4017,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                     // Update progress in state
                     this.updateSingleCellTranslation(1.0);
 
-                    debug("LLM completion result", { completion: singleCompletion?.slice?.(0, 80) });
-                    return singleCompletion;
+                    debug("LLM completion result", { completion: finalContent?.slice?.(0, 80) });
+                    return finalContent;
                 } catch (error: any) {
                     // Check if this is a cancellation error
                     if (error instanceof vscode.CancellationError ||

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -344,6 +344,24 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
             progress: 0,
         };
 
+    public structureResolveState: {
+        isProcessing: boolean;
+        totalCells: number;
+        completedCells: number;
+        currentCellId?: string;
+        cellsToProcess: string[];
+        progress: number;
+    } = {
+            isProcessing: false,
+            totalCells: 0,
+            completedCells: 0,
+            currentCellId: undefined,
+            cellsToProcess: [],
+            progress: 0,
+        };
+
+    private structureResolveCancellation?: vscode.CancellationTokenSource;
+
     // Single cell translation state - using the same robust pattern as autocomplete
     public singleCellQueueState: {
         isProcessing: boolean;
@@ -2438,6 +2456,154 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         }
         debug("No active autocompletion to cancel");
         return false;
+    }
+
+    public async performResolveHtmlStructureBatch(
+        document: CodexCellDocument,
+        webviewPanel: vscode.WebviewPanel,
+        cellIds: string[],
+    ): Promise<void> {
+        if (cellIds.length === 0) {
+            return;
+        }
+
+        if (this.structureResolveCancellation) {
+            this.structureResolveCancellation.dispose();
+        }
+        this.structureResolveCancellation = new vscode.CancellationTokenSource();
+        const token = this.structureResolveCancellation.token;
+
+        const totalCells = cellIds.length;
+        this.structureResolveState = {
+            isProcessing: true,
+            totalCells,
+            completedCells: 0,
+            currentCellId: undefined,
+            cellsToProcess: cellIds,
+            progress: 0.01,
+        };
+        this.broadcastStructureResolveState();
+
+        try {
+            const { fetchCompletionConfig } = await import("../../utils/llmUtils");
+            const { resolveCellHtmlStructure } = await import("./utils/htmlStructureResolver");
+            const config = await fetchCompletionConfig();
+
+            for (let i = 0; i < cellIds.length; i++) {
+                if (token.isCancellationRequested) {
+                    break;
+                }
+
+                const cellId = cellIds[i];
+                this.structureResolveState.currentCellId = cellId;
+                this.structureResolveState.progress = Math.min(0.99, i / totalCells);
+                this.broadcastStructureResolveState();
+
+                try {
+                    const resolved = await resolveCellHtmlStructure(cellId, document, config);
+                    if (!resolved) {
+                        this.postMessageToWebview(webviewPanel, {
+                            type: "providerSendsResolvedHtmlStructure",
+                            content: { cellId, resolvedContent: "" },
+                        });
+                        continue;
+                    }
+
+                    await document.updateCellContent(cellId, resolved, EditType.LLM_GENERATION);
+                    await this.saveCustomDocument(
+                        document,
+                        new vscode.CancellationTokenSource().token,
+                    );
+
+                    this.structureResolveState.completedCells = i + 1;
+                    this.broadcastStructureResolveState();
+
+                    this.postMessageToWebview(webviewPanel, {
+                        type: "providerSendsResolvedHtmlStructure",
+                        content: { cellId, resolvedContent: resolved },
+                    });
+                } catch (error) {
+                    console.error(`[resolveHtmlStructureBatch] Error for ${cellId}:`, error);
+                    this.postMessageToWebview(webviewPanel, {
+                        type: "providerSendsResolvedHtmlStructure",
+                        content: { cellId, resolvedContent: "" },
+                    });
+                }
+            }
+
+            this.structureResolveState.progress = 1.0;
+            this.broadcastStructureResolveState();
+
+            setTimeout(() => {
+                this.structureResolveState = {
+                    isProcessing: false,
+                    totalCells: 0,
+                    completedCells: 0,
+                    currentCellId: undefined,
+                    cellsToProcess: [],
+                    progress: 0,
+                };
+                this.broadcastStructureResolveState();
+
+                if (this.structureResolveCancellation) {
+                    this.structureResolveCancellation.dispose();
+                    this.structureResolveCancellation = undefined;
+                }
+            }, 1500);
+        } catch (error) {
+            console.error("Error in performResolveHtmlStructureBatch:", error);
+            if (this.structureResolveCancellation) {
+                this.structureResolveCancellation.dispose();
+                this.structureResolveCancellation = undefined;
+            }
+            throw error;
+        }
+    }
+
+    public cancelResolveHtmlStructureBatch(): boolean {
+        if (this.structureResolveCancellation) {
+            this.structureResolveCancellation.cancel();
+
+            this.structureResolveState = {
+                isProcessing: false,
+                totalCells: 0,
+                completedCells: 0,
+                currentCellId: undefined,
+                cellsToProcess: [],
+                progress: 0,
+            };
+            this.broadcastStructureResolveState();
+
+            this.structureResolveCancellation.dispose();
+            this.structureResolveCancellation = undefined;
+            return true;
+        }
+        return false;
+    }
+
+    private broadcastStructureResolveState(): void {
+        const {
+            isProcessing,
+            totalCells,
+            completedCells,
+            currentCellId,
+            cellsToProcess,
+            progress,
+        } = this.structureResolveState;
+
+        this.webviewPanels.forEach((panel) => {
+            safePostMessageToPanel(panel, {
+                type: "providerStructureResolveState",
+                state: {
+                    isProcessing,
+                    totalCells,
+                    completedCells,
+                    currentCellId,
+                    cellsToProcess,
+                    progress,
+                },
+            });
+        });
     }
 
     // New method to set single cell translation state

--- a/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
+++ b/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
@@ -1,0 +1,106 @@
+import * as vscode from "vscode";
+import { compareHtmlStructure } from "../../../../sharedUtils/htmlStructureUtils";
+import type { CompletionConfig } from "../../../utils/llmUtils";
+import type { CodexCellDocument } from "../codexDocument";
+
+export const stripMarkdownCodeFences = (content: string): string => {
+    let resolved = content.trim();
+    const fenceMatch = resolved.match(/^```(?:html)?\s*\n?([\s\S]*?)\n?\s*```$/);
+    if (fenceMatch) {
+        resolved = fenceMatch[1].trim();
+    }
+    return resolved;
+};
+
+const buildResolvePrompt = (sourceHtml: string, targetHtml: string) => [
+    {
+        role: "system" as const,
+        content:
+            "You fix structural mismatches between a source text and its translation. " +
+            "The translation is missing some non-translatable elements that exist in the source. These can be:\n" +
+            "1. USFM markers in angle brackets: <\\f + \\fr 1:7. \\ft>, <\\xt>, <11:44\\xt*>, <\\f*>\n" +
+            "2. Line breaks: <br/>, <br>\n" +
+            "3. Formatting tags: <strong>, </strong>, <em>, </em>, <b>, </b>, <i>, </i>, " +
+            "<sup>, </sup>, <sub>, </sub>\n" +
+            "4. Semantic spans: <span data-tag=\"...\"> and </span> (for bold, italic, small-caps, etc.)\n" +
+            "5. Headings: <h1>–<h4> and their closing tags\n" +
+            "6. Paragraph tags: <p>, </p>\n" +
+            "Copy ALL missing elements EXACTLY from the source and place them at the corresponding position in the translation. " +
+            "Keep ALL translated text unchanged. Do NOT revert any translated words back to the source language. " +
+            "Return ONLY the corrected translation, no explanation.",
+    },
+    {
+        role: "user" as const,
+        content:
+            `Source (with structural elements):\n${sourceHtml}\n\n` +
+            `Translation (missing elements):\n${targetHtml}\n\n` +
+            "Return the translation with ALL missing structural elements inserted:",
+    },
+];
+
+export const resolveHtmlStructureWithLLM = async (
+    sourceHtml: string,
+    targetHtml: string,
+    config: CompletionConfig,
+    callLLMOverride?: (
+        prompt: Array<{ role: "system" | "user"; content: string }>,
+        config: CompletionConfig,
+    ) => Promise<{ content: string }>,
+): Promise<string> => {
+    const callLLM = callLLMOverride ?? (await import("../../../utils/llmUtils")).callLLM;
+    const prompt = buildResolvePrompt(sourceHtml, targetHtml);
+    const llmResult = await callLLM(prompt, config);
+    return stripMarkdownCodeFences(llmResult.content);
+};
+
+export const getSourceCellContent = async (cellId: string): Promise<string | null> => {
+    const sourceCell = (await vscode.commands.executeCommand(
+        "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells",
+        cellId,
+    )) as { cellId: string; content: string } | null;
+
+    return sourceCell?.content ?? null;
+};
+
+export type AutoResolveHtmlStructureOptions = {
+    config?: CompletionConfig;
+    onResolving?: () => void;
+    resolveWithLLM?: (
+        sourceHtml: string,
+        targetHtml: string,
+        config: CompletionConfig,
+    ) => Promise<string>;
+};
+
+export const maybeAutoResolveHtmlStructure = async (
+    cellId: string,
+    translatedHtml: string,
+    document: CodexCellDocument,
+    options?: AutoResolveHtmlStructureOptions,
+): Promise<string> => {
+    const metadata = document.getNotebookMetadata();
+    if (!metadata.enforceHtmlStructure) {
+        return translatedHtml;
+    }
+
+    const sourceHtml = await getSourceCellContent(cellId);
+    if (!sourceHtml) {
+        return translatedHtml;
+    }
+
+    const diff = compareHtmlStructure(sourceHtml, translatedHtml);
+    if (diff.isMatch) {
+        return translatedHtml;
+    }
+
+    try {
+        const { fetchCompletionConfig } = await import("../../../utils/llmUtils");
+        const completionConfig = options?.config ?? (await fetchCompletionConfig());
+        options?.onResolving?.();
+        const resolveWithLLM = options?.resolveWithLLM ?? resolveHtmlStructureWithLLM;
+        return await resolveWithLLM(sourceHtml, translatedHtml, completionConfig);
+    } catch (error) {
+        console.error("[maybeAutoResolveHtmlStructure] Error:", error);
+        return translatedHtml;
+    }
+};

--- a/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
+++ b/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
@@ -53,6 +53,26 @@ export const resolveHtmlStructureWithLLM = async (
     return stripMarkdownCodeFences(llmResult.content);
 };
 
+export const resolveCellHtmlStructure = async (
+    cellId: string,
+    document: CodexCellDocument,
+    config?: CompletionConfig,
+): Promise<string | null> => {
+    const sourceHtml = await getSourceCellContent(cellId);
+    if (!sourceHtml) {
+        return null;
+    }
+
+    const targetCell = document.getCellContent(cellId);
+    if (!targetCell) {
+        return null;
+    }
+
+    const { fetchCompletionConfig } = await import("../../../utils/llmUtils");
+    const completionConfig = config ?? (await fetchCompletionConfig());
+    return resolveHtmlStructureWithLLM(sourceHtml, targetCell.cellContent, completionConfig);
+};
+
 export const getSourceCellContent = async (cellId: string): Promise<string | null> => {
     const sourceCell = (await vscode.commands.executeCommand(
         "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells",

--- a/src/test/suite/unit/htmlStructureResolver.test.ts
+++ b/src/test/suite/unit/htmlStructureResolver.test.ts
@@ -1,0 +1,136 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import type { CompletionConfig } from "../../../utils/llmUtils";
+import type { CodexCellDocument } from "../../../providers/codexCellEditorProvider/codexDocument";
+import {
+    maybeAutoResolveHtmlStructure,
+    resolveHtmlStructureWithLLM,
+    stripMarkdownCodeFences,
+} from "../../../providers/codexCellEditorProvider/utils/htmlStructureResolver";
+
+const mockConfig = { model: "test" } as CompletionConfig;
+
+const createMockDocument = (enforceHtmlStructure: boolean): CodexCellDocument =>
+    ({
+        getNotebookMetadata: () => ({ enforceHtmlStructure }),
+    }) as CodexCellDocument;
+
+suite("htmlStructureResolver", () => {
+    suite("stripMarkdownCodeFences", () => {
+        test("returns content unchanged when no fences", () => {
+            assert.strictEqual(stripMarkdownCodeFences("<p>Hello</p>"), "<p>Hello</p>");
+        });
+
+        test("strips html code fences", () => {
+            const input = "```html\n<p>Hello</p>\n```";
+            assert.strictEqual(stripMarkdownCodeFences(input), "<p>Hello</p>");
+        });
+
+        test("strips plain code fences", () => {
+            const input = "```\n<p>Hello</p>\n```";
+            assert.strictEqual(stripMarkdownCodeFences(input), "<p>Hello</p>");
+        });
+    });
+
+    suite("resolveHtmlStructureWithLLM", () => {
+        test("uses callLLM override when provided", async () => {
+            const callLLMOverride = sinon.stub().resolves({ content: "```html\n<p>Fixed</p>\n```" });
+
+            const resolved = await resolveHtmlStructureWithLLM(
+                "<p>Source</p>",
+                "Translation",
+                mockConfig,
+                callLLMOverride,
+            );
+
+            assert.strictEqual(resolved, "<p>Fixed</p>");
+            assert.strictEqual(callLLMOverride.callCount, 1);
+        });
+    });
+
+    suite("maybeAutoResolveHtmlStructure", () => {
+        let executeCommandStub: sinon.SinonStub;
+
+        setup(() => {
+            executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+        });
+
+        teardown(() => {
+            executeCommandStub.restore();
+        });
+
+        test("returns translation unchanged when enforcement is off", async () => {
+            const result = await maybeAutoResolveHtmlStructure(
+                "GEN 1:1",
+                "Translated text",
+                createMockDocument(false),
+            );
+
+            assert.strictEqual(result, "Translated text");
+            assert.strictEqual(executeCommandStub.callCount, 0);
+        });
+
+        test("returns translation unchanged when structures already match", async () => {
+            executeCommandStub.resolves({ cellId: "GEN 1:1", content: "<p>Hello</p>" });
+
+            const result = await maybeAutoResolveHtmlStructure(
+                "GEN 1:1",
+                "<p>Hola</p>",
+                createMockDocument(true),
+            );
+
+            assert.strictEqual(result, "<p>Hola</p>");
+        });
+
+        test("calls resolve when structures mismatch", async () => {
+            executeCommandStub.resolves({ cellId: "GEN 1:1", content: "<p>Hello</p><br/>" });
+            const resolveWithLLM = sinon.stub().resolves("<p>Hola</p><br/>");
+            const onResolving = sinon.stub();
+
+            const result = await maybeAutoResolveHtmlStructure(
+                "GEN 1:1",
+                "<p>Hola</p>",
+                createMockDocument(true),
+                {
+                    config: mockConfig,
+                    onResolving,
+                    resolveWithLLM,
+                },
+            );
+
+            assert.strictEqual(result, "<p>Hola</p><br/>");
+            assert.strictEqual(resolveWithLLM.callCount, 1);
+            assert.strictEqual(onResolving.callCount, 1);
+        });
+
+        test("returns raw translation when resolve throws", async () => {
+            executeCommandStub.resolves({ cellId: "GEN 1:1", content: "<p>Hello</p><br/>" });
+            const resolveWithLLM = sinon.stub().rejects(new Error("LLM failed"));
+
+            const result = await maybeAutoResolveHtmlStructure(
+                "GEN 1:1",
+                "<p>Hola</p>",
+                createMockDocument(true),
+                {
+                    config: mockConfig,
+                    resolveWithLLM,
+                },
+            );
+
+            assert.strictEqual(result, "<p>Hola</p>");
+        });
+
+        test("returns raw translation when source cell is missing", async () => {
+            executeCommandStub.resolves(null);
+
+            const result = await maybeAutoResolveHtmlStructure(
+                "GEN 1:1",
+                "<p>Hola</p>",
+                createMockDocument(true),
+            );
+
+            assert.strictEqual(result, "<p>Hola</p>");
+        });
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -423,6 +423,8 @@ export type EditorPostMessages =
     | { command: "updateCellLabel"; content: { cellId: string; cellLabel: string; }; }
     | { command: "updateCellIsLocked"; content: { cellId: string; isLocked: boolean; }; }
     | { command: "resolveHtmlStructure"; content: { cellId: string; }; }
+    | { command: "requestResolveHtmlStructureBatch"; content: { cellIds: string[]; }; }
+    | { command: "stopResolveHtmlStructureBatch"; }
     | {
         command: "updateNotebookMetadata";
         content: CustomNotebookMetadata;
@@ -2054,6 +2056,17 @@ type EditorReceiveMessages =
     }
     | {
         type: "providerAutocompletionState";
+        state: {
+            isProcessing: boolean;
+            totalCells: number;
+            completedCells: number;
+            currentCellId?: string;
+            cellsToProcess: string[];
+            progress: number;
+        };
+    }
+    | {
+        type: "providerStructureResolveState";
         state: {
             isProcessing: boolean;
             totalCells: number;

--- a/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellContentDisplay.tsx
@@ -64,6 +64,7 @@ interface CellContentDisplayProps {
     showInlineBacktranslations?: boolean;
     backtranslation?: any;
     htmlStructureError?: string;
+    isResolvingStructureExternally?: boolean;
     // Audio playback state from other webview type (source or target)
     isOtherTypeAudioPlaying?: boolean;
 }
@@ -128,6 +129,7 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
         showInlineBacktranslations = false,
         backtranslation,
         htmlStructureError,
+        isResolvingStructureExternally = false,
         isOtherTypeAudioPlaying = false,
     }) => {
         const cellIds = cell.cellMarkers;
@@ -147,6 +149,7 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
         const [isLockButtonGlowing, setIsLockButtonGlowing] = useState(false);
         const [isLockButtonFlashing, setIsLockButtonFlashing] = useState(false);
         const [isResolvingStructure, setIsResolvingStructure] = useState(false);
+        const isResolving = isResolvingStructure || isResolvingStructureExternally;
         const { showTooltip, hideTooltip } = useTooltip();
 
         const { unsavedChanges, toggleFlashingBorder } = useContext(UnsavedChangesContext);
@@ -1093,20 +1096,20 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                             >
                                 <i
                                     className={`codicon ${
-                                        isResolvingStructure
+                                        isResolving
                                             ? "codicon-loading codicon-modifier-spin"
                                             : "codicon-warning"
                                     }`}
                                 />
                                 <span style={{ flex: 1 }}>
-                                    {isResolvingStructure
+                                    {isResolving
                                         ? "Resolving structure..."
                                         : `Structure mismatch: ${htmlStructureError}`}
                                 </span>
                                 <Button
                                     variant="outline"
                                     size="sm"
-                                    disabled={isResolvingStructure}
+                                    disabled={isResolving}
                                     style={{
                                         height: "1.4rem",
                                         fontSize: "0.75rem",
@@ -1121,7 +1124,7 @@ const CellContentDisplay: React.FC<CellContentDisplayProps> = React.memo(
                                         } as EditorPostMessages);
                                     }}
                                 >
-                                    {isResolvingStructure ? "Resolving…" : "Resolve"}
+                                    {isResolving ? "Resolving…" : "Resolve"}
                                 </Button>
                             </div>
                         )}

--- a/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
@@ -74,6 +74,7 @@ export interface CellListProps {
     showInlineBacktranslations?: boolean;
     backtranslationsMap?: Map<string, any>;
     enforceHtmlStructure?: boolean;
+    currentStructureResolveCellId?: string;
     // Milestone-based pagination props for global line numbering
     milestoneIndex?: MilestoneIndex | null;
     currentMilestoneIndex?: number;
@@ -134,6 +135,7 @@ const CellList: React.FC<CellListProps> = ({
     backtranslationsMap = new Map(),
     isAuthenticated = false,
     enforceHtmlStructure = false,
+    currentStructureResolveCellId,
     milestoneIndex = null,
     playerRef,
     shouldShowVideoPlayer = false,
@@ -1017,6 +1019,9 @@ const CellList: React.FC<CellListProps> = ({
                                 showInlineBacktranslations={showInlineBacktranslations}
                                 backtranslation={backtranslationsMap.get(cellMarkers[0])}
                                 htmlStructureError={htmlStructureErrors.get(cellMarkers[0])}
+                                isResolvingStructureExternally={
+                                    currentStructureResolveCellId === cellMarkers[0]
+                                }
                                 isOtherTypeAudioPlaying={isOtherTypeAudioPlaying}
                             />
                         </span>
@@ -1052,6 +1057,7 @@ const CellList: React.FC<CellListProps> = ({
             isAudioOnly,
             lineNumbersEnabled,
             htmlStructureErrors,
+            currentStructureResolveCellId,
         ]
     );
 
@@ -1198,6 +1204,9 @@ const CellList: React.FC<CellListProps> = ({
                                 showInlineBacktranslations={showInlineBacktranslations}
                                 backtranslation={backtranslationsMap.get(cellMarkers[0])}
                                 htmlStructureError={htmlStructureErrors.get(cellMarkers[0])}
+                                isResolvingStructureExternally={
+                                    currentStructureResolveCellId === cellMarkers[0]
+                                }
                                 isOtherTypeAudioPlaying={isOtherTypeAudioPlaying}
                             />
                         </span>

--- a/webviews/codex-webviews/src/CodexCellEditor/ChapterNavigationHeader.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/ChapterNavigationHeader.tsx
@@ -3,6 +3,7 @@ import { Button } from "../components/ui/button";
 import { extractChapterNumberFromMilestoneValue } from "./CodexCellEditor";
 import NotebookMetadataModal from "./NotebookMetadataModal";
 import { AutocompleteModal } from "./modals/AutocompleteModal";
+import { ResolveAllModal } from "./modals/ResolveAllModal";
 import { MobileHeaderMenu } from "./components/MobileHeaderMenu";
 import { MilestoneAccordion } from "./components/MilestoneAccordion";
 import {
@@ -39,6 +40,11 @@ interface ChapterNavigationHeaderProps {
     ) => void;
     onStopAutocomplete: () => void;
     isAutocompletingChapter: boolean;
+    onResolveStructureBatch: (numberOfCells: number) => void;
+    onStopResolveStructureBatch: () => void;
+    isResolvingStructureBatch: boolean;
+    mismatchedCellIds: string[];
+    showResolveAllButton: boolean;
     onSetTextDirection: (direction: "ltr" | "rtl") => void;
     textDirection: "ltr" | "rtl";
     isSourceText: boolean;
@@ -105,6 +111,11 @@ export function ChapterNavigationHeader({
     onAutocompleteChapter,
     onStopAutocomplete,
     isAutocompletingChapter,
+    onResolveStructureBatch,
+    onStopResolveStructureBatch,
+    isResolvingStructureBatch,
+    mismatchedCellIds,
+    showResolveAllButton,
     onSetTextDirection,
     textDirection,
     isSourceText,
@@ -162,6 +173,7 @@ export function ChapterNavigationHeader({
 }: // Removed onToggleCorrectionEditor since it will be a VS Code command now
 ChapterNavigationHeaderProps) {
     const [showConfirm, setShowConfirm] = useState(false);
+    const [showResolveConfirm, setShowResolveConfirm] = useState(false);
     const [isMetadataModalOpen, setIsMetadataModalOpen] = useState(false);
     const [autoDownloadAudioOnOpen, setAutoDownloadAudioOnOpenState] = useState<boolean>(false);
     const [autoRecordOnMicClick, setAutoRecordOnMicClickState] = useState<boolean>(false);
@@ -211,6 +223,7 @@ ChapterNavigationHeaderProps) {
 
     // Helper to determine if any translation is in progress
     const isAnyTranslationInProgress = isAutocompletingChapter || isTranslatingCell;
+    const isAnyBatchOperationInProgress = isAnyTranslationInProgress || isResolvingStructureBatch;
 
     // Update font size when metadata changes
     useEffect(() => {
@@ -375,11 +388,22 @@ ChapterNavigationHeaderProps) {
 
     // Common handler for stopping any kind of translation
     const handleStopTranslation = () => {
-        if (isAutocompletingChapter) {
+        if (isResolvingStructureBatch) {
+            onStopResolveStructureBatch();
+        } else if (isAutocompletingChapter) {
             onStopAutocomplete();
         } else if (isTranslatingCell && onStopSingleCellTranslation) {
             onStopSingleCellTranslation();
         }
+    };
+
+    const handleResolveAllClick = () => {
+        setShowResolveConfirm(true);
+    };
+
+    const handleConfirmResolveAll = (numberOfCells: number) => {
+        onResolveStructureBatch(numberOfCells);
+        setShowResolveConfirm(false);
     };
 
     const handleAutocompleteClick = () => {
@@ -549,10 +573,13 @@ ChapterNavigationHeaderProps) {
                     <MobileHeaderMenu
                         isAutocompletingChapter={isAutocompletingChapter}
                         isTranslatingCell={isTranslatingCell}
+                        isResolvingStructureBatch={isResolvingStructureBatch}
                         onAutocompleteClick={handleAutocompleteClick}
+                        onResolveAllClick={handleResolveAllClick}
                         onStopTranslation={handleStopTranslation}
                         unsavedChanges={unsavedChanges}
                         isSourceText={isSourceText}
+                        showResolveAllButton={showResolveAllButton}
                         textDirection={textDirection}
                         onSetTextDirection={onSetTextDirection}
                         fontSize={fontSize}
@@ -878,12 +905,14 @@ ChapterNavigationHeaderProps) {
             >
                 {!isSourceText && (
                     <>
-                        {isAnyTranslationInProgress ? (
+                        {isAnyBatchOperationInProgress ? (
                             <Button
                                 variant="outline"
                                 onClick={handleStopTranslation}
                                 title={
-                                    isAutocompletingChapter
+                                    isResolvingStructureBatch
+                                        ? "Stop Resolve"
+                                        : isAutocompletingChapter
                                         ? "Stop Autocomplete"
                                         : "Stop Translation"
                                 }
@@ -892,14 +921,27 @@ ChapterNavigationHeaderProps) {
                                 <i className="codicon codicon-circle-slash" />
                             </Button>
                         ) : (
-                            <Button
-                                variant="outline"
-                                onClick={handleAutocompleteClick}
-                                disabled={unsavedChanges}
-                                title="Autocomplete Chapter"
-                            >
-                                <i className="codicon codicon-sparkle" />
-                            </Button>
+                            <>
+                                <Button
+                                    variant="outline"
+                                    onClick={handleAutocompleteClick}
+                                    disabled={unsavedChanges}
+                                    title="Autocomplete Chapter"
+                                >
+                                    <i className="codicon codicon-sparkle" />
+                                </Button>
+                                {showResolveAllButton && (
+                                    <Button
+                                        variant="outline"
+                                        onClick={handleResolveAllClick}
+                                        disabled={unsavedChanges}
+                                        title="Resolve structure mismatches"
+                                    >
+                                        <i className="codicon codicon-warning" />
+                                        <span className="ml-1 hidden xl:inline">Resolve All</span>
+                                    </Button>
+                                )}
+                            </>
                         )}
                     </>
                 )}
@@ -1214,6 +1256,14 @@ ChapterNavigationHeaderProps) {
                     5,
                     untranslatedCellIds.length > 0 ? untranslatedCellIds.length : 5
                 )}
+            />
+
+            <ResolveAllModal
+                isOpen={showResolveConfirm}
+                onClose={() => setShowResolveConfirm(false)}
+                onConfirm={handleConfirmResolveAll}
+                mismatchedCellIds={mismatchedCellIds}
+                defaultValue={Math.min(5, mismatchedCellIds.length > 0 ? mismatchedCellIds.length : 5)}
             />
 
             <MilestoneAccordion

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -23,6 +23,7 @@ import ScrollToContentContext from "./contextProviders/ScrollToContentContext";
 import DuplicateCellResolver from "./DuplicateCellResolver";
 import VideoTimelineEditor from "./VideoTimelineEditor";
 import type { AudioAvailability } from "./utils/audioViewMode";
+import { getStructureMismatchCellIds } from "./utils/structureMismatchCells";
 
 import {
     getCellValueData,
@@ -207,7 +208,7 @@ const CodexCellEditor: React.FC = () => {
     const playerRef = useRef<ReactPlayerRef>(null);
     const [shouldShowVideoPlayer, setShouldShowVideoPlayer] = useState<boolean>(false);
     const [muteVideoAudioDuringPlayback, setMuteVideoAudioDuringPlayback] = useState(true);
-    const { setSourceCellMap } = useContext(SourceCellContext);
+    const { sourceCellMap, setSourceCellMap } = useContext(SourceCellContext);
     const { setContentToScrollTo } = useContext(ScrollToContentContext);
     const { setUnsavedChanges } = useContext(UnsavedChangesContext);
 
@@ -244,6 +245,22 @@ const CodexCellEditor: React.FC = () => {
         progress: 0,
     });
 
+    const [structureResolveState, setStructureResolveState] = useState<{
+        isProcessing: boolean;
+        totalCells: number;
+        completedCells: number;
+        currentCellId?: string;
+        cellsToProcess: string[];
+        progress: number;
+    }>({
+        isProcessing: false,
+        totalCells: 0,
+        completedCells: 0,
+        currentCellId: undefined,
+        cellsToProcess: [],
+        progress: 0,
+    });
+
     // Instead of separate state variables, use computed properties
     // These provide backward compatibility for any code that might use these variables
     const isAutocompletingChapter = autocompletionState.isProcessing;
@@ -255,6 +272,8 @@ const CodexCellEditor: React.FC = () => {
     const isSingleCellTranslating = singleCellTranslationState.isProcessing;
     const singleCellId = singleCellTranslationState.cellId;
     const singleCellProgress = singleCellTranslationState.progress;
+    const isResolvingStructureBatch = structureResolveState.isProcessing;
+    const currentStructureResolveCellId = structureResolveState.currentCellId;
 
     // Required state variables that were removed
     const [contentBeingUpdated, setContentBeingUpdated] = useState<EditorCellContent>(
@@ -1706,6 +1725,10 @@ const CodexCellEditor: React.FC = () => {
             setAutocompletionState(state);
         },
 
+        updateStructureResolveState: (state) => {
+            setStructureResolveState(state);
+        },
+
         updateSingleCellTranslationState: (state) => {
             debug("autocomplete", "Received single cell translation state from provider:", state);
             setSingleCellTranslationState(state);
@@ -3014,6 +3037,28 @@ const CodexCellEditor: React.FC = () => {
         } as EditorPostMessages);
     };
 
+    const handleResolveStructureBatch = (numberOfCells: number) => {
+        const selectedCellIds = mismatchedCellIds.slice(0, numberOfCells);
+        if (selectedCellIds.length === 0) {
+            vscode.postMessage({
+                command: "showInformationMessage",
+                message: "No cells with structure mismatches found in this section.",
+            });
+            return;
+        }
+
+        vscode.postMessage({
+            command: "requestResolveHtmlStructureBatch",
+            content: { cellIds: selectedCellIds },
+        } as EditorPostMessages);
+    };
+
+    const handleStopResolveStructureBatch = () => {
+        vscode.postMessage({
+            command: "stopResolveHtmlStructureBatch",
+        } as EditorPostMessages);
+    };
+
     const openSourceText = (sectionIdNumber: number) => {
         vscode.postMessage({
             command: "openSourceText",
@@ -3084,6 +3129,24 @@ const CodexCellEditor: React.FC = () => {
             return unit;
         });
     }, [contentBeingUpdated, translationUnitsForSection]);
+
+    const mismatchedCellIds = useMemo(
+        () =>
+            getStructureMismatchCellIds(
+                translationUnitsWithCurrentEditorContent,
+                sourceCellMap,
+                metadata?.enforceHtmlStructure ?? false,
+                isSourceText,
+            ),
+        [
+            translationUnitsWithCurrentEditorContent,
+            sourceCellMap,
+            metadata?.enforceHtmlStructure,
+            isSourceText,
+        ],
+    );
+
+    const showResolveAllButton = !isSourceText && (metadata?.enforceHtmlStructure ?? false);
 
     const handleMetadataChange = (key: string, value: string) => {
         setMetadata((prev) => {
@@ -3700,6 +3763,11 @@ const CodexCellEditor: React.FC = () => {
                             }}
                             onStopAutocomplete={handleStopAutocomplete}
                             isAutocompletingChapter={isAutocompletingChapter}
+                            onResolveStructureBatch={handleResolveStructureBatch}
+                            onStopResolveStructureBatch={handleStopResolveStructureBatch}
+                            isResolvingStructureBatch={isResolvingStructureBatch}
+                            mismatchedCellIds={mismatchedCellIds}
+                            showResolveAllButton={showResolveAllButton}
                             onSetTextDirection={(direction) => {
                                 setTextDirection(direction);
                                 // Save the text direction with local source marking (similar to font size)
@@ -3987,6 +4055,7 @@ const CodexCellEditor: React.FC = () => {
                             }
                             lineNumbersEnabled={metadata?.lineNumbersEnabled ?? true}
                             enforceHtmlStructure={metadata?.enforceHtmlStructure ?? false}
+                            currentStructureResolveCellId={currentStructureResolveCellId}
                             currentUsername={username}
                             requiredValidations={requiredValidations ?? undefined}
                             requiredAudioValidations={requiredAudioValidations ?? undefined}

--- a/webviews/codex-webviews/src/CodexCellEditor/components/MobileHeaderMenu.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/components/MobileHeaderMenu.tsx
@@ -19,10 +19,13 @@ interface MobileHeaderMenuProps {
     // Translation controls
     isAutocompletingChapter: boolean;
     isTranslatingCell: boolean;
+    isResolvingStructureBatch?: boolean;
     onAutocompleteClick: () => void;
+    onResolveAllClick?: () => void;
     onStopTranslation: () => void;
     unsavedChanges: boolean;
     isSourceText: boolean;
+    showResolveAllButton?: boolean;
 
     // Settings
     textDirection: "ltr" | "rtl";
@@ -65,10 +68,13 @@ interface MobileHeaderMenuProps {
 export function MobileHeaderMenu({
     isAutocompletingChapter,
     isTranslatingCell,
+    isResolvingStructureBatch = false,
     onAutocompleteClick,
+    onResolveAllClick,
     onStopTranslation,
     unsavedChanges,
     isSourceText,
+    showResolveAllButton = false,
     textDirection,
     onSetTextDirection,
     fontSize,
@@ -93,6 +99,7 @@ export function MobileHeaderMenu({
     onCycleRecordingCountdown,
 }: MobileHeaderMenuProps) {
     const isAnyTranslationInProgress = isAutocompletingChapter || isTranslatingCell;
+    const isAnyBatchOperationInProgress = isAnyTranslationInProgress || isResolvingStructureBatch;
 
     return (
         <DropdownMenu>
@@ -146,27 +153,41 @@ export function MobileHeaderMenu({
                 {/* Translation Controls */}
                 {!isSourceText && (
                     <>
-                        {isAnyTranslationInProgress ? (
+                        {isAnyBatchOperationInProgress ? (
                             <DropdownMenuItem
                                 onClick={onStopTranslation}
                                 className="cursor-pointer"
                             >
                                 <i className="codicon codicon-circle-slash mr-2 h-4 w-4" />
                                 <span>
-                                    {isAutocompletingChapter
+                                    {isResolvingStructureBatch
+                                        ? "Stop Resolve"
+                                        : isAutocompletingChapter
                                         ? "Stop Autocomplete"
                                         : "Stop Translation"}
                                 </span>
                             </DropdownMenuItem>
                         ) : (
-                            <DropdownMenuItem
-                                onClick={onAutocompleteClick}
-                                disabled={unsavedChanges}
-                                className="cursor-pointer"
-                            >
-                                <i className="codicon codicon-sparkle mr-2 h-4 w-4" />
-                                <span>Autocomplete Chapter</span>
-                            </DropdownMenuItem>
+                            <>
+                                <DropdownMenuItem
+                                    onClick={onAutocompleteClick}
+                                    disabled={unsavedChanges}
+                                    className="cursor-pointer"
+                                >
+                                    <i className="codicon codicon-sparkle mr-2 h-4 w-4" />
+                                    <span>Autocomplete Chapter</span>
+                                </DropdownMenuItem>
+                                {showResolveAllButton && onResolveAllClick && (
+                                    <DropdownMenuItem
+                                        onClick={onResolveAllClick}
+                                        disabled={unsavedChanges}
+                                        className="cursor-pointer"
+                                    >
+                                        <i className="codicon codicon-warning mr-2 h-4 w-4" />
+                                        <span>Resolve All</span>
+                                    </DropdownMenuItem>
+                                )}
+                            </>
                         )}
                         <DropdownMenuSeparator />
                     </>

--- a/webviews/codex-webviews/src/CodexCellEditor/hooks/useVSCodeMessageHandler.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/hooks/useVSCodeMessageHandler.ts
@@ -106,6 +106,15 @@ interface UseVSCodeMessageHandlerProps {
         progress: number;
     }) => void;
 
+    updateStructureResolveState?: (state: {
+        isProcessing: boolean;
+        totalCells: number;
+        completedCells: number;
+        currentCellId?: string;
+        cellsToProcess: string[];
+        progress: number;
+    }) => void;
+
     updateSingleCellTranslationState?: (state: {
         isProcessing: boolean;
         cellId?: string;
@@ -174,6 +183,7 @@ export const useVSCodeMessageHandler = ({
 
     // New handlers
     updateAutocompletionState,
+    updateStructureResolveState,
     updateSingleCellTranslationState,
     updateSingleCellQueueState,
     updateCellTranslationCompletion,
@@ -282,6 +292,11 @@ export const useVSCodeMessageHandler = ({
                 case "providerAutocompletionState":
                     if (updateAutocompletionState) {
                         updateAutocompletionState(message.state);
+                    }
+                    break;
+                case "providerStructureResolveState":
+                    if (updateStructureResolveState) {
+                        updateStructureResolveState(message.state);
                     }
                     break;
                 case "providerSingleCellTranslationState":
@@ -466,6 +481,7 @@ export const useVSCodeMessageHandler = ({
         videoStreamUnavailable,
         videoNeedsDownload,
         updateAutocompletionState,
+        updateStructureResolveState,
         updateSingleCellTranslationState,
         updateSingleCellQueueState,
         updateCellTranslationCompletion,

--- a/webviews/codex-webviews/src/CodexCellEditor/modals/ResolveAllModal.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/modals/ResolveAllModal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Button } from "../../components/ui/button";
+import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+
+interface ResolveAllModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (numberOfCells: number) => void;
+    mismatchedCellIds: string[];
+    defaultValue?: number;
+}
+
+export function ResolveAllModal({
+    isOpen,
+    onClose,
+    onConfirm,
+    mismatchedCellIds,
+    defaultValue = 5,
+}: ResolveAllModalProps) {
+    const totalAvailable = mismatchedCellIds.length;
+    const [numberOfCellsToResolve, setNumberOfCellsToResolve] = useState(
+        Math.min(defaultValue, totalAvailable)
+    );
+
+    useEffect(() => {
+        if (isOpen) {
+            setNumberOfCellsToResolve(Math.min(defaultValue, totalAvailable));
+        }
+    }, [isOpen, defaultValue, totalAvailable]);
+
+    useEffect(() => {
+        if (numberOfCellsToResolve > totalAvailable) {
+            setNumberOfCellsToResolve(totalAvailable);
+        }
+    }, [totalAvailable, numberOfCellsToResolve]);
+
+    if (!isOpen) return null;
+
+    const handleNumberChange = (value: string) => {
+        const num = parseInt(value, 10) || 0;
+        setNumberOfCellsToResolve(Math.min(num, totalAvailable));
+    };
+
+    const isValidSelection = totalAvailable > 0 && numberOfCellsToResolve > 0;
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[9999]">
+            <div className="bg-background border border-border rounded-lg p-6 max-w-lg w-full">
+                <div className="flex items-center justify-between mb-6">
+                    <h2 className="text-xl font-semibold text-foreground">Resolve Structure Mismatches</h2>
+                    <Button onClick={onClose}>
+                        <i className="codicon codicon-close" />
+                    </Button>
+                </div>
+
+                <div className="mb-6">
+                    <div className="flex items-center justify-between mb-3">
+                        <span className="text-sm text-muted-foreground">
+                            Cells with structure mismatches in this section
+                        </span>
+                        <VSCodeTag>{totalAvailable} cells</VSCodeTag>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                        The LLM will insert missing structural elements (tags, markers, line breaks)
+                        from the source into the translation without changing translated text.
+                    </p>
+                </div>
+
+                <div className="mb-6">
+                    <div className="flex items-center justify-between mb-3">
+                        <label className="font-semibold text-foreground">
+                            Number of cells to resolve:
+                        </label>
+                        <div className="text-sm text-muted-foreground">
+                            {numberOfCellsToResolve} of {totalAvailable} available
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <input
+                            type="number"
+                            value={numberOfCellsToResolve || ""}
+                            onChange={(e) => handleNumberChange(e.target.value)}
+                            className="flex-1 px-3 py-2 bg-input border border-border rounded text-foreground"
+                            placeholder="Enter number of cells"
+                            min="1"
+                            max={totalAvailable}
+                        />
+                        {totalAvailable > 0 && (
+                            <Button
+                                variant="outline"
+                                onClick={() => setNumberOfCellsToResolve(totalAvailable)}
+                            >
+                                All
+                            </Button>
+                        )}
+                    </div>
+
+                    {totalAvailable === 0 && (
+                        <p className="text-sm text-muted-foreground mt-2">
+                            No structure mismatches found in this section.
+                        </p>
+                    )}
+
+                    {numberOfCellsToResolve === 0 && totalAvailable > 0 && (
+                        <p className="text-sm text-destructive mt-2">
+                            Enter a number greater than 0
+                        </p>
+                    )}
+                </div>
+
+                <div className="flex justify-end gap-2">
+                    <Button variant="secondary" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => onConfirm(numberOfCellsToResolve)}
+                        disabled={!isValidSelection}
+                    >
+                        Resolve {numberOfCellsToResolve} Cells
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/structureMismatchCells.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/structureMismatchCells.ts
@@ -1,0 +1,31 @@
+import type { QuillCellContent } from "../../../../../types";
+import { compareHtmlStructure } from "./htmlStructureValidator";
+
+export function getStructureMismatchCellIds(
+    cells: QuillCellContent[],
+    sourceCellMap: Record<string, { content: string }>,
+    enforceHtmlStructure: boolean,
+    isSourceText: boolean,
+): string[] {
+    if (!enforceHtmlStructure || isSourceText) {
+        return [];
+    }
+
+    const mismatchedCellIds: string[] = [];
+
+    for (const cell of cells) {
+        const cellId = cell.cellMarkers[0];
+        if (!cellId) continue;
+
+        const sourceHtml = sourceCellMap[cellId]?.content;
+        const targetHtml = cell.cellContent;
+        if (!sourceHtml || !targetHtml) continue;
+
+        const diff = compareHtmlStructure(sourceHtml, targetHtml);
+        if (!diff.isMatch) {
+            mismatchedCellIds.push(cellId);
+        }
+    }
+
+    return mismatchedCellIds;
+}


### PR DESCRIPTION
When sparkling and the HTML enforcement is on, the AI translation will finish and before writing into cell, it will also trigger the "Resolve" function to enforce all the missing html tags to preserve the styles. The original "Resolve" button is still there as a fallback function.

## PR Title
Format:
Add-Resolve-function-to-Sparkle-process-1071

## Summary
Closes #1071

The sparkle button has 2 steps now, also shown in the loading bar on the bottom of the screen. First is the AI translating the content and second is the HTML enforcement that will resolve the cell tag missmatch before the final translation is written in the cell.

## Changes
These should match with the Acceptance Criteria

## Test Checklist
- [x] Import style heavy file format, like biblica study bible, with HTML enforcement enabled.
- [x] Try sprakle button on cells, they should come out always green without the tag missmatch warning.
- [x] Some might have the warning still if they contain complicated tags or lot of them, and the "Resolve" button is still there as a fallback feature.
- [x] Later try exporting it with round-trip export and see if the styles were preserved.