### PR TITLE
1078-bib-ett-algerian-project-usfm-export-issues

### DIFF
--- a/src/exportHandler/usfmExporter.ts
+++ b/src/exportHandler/usfmExporter.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { basename } from "path";
 import * as grammar from "usfm-grammar";
 import { CodexCellTypes } from "../../types/enums";
-import { readCodexNotebookFromUri, isContentCellType } from "./exportHandlerUtils";
+import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -247,7 +247,9 @@ export async function exportCodexContentAsUsfm(
                 const codexNotebook =
                     await readCodexNotebookFromUri(file);
 
-                const textCells = codexNotebook.cells.filter(
+                const activeCells = getActiveCells(codexNotebook.cells);
+
+                const textCells = activeCells.filter(
                     (cell) =>
                         (cell.kind === 2 || cell.kind === 1) &&
                         isContentCellType(cell.metadata?.type)
@@ -289,16 +291,14 @@ export async function exportCodexContentAsUsfm(
                 usfmContent += `\\toc3 ${bookCode}\n`;
                 usfmContent += `\\mt1 ${fullBookName}\n`;
 
-                const relevantCells = codexNotebook.cells.filter(
+                const relevantCells = activeCells.filter(
                     (cell) => {
-                        const metadata = cell.metadata as any;
                         return (
                             (cell.kind === 2 || cell.kind === 1) &&
                             cell.metadata?.type &&
                             cell.metadata?.type !==
                             CodexCellTypes.MILESTONE &&
-                            cell.value.trim().length > 0 &&
-                            !metadata?.merged
+                            cell.value.trim().length > 0
                         );
                     }
                 );

--- a/src/test/suite/exportHandlerUtils.test.ts
+++ b/src/test/suite/exportHandlerUtils.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "assert";
+import type { CodexNotebookAsJSONData } from "../../../types";
+import { CodexCellTypes } from "../../../types/enums";
+import { getActiveCells } from "../../exportHandler/exportHandlerUtils";
+
+type Cell = CodexNotebookAsJSONData["cells"][number];
+
+const makeCell = (
+    id: string,
+    data?: Cell["metadata"]["data"]
+): Cell => ({
+    kind: 2,
+    languageId: "html",
+    value: id,
+    metadata: {
+        id,
+        type: CodexCellTypes.TEXT,
+        edits: [],
+        data,
+    },
+});
+
+suite("Export handler active-cell filtering", () => {
+    test("excludes merged and deleted cells while preserving active-cell order", () => {
+        const cells = [
+            makeCell("first"),
+            makeCell("merged", { merged: true }),
+            makeCell("second", { merged: false, deleted: false }),
+            makeCell("deleted", { deleted: true }),
+            makeCell("third"),
+        ];
+
+        const activeCellIds = getActiveCells(cells).map(
+            (cell) => cell.metadata.id
+        );
+
+        assert.deepStrictEqual(activeCellIds, ["first", "second", "third"]);
+    });
+});


### PR DESCRIPTION
## Summary
Closes #1078 

USFM exports included content from soft-deleted cells — stray test headings, bolded section titles, duplicate verse ranges, and in one case a duplicate chapter marker — none of which are visible in the Codex editor. The USFM exporter used its own inline cell filter that never checked `metadata.data.deleted`, and its merged-cell check read the flag from the wrong path (`metadata.merged` instead of `metadata.data.merged`), so it effectively excluded neither deleted nor merged cells. Every other exporter (HTML, plaintext, XLIFF) already filters through the shared `getActiveCells()` helper, which is why only USFM had this problem.

## Changes
- USFM exporter now filters notebook cells through `getActiveCells()` (the shared helper used by the HTML, plaintext, and XLIFF exporters), so cells with `metadata.data.deleted: true` are excluded from export
- Merged cells are now correctly excluded via `metadata.data.merged` (the old inline check read `metadata.merged`, which never matched)
- Removed the redundant inline filter logic in favor of the shared helper; the empty-file/content checks now also operate on active cells only

## Test Checklist
### Regression
- [x] All 14 cells flagged `deleted: true` in GEN.codex are excluded by the new filter — exactly the stray `\p Test heading...` and `\p \bd ...\bd*` lines from the reported export
- [x] No live cells are dropped (`<strong>` paratext and "Test" heading counts go to zero; all other cells unchanged)

### No side effects
- [x] Exported file headers, chapter/verse structure, and all live-cell content are byte-identical between old and new output (sole exception: one trailing space in JHN, an end-of-file `trim()` artifact where the deleted heading was previously the last line)
