### PR TITLE
1075-patani-malay-project-formatting-issues-2

### DIFF
--- a/src/projectManager/utils/migrationUtils.ts
+++ b/src/projectManager/utils/migrationUtils.ts
@@ -3594,7 +3594,10 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
                         const report = await repairVerseRangeDuplicationForFile(file, {
                             dryRun: true,
                         });
-                        if (report.changed && report.tombstoned > 0) {
+                        // Include reposition-only files (tombstoned === 0): duplicates may already
+                        // be soft-deleted while their live counterparts are still stranded out of
+                        // their chapter (e.g. after a sync merge reverted an earlier repair).
+                        if (report.changed) {
                             affected.push({ uri: file, tombstoned: report.tombstoned });
                             totalTombstones += report.tombstoned;
                         }
@@ -3648,7 +3651,10 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
         const previewLimit = 10;
         const previewLines = affected
             .slice(0, previewLimit)
-            .map((r) => `  • ${path.basename(r.uri.fsPath)} (${r.tombstoned})`)
+            .map(
+                (r) =>
+                    `  • ${path.basename(r.uri.fsPath)} (${r.tombstoned > 0 ? r.tombstoned : "reposition only"})`
+            )
             .join("\n");
         const moreLine =
             affected.length > previewLimit
@@ -3658,10 +3664,14 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
             totalConflicts > 0
                 ? `\n\n${totalConflicts} overlapping-content conflict(s) will be LEFT untouched for manual review.`
                 : "";
-        const detail = `Empty duplicate cells will be soft-deleted (recoverable). No translated text is removed.\n\nFiles:\n${previewLines}${moreLine}${conflictLine}`;
+        const detail = `Empty duplicate cells will be soft-deleted (recoverable) and stranded verse cells moved back to their chapter. No translated text is removed.\n\nFiles:\n${previewLines}${moreLine}${conflictLine}`;
 
+        const headline =
+            totalTombstones > 0
+                ? `Found ${totalTombstones} empty duplicate verse cell(s) across ${affected.length} file(s). Apply repair?`
+                : `Found ${affected.length} file(s) with verse cells stranded out of their chapter. Apply repair?`;
         const choice = await vscode.window.showWarningMessage(
-            `Found ${totalTombstones} empty duplicate verse cell(s) across ${affected.length} file(s). Apply repair?`,
+            headline,
             { modal: true, detail },
             "Apply"
         );
@@ -3714,7 +3724,9 @@ export const migration_repairVerseRangeDuplication = async (): Promise<void> => 
         }
 
         void vscode.window.showInformationMessage(
-            `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
+            totalTombstones > 0
+                ? `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, ${totalTombstones} duplicate(s) removed.`
+                : `Verse-duplication repair complete: ${appliedFilePaths.length} file(s) updated, stranded cells repositioned.`
         );
     } catch (error) {
         console.error("Error running verse-range duplication repair:", error);


### PR DESCRIPTION
## Summary
Closes #1075

The `Codex: Repair Duplicated Verse Cells` command silently skipped files that only needed repositioning. Its scan gated on `report.changed && report.tombstoned > 0`, so a file whose empty duplicate cells were *already* soft-deleted — but whose live, translated verse cells were still stranded at the end of the file (e.g. after a sync merge reverted an earlier repair's ordering, as happened to the Patani Malay project's MAT.codex) — was dropped from the apply list and the command reported "No duplicated verse cells detected."

This PR makes the scan include reposition-only files and adjusts the command's messaging so that case is described accurately.

## Changes
- `migration_repairVerseRangeDuplication` scan now gates on `report.changed` alone, so files needing only the reposition pass (zero new tombstones) are offered for repair.
- Confirm dialog: reposition-only files are listed as "(reposition only)" instead of "(0)", and when no duplicates exist the headline reads "Found N file(s) with verse cells stranded out of their chapter" instead of "Found 0 empty duplicate verse cell(s)".
- Confirm dialog detail now mentions that stranded verse cells are moved back to their chapter.
- Completion toast says "stranded cells repositioned" instead of the misleading "0 duplicate(s) removed" when no tombstones were created.
- No changes to the repair logic itself (`repairVerseRangeDuplicationForFile`, `planVerseDuplicationRepair`, `reorderVerseRangeCells` are untouched).

## Test Checklist
### Scan gate (verified against the real affected file)
- [x] Dry-run on the Pattani Malay `MAT.codex` returns `tombstoneIds: 0, orderChanged: true` — the old gate excluded it, the new gate includes it
- [x] Files with neither duplicates nor stranded cells are still excluded (`changed: false`), so the command remains a no-op on healthy projects

### Apply path (verified against the real affected file)
- [x] All 1179 cells and cell IDs preserved after apply
- [x] All 22 stranded verses (MAT 12:46–15:6 translations, 17:21, 22:34–35, 22:41–42, 24:35) end up under their correct chapter milestone
- [x] Stranded translations survive intact (e.g. 13:1 and 13:2 keep pmsue's text)
- [x] Command re-run end-to-end from the extension host on the affected project: MAT.codex is offered and repaired correctly

### Messaging
- [x] Reposition-only path shows the stranded-cells headline and "(reposition only)" file labels, and completes with "stranded cells repositioned"