### PR TITLE
1096-makhuwa-meetto_mgh---character-labels-missing-after-upload

### DIFF
--- a/src/cellLabelImporter/README.md
+++ b/src/cellLabelImporter/README.md
@@ -32,6 +32,35 @@ The importer expects spreadsheet files with columns containing:
 - Optional "character" column for speaker names
 - Optional "dialogue" column for the actual text
 
+### Recognized timestamp columns
+
+A row is only processed if the importer can find a start time for it. Headers recognized as
+carrying a start time include `START`, `STARTTIME`, `Start Time`, `Time In`, and `TC In`, plus a
+`TIMESTAMP` column holding a full range (`00:00:41.792 --> 00:00:43.043`).
+
+Where more than one column claims to be the start, one whose values are actually shaped like
+timecode wins — dialogue lists in the wild carry duplicated or copy-pasted headers, and a column
+headed `TC In` that really holds line numbers must not be read as seconds.
+
+### Recognized timestamp formats
+
+| Format | Example |
+|--------|---------|
+| `HH:MM:SS,mmm` / `HH:MM:SS.mmm` | `00:01:03.209` |
+| `HH:MM:SS` | `00:01:03` |
+| `MM:SS.mmm` / `MM:SS` | `01:03.209` |
+| Raw seconds | `63.209` |
+| SMPTE timecode `HH:MM:SS:FF` | `00:01:03:05` |
+
+For SMPTE timecode the frame rate is inferred from the largest frame value in the file, since
+frames run `0..fps-1`. This resolves to the nominal rate (24/25/30/50/60) rather than a
+pulled-down variant such as 23.976 — the two cannot be told apart from frame values alone, and
+they differ by far less than the matcher's tolerance. `HH:MM:SS` is read as clock time and the
+frame field as the sub-second remainder.
+
+Prefer keeping sub-second precision. Timestamps rounded to whole seconds still match, but
+neighbouring cues can collapse onto the same cell.
+
 Example TSV:
 
 ```tsv
@@ -49,10 +78,22 @@ index	type	start		end	CHARACTER	DIALOGUE
 
 The Cell Label Importer:
 
-- Parses different timestamp formats (HH:MM:SS,mmm, MM:SS.mmm, or raw seconds)
+- Parses different timestamp formats (HH:MM:SS,mmm, MM:SS.mmm, SMPTE HH:MM:SS:FF, or raw seconds)
 - Matches cells using exact or nearest-match timestamp matching
+- Assigns one cell per row when several cells share a start time (see below)
 - Updates both source and target (.source and .codex) files when labels are applied
 - Preserves all other metadata and content during updates
+
+### Simultaneous speakers
+
+Several cells legitimately share one start time when characters speak at once — a group greeting,
+a crowd reciting together. The importer indexes *every* cell at a given start time and hands them
+out in file order, so N rows at the same timestamp fill N distinct cells.
+
+This assumes the rows and the cells are in the same order, which is the only signal available:
+such cells typically carry identical text and identical times, so nothing else distinguishes them.
+Rows beyond the number of cells at that timestamp are left unmatched rather than overwriting a
+label an earlier row set.
 
 ## Example Use Case
 

--- a/src/cellLabelImporter/matcher.ts
+++ b/src/cellLabelImporter/matcher.ts
@@ -1,5 +1,12 @@
 import { CellLabelData, FileData, ImportedRow, CellMetadata, MatchOptions } from "./types";
-import { convertTimestampToSeconds, parseTimestampRange } from "./utils";
+import {
+    convertTimestampToSeconds,
+    detectTimecodeFrameRate,
+    isStartTimeHeader,
+    isTimeishHeader,
+    looksLikeTimecodeValue,
+    parseTimestampRange,
+} from "./utils";
 
 /**
  * Match imported labels with existing cell IDs
@@ -18,10 +25,17 @@ export async function matchCellLabels(
 
     // Create a map of all cells by their start time, and also keep a sorted list for nearest match
     // CRITICAL: Now tracking fileUri to ensure labels go to the correct file
+    //
+    // Each start time holds *every* cell that begins at it, in file order, because simultaneous
+    // speakers (a group greeting, a crowd reciting together) legitimately produce several cells
+    // sharing one timestamp. Rows claim them in order via takeCellAt() so that N rows at the same
+    // time fill N distinct cells rather than all collapsing onto the first.
     const cellMap = new Map<
         number,
-        { cellId: string; currentLabel?: string; fileUri: string; startTimeSeconds?: number; endTimeSeconds?: number; }
+        Array<{ cellId: string; currentLabel?: string; fileUri: string; startTimeSeconds?: number; endTimeSeconds?: number; }>
     >();
+    // How many cells at a given start time have already been claimed by an earlier row.
+    const claimedAt = new Map<number, number>();
     // Also create an exact ID lookup for direct ID-based matching
     const idMap = new Map<string, { cellId: string; currentLabel?: string; fileUri: string; startTimeSeconds?: number; endTimeSeconds?: number; }>();
     // Optional: match using a specific metadata field
@@ -128,22 +142,55 @@ export async function matchCellLabels(
                     // For time-based matching, we store per timestamp (may conflict across files)
                     // but we'll prefer exact ID matches when available
                     if (!cellMap.has(startTimeSeconds)) {
-                        cellMap.set(startTimeSeconds, {
-                            cellId,
-                            currentLabel: metadata.cellLabel,
-                            fileUri,
-                            startTimeSeconds,
-                            endTimeSeconds,
-                        });
+                        cellMap.set(startTimeSeconds, []);
                         cellTimes.push(startTimeSeconds);
                     }
+                    cellMap.get(startTimeSeconds)!.push({
+                        cellId,
+                        currentLabel: metadata.cellLabel,
+                        fileUri,
+                        startTimeSeconds,
+                        endTimeSeconds,
+                    });
                 }
             }
         });
     });
-    console.log(`[matchCellLabels] Populated cellMap with ${cellMap.size} cells from ${sourceFiles.length} files.`);
+    const totalIndexedCells = Array.from(cellMap.values()).reduce((sum, cells) => sum + cells.length, 0);
+    const sharedTimestamps = Array.from(cellMap.values()).filter((cells) => cells.length > 1).length;
+    console.log(
+        `[matchCellLabels] Populated cellMap with ${totalIndexedCells} cells across ${cellMap.size} distinct start times from ${sourceFiles.length} files` +
+            (sharedTimestamps ? ` (${sharedTimestamps} start times have simultaneous speakers).` : ".")
+    );
     cellTimes.sort((a, b) => a - b);
     matchNumberValues.sort((a, b) => a - b);
+
+    /**
+     * Claim the next unclaimed cell at `time`. Returns undefined once every cell there is spoken
+     * for, so surplus rows stay unmatched rather than overwriting a label an earlier row set.
+     */
+    const takeCellAt = (time: number) => {
+        const cells = cellMap.get(time);
+        if (!cells || cells.length === 0) return undefined;
+        const claimed = claimedAt.get(time) ?? 0;
+        if (claimed >= cells.length) return undefined;
+        claimedAt.set(time, claimed + 1);
+        return cells[claimed];
+    };
+
+    // Frame rate is a property of the file as a whole, so infer it once from every timecode-ish
+    // column rather than guessing per value. Non-SMPTE imports leave this undefined and are
+    // unaffected.
+    const timecodeValues: string[] = [];
+    for (const row of importedRows) {
+        for (const key of Object.keys(row)) {
+            if (isTimeishHeader(key)) timecodeValues.push(String(row[key] ?? ""));
+        }
+    }
+    const detectedFps = detectTimecodeFrameRate(timecodeValues);
+    if (detectedFps) {
+        console.log(`[matchCellLabels] Detected SMPTE timecode; assuming ${detectedFps}fps.`);
+    }
 
     // Process each imported row
     importedRows.forEach((row) => {
@@ -152,7 +199,7 @@ export async function matchCellLabels(
         const isCue =
             row.type === "cue" ||
             (row.start && row.end) || // Has time fields
-            Object.keys(row).some((key) => key.toLowerCase().includes("time")) ||
+            Object.keys(row).some((key) => isTimeishHeader(key)) ||
             (typeof row["ID"] === "string" && /cue-\d+(?:\.\d+)?-\d+(?:\.\d+)?/.test(row["ID"]));
 
         // New: allow processing when there is an explicit ID, even if not a cue/timed row
@@ -186,7 +233,7 @@ export async function matchCellLabels(
                     if (typeof mappedValue === "number") {
                         startTimeSeconds = mappedValue;
                     } else {
-                        startTimeSeconds = convertTimestampToSeconds(String(mappedValue));
+                        startTimeSeconds = convertTimestampToSeconds(String(mappedValue), detectedFps);
                     }
                 }
             }
@@ -194,10 +241,10 @@ export async function matchCellLabels(
             // 1) STARTTIME or START
             if (!startTimeSeconds && row["STARTTIME"]) {
                 startTimeDisplay = row["STARTTIME"];
-                startTimeSeconds = convertTimestampToSeconds(row["STARTTIME"] || "");
+                startTimeSeconds = convertTimestampToSeconds(row["STARTTIME"] || "", detectedFps);
             } else if (!startTimeSeconds && row["START"]) {
                 startTimeDisplay = row["START"];
-                startTimeSeconds = convertTimestampToSeconds(row["START"] || "");
+                startTimeSeconds = convertTimestampToSeconds(row["START"] || "", detectedFps);
             } else if (!startTimeSeconds && typeof row["ID"] === "string") {
                 const idMatch = row["ID"].match(/cue-(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)/);
                 if (idMatch) {
@@ -210,7 +257,7 @@ export async function matchCellLabels(
                 // Try TIMESTAMP range
                 const tsKey = rowKeys.find((k) => k.toLowerCase() === "timestamp" || k.toLowerCase().replace(/\s+/g, "") === "timestamp");
                 if (tsKey && typeof row[tsKey] === "string") {
-                    const [s] = parseTimestampRange(row[tsKey]);
+                    const [s] = parseTimestampRange(row[tsKey], detectedFps);
                     if (s) {
                         startTimeSeconds = s;
                         // set display to left side of range
@@ -221,15 +268,15 @@ export async function matchCellLabels(
             }
 
             if (!startTimeSeconds) {
-                // Try common alternatives
-                const startKey = rowKeys.find((key) =>
-                    key.toLowerCase().includes("start") ||
-                    key.toLowerCase().includes("begin") ||
-                    key.toLowerCase().replace(/\s+/g, "").includes("timein")
-                );
+                // Try common alternatives. Where several columns claim to be the start, favour one
+                // whose value is actually shaped like a timecode — a mislabelled column holding
+                // line numbers would otherwise be read as a seconds value and match wildly.
+                const startKeys = rowKeys.filter((key) => isStartTimeHeader(key));
+                const startKey =
+                    startKeys.find((key) => looksLikeTimecodeValue(row[key])) ?? startKeys[0];
                 if (startKey) {
                     startTimeDisplay = row[startKey];
-                    startTimeSeconds = convertTimestampToSeconds(row[startKey] || "");
+                    startTimeSeconds = convertTimestampToSeconds(row[startKey] || "", detectedFps);
                 }
             }
 
@@ -244,7 +291,7 @@ export async function matchCellLabels(
                         if (typeof mappedValue === "number") {
                             numericValue = mappedValue;
                         } else {
-                            const parsed = convertTimestampToSeconds(String(mappedValue));
+                            const parsed = convertTimestampToSeconds(String(mappedValue), detectedFps);
                             numericValue = parsed || undefined;
                         }
                         if (numericValue !== undefined) {
@@ -331,8 +378,8 @@ export async function matchCellLabels(
 
             // If we don't have an exact match yet, try time-based matching (exact or nearest)
             if (!match && startTimeSeconds) {
-                match = cellMap.get(startTimeSeconds);
-                if (!match) {
+                match = takeCellAt(startTimeSeconds);
+                if (!match && !cellMap.has(startTimeSeconds)) {
                     // Dynamic threshold: allow up to 300ms, but if input has no ms (integer seconds), allow 600ms
                     const hasMs =
                         String(startTimeDisplay).match(/[.,]\d{1,3}$/) || String(startTimeSeconds).includes(".");
@@ -359,7 +406,7 @@ export async function matchCellLabels(
                         }
                     }
                     if (bestTime !== null) {
-                        match = cellMap.get(bestTime);
+                        match = takeCellAt(bestTime);
                     }
                 }
             }
@@ -373,7 +420,7 @@ export async function matchCellLabels(
             } else {
                 const tsKey = rowKeys.find((k) => k.toLowerCase() === "timestamp" || k.toLowerCase().replace(/\s+/g, "") === "timestamp");
                 if (tsKey && typeof row[tsKey] === "string") {
-                    const [, e] = parseTimestampRange(row[tsKey]);
+                    const [, e] = parseTimestampRange(row[tsKey], detectedFps);
                     if (e) {
                         const right = String(row[tsKey]).split(/\s*-->\s*/)[1] || "";
                         endTimeDisplay = right;

--- a/src/cellLabelImporter/utils.ts
+++ b/src/cellLabelImporter/utils.ts
@@ -1,15 +1,93 @@
 import * as vscode from "vscode";
 import * as path from "path";
 
+/** SMPTE timecode: HH:MM:SS:FF, where the final field counts frames rather than milliseconds. */
+const SMPTE_TIMECODE = /^(\d+):(\d+):(\d+):(\d+)$/;
+
+/** Frame rate assumed for SMPTE timecode when the source file offers no evidence of its own. */
+export const DEFAULT_TIMECODE_FPS = 24;
+
+/**
+ * Infer the frame rate of a column of SMPTE timecodes from the largest frame value present.
+ * Frames run 0..fps-1, so the maximum observed frame puts a floor under the rate. Returns
+ * undefined when no value in the column is SMPTE, which is the caller's signal to ignore fps
+ * entirely.
+ *
+ * This deliberately resolves to the nominal rate (24/30/60) rather than its pulled-down
+ * variant (23.976/29.97/59.94): the two are indistinguishable from frame values alone, and
+ * they differ by well under the matcher's tolerance.
+ */
+export function detectTimecodeFrameRate(values: Array<string | undefined | null>): number | undefined {
+    let maxFrame = -1;
+    for (const value of values) {
+        const match = String(value ?? "").trim().match(SMPTE_TIMECODE);
+        if (!match) continue;
+        maxFrame = Math.max(maxFrame, parseInt(match[4], 10));
+    }
+    if (maxFrame < 0) return undefined; // no SMPTE values at all
+    if (maxFrame <= 23) return 24;
+    if (maxFrame === 24) return 25;
+    if (maxFrame <= 29) return 30;
+    if (maxFrame <= 49) return 50;
+    return 60;
+}
+
+/**
+ * True for headers that mark a column as carrying time data of some kind.
+ *
+ * The lookahead rather than \b is deliberate: a spreadsheet with duplicate headers arrives here
+ * de-duplicated as "TC In", "TC In_1", and \b does not match before an underscore.
+ */
+export function isTimeishHeader(key: string): boolean {
+    const k = key.toLowerCase().trim();
+    return k.includes("time") || k.includes("timecode") || /^tc[\s_-]*(in|out)(?![a-z])/.test(k);
+}
+
+/** True for headers that specifically mark the *start* of a cue. */
+export function isStartTimeHeader(key: string): boolean {
+    const k = key.toLowerCase().trim();
+    if (k.includes("start") || k.includes("begin")) return true;
+    if (k.replace(/\s+/g, "").includes("timein")) return true;
+    return /^tc[\s_-]*in(?![a-z])/.test(k);
+}
+
+/**
+ * True when a value is shaped like a clock time or timecode ("00:01:03.209", "00:01:03:05")
+ * rather than a bare number.
+ *
+ * Used to break ties between columns that all *claim* to hold a start time: dialogue lists in
+ * the wild carry copy-paste header mistakes, and a column headed "TC In" that actually holds
+ * line numbers must not win over one that holds real timecode. Bare seconds are a legitimate
+ * format, so this is only ever a preference — never a filter.
+ */
+export function looksLikeTimecodeValue(value: unknown): boolean {
+    return /^\s*\d{1,3}(:\d{1,2}){1,3}([.,]\d+)?\s*$/.test(String(value ?? ""));
+}
+
 /**
  * Helper function to convert timestamp from various formats to seconds
- * Supports: HH:MM:SS,mmm, MM:SS.mmm, and raw seconds
+ * Supports: HH:MM:SS,mmm, MM:SS.mmm, HH:MM:SS:FF (SMPTE), and raw seconds
+ *
+ * `fps` is only consulted for SMPTE timecode; pass the value from detectTimecodeFrameRate so a
+ * 30fps list isn't read as though frames 24-29 overflowed into the next second.
  */
-export function convertTimestampToSeconds(timestamp: string): number {
+export function convertTimestampToSeconds(timestamp: string, fps?: number): number {
     if (!timestamp) return 0;
 
     // Handle different timestamp formats
     let match;
+
+    // Format: HH:MM:SS:FF (SMPTE). Checked before the millisecond formats because those
+    // require a , or . separator and so cannot collide with it.
+    match = timestamp.match(SMPTE_TIMECODE);
+    if (match) {
+        const hours = parseInt(match[1]);
+        const minutes = parseInt(match[2]);
+        const seconds = parseInt(match[3]);
+        const frames = parseInt(match[4]);
+        const rate = fps && fps > 0 ? fps : DEFAULT_TIMECODE_FPS;
+        return hours * 3600 + minutes * 60 + seconds + frames / rate;
+    }
 
     // Format: HH:MM:SS,mmm
     match = timestamp.match(/(\d+):(\d+):(\d+)[,.](\d+)/);
@@ -59,13 +137,13 @@ export function convertTimestampToSeconds(timestamp: string): number {
  * Parse a timestamp range string like "50.634 --> 51.468" or "00:00:50.634 --> 00:00:51.468"
  * Returns [startSeconds, endSeconds]. If parsing fails, returns [0, 0].
  */
-export function parseTimestampRange(range: string): [number, number] {
+export function parseTimestampRange(range: string, fps?: number): [number, number] {
     if (!range) return [0, 0];
     // Split on arrow, allowing spaces
     const parts = range.split(/\s*-->\s*/);
     if (parts.length === 2) {
-        const start = convertTimestampToSeconds(parts[0]);
-        const end = convertTimestampToSeconds(parts[1]);
+        const start = convertTimestampToSeconds(parts[0].trim(), fps);
+        const end = convertTimestampToSeconds(parts[1].trim(), fps);
         return [start, end];
     }
     return [0, 0];

--- a/src/test/suite/cellLabelImporterMatching.test.ts
+++ b/src/test/suite/cellLabelImporterMatching.test.ts
@@ -1,0 +1,180 @@
+import * as assert from "assert";
+import { matchCellLabels } from "../../cellLabelImporter/matcher";
+import {
+    convertTimestampToSeconds,
+    detectTimecodeFrameRate,
+    isStartTimeHeader,
+    isTimeishHeader,
+    looksLikeTimecodeValue,
+} from "../../cellLabelImporter/utils";
+import type { FileData, ImportedRow } from "../../cellLabelImporter/types";
+
+const cell = (id: string, value: string, startTime: number, endTime: number) => ({
+    value,
+    metadata: { id, type: "text", edits: [], data: { startTime, endTime } },
+});
+
+const sourceFile = (cells: ReturnType<typeof cell>[]): FileData =>
+    ({ uri: { fsPath: "/project/episode.source" }, cells } as unknown as FileData);
+
+const labelsFor = async (rows: ImportedRow[], cells: ReturnType<typeof cell>[], column: string) =>
+    matchCellLabels(rows, [sourceFile(cells)], [], column);
+
+suite("cellLabelImporter — timestamp parsing", () => {
+    test("parses SMPTE timecode using the supplied frame rate", () => {
+        // 5 frames at 24fps = 0.2083s past the 63s mark
+        assert.ok(Math.abs(convertTimestampToSeconds("00:01:03:05", 24) - 63.2083) < 0.001);
+        // The same timecode at 30fps is a different instant
+        assert.ok(Math.abs(convertTimestampToSeconds("00:01:03:05", 30) - 63.1667) < 0.001);
+    });
+
+    test("SMPTE without a frame rate falls back to the default rather than zero", () => {
+        // Regression: this previously fell through to parseFloat and returned 0, silently
+        // dropping every row in the file.
+        assert.ok(convertTimestampToSeconds("00:01:03:05") > 63);
+    });
+
+    test("existing timestamp formats are unchanged", () => {
+        assert.strictEqual(convertTimestampToSeconds("00:00:41.792"), 41.792);
+        assert.strictEqual(convertTimestampToSeconds("00:00:41,792"), 41.792);
+        assert.strictEqual(convertTimestampToSeconds("00:01:03"), 63);
+        assert.strictEqual(convertTimestampToSeconds("01:03.500"), 63.5);
+        assert.strictEqual(convertTimestampToSeconds("63.209"), 63.209);
+        assert.strictEqual(convertTimestampToSeconds(""), 0);
+    });
+
+    test("frame rate is inferred from the largest frame value seen", () => {
+        assert.strictEqual(detectTimecodeFrameRate(["00:00:01:23", "00:00:02:04"]), 24);
+        assert.strictEqual(detectTimecodeFrameRate(["00:00:01:24"]), 25);
+        assert.strictEqual(detectTimecodeFrameRate(["00:00:01:29"]), 30);
+        // Nothing SMPTE in the column at all
+        assert.strictEqual(detectTimecodeFrameRate(["00:00:41.792", "63.209", ""]), undefined);
+    });
+});
+
+suite("cellLabelImporter — header recognition", () => {
+    test("recognises dialogue-list timecode headers", () => {
+        assert.ok(isTimeishHeader("TC In"));
+        assert.ok(isTimeishHeader("TC Out"));
+        assert.ok(isTimeishHeader("startTime"));
+        // Duplicate headers arrive de-duplicated with a _N suffix
+        assert.ok(isTimeishHeader("TC In_1"));
+        assert.ok(!isTimeishHeader("Character"));
+        assert.ok(!isTimeishHeader("Translation"));
+    });
+
+    test("identifies the start column specifically", () => {
+        assert.ok(isStartTimeHeader("TC In"));
+        assert.ok(isStartTimeHeader("TC In_1"));
+        assert.ok(isStartTimeHeader("Start Time"));
+        assert.ok(isStartTimeHeader("Time In"));
+        assert.ok(!isStartTimeHeader("TC Out"));
+        assert.ok(!isStartTimeHeader("Character"));
+    });
+
+    test("distinguishes timecode-shaped values from bare numbers", () => {
+        assert.ok(looksLikeTimecodeValue("00:01:03:05"));
+        assert.ok(looksLikeTimecodeValue("00:01:03.209"));
+        assert.ok(!looksLikeTimecodeValue("7"));
+        assert.ok(!looksLikeTimecodeValue(""));
+    });
+});
+
+suite("cellLabelImporter — matching", () => {
+    test("imports a dialogue list keyed on TC In with SMPTE timecode", async () => {
+        const cells = [cell("a", "Abba?", 63.209, 63.667), cell("b", "Sit down.", 68.876, 69.5)];
+        const rows: ImportedRow[] = [
+            { "Line #": "10", "TC In": "00:01:03:05", "TC Out": "00:01:03:16", Character: "MARY" },
+            { "Line #": "11", "TC In": "00:01:08:21", "TC Out": "00:01:09:12", Character: "FATHER" },
+        ];
+        const result = await labelsFor(rows, cells, "Character");
+        assert.strictEqual(result.length, 2);
+        assert.deepStrictEqual(
+            result.map((r) => [r.cellId, r.newLabel, r.matched]),
+            [
+                ["a", "MARY", true],
+                ["b", "FATHER", true],
+            ]
+        );
+    });
+
+    test("simultaneous speakers each claim their own cell, in order", async () => {
+        // Four characters greet at once; the source holds four cells at one timestamp.
+        const cells = [
+            cell("c1", "Shalom.", 818.375, 819.417),
+            cell("c2", "Shalom.", 818.375, 819.417),
+            cell("c3", "Shalom.", 818.375, 819.417),
+            cell("c4", "Shalom.", 818.375, 819.417),
+        ];
+        const rows: ImportedRow[] = ["JOSHUA", "FRIEND #2", "FRIEND #3", "FRIEND #4"].map((c) => ({
+            "TC In": "00:13:38:09",
+            Character: c,
+        }));
+        const result = await labelsFor(rows, cells, "Character");
+        assert.strictEqual(result.filter((r) => r.matched).length, 4);
+        assert.deepStrictEqual(
+            result.map((r) => [r.cellId, r.newLabel]),
+            [
+                ["c1", "JOSHUA"],
+                ["c2", "FRIEND #2"],
+                ["c3", "FRIEND #3"],
+                ["c4", "FRIEND #4"],
+            ]
+        );
+    });
+
+    test("surplus rows at one timestamp stay unmatched instead of overwriting", async () => {
+        const cells = [cell("only", "Shalom.", 100, 101)];
+        const rows: ImportedRow[] = [
+            { "TC In": "00:01:40:00", Character: "FIRST" },
+            { "TC In": "00:01:40:00", Character: "SECOND" },
+        ];
+        const result = await labelsFor(rows, cells, "Character");
+        assert.strictEqual(result[0].matched, true);
+        assert.strictEqual(result[0].cellId, "only");
+        assert.strictEqual(result[1].matched, false, "second row must not steal the first's cell");
+    });
+
+    test("a mislabelled column holding line numbers loses to the real timecode column", async () => {
+        // Seen in the wild: the header row repeats "TC In", so column A (line numbers) and the
+        // real timecode column are both start-time candidates. Reading "7" as 7 seconds matched
+        // arbitrary cells and applied wrong labels.
+        const cells = [cell("x", "This is the spot.", 30.042, 31.542)];
+        const rows: ImportedRow[] = [
+            { "TC In": "7", "TC In_1": "00:00:30:01", "TC Out": "00:00:31:13", Character: "JACOB" },
+        ];
+        const result = await labelsFor(rows, cells, "Character");
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].matched, true);
+        assert.strictEqual(result[0].cellId, "x");
+        assert.strictEqual(result[0].newLabel, "JACOB");
+    });
+
+    test("still matches millisecond timestamps via a timeStamp range column", async () => {
+        const cells = [cell("v", "What do you make of this?", 41.792, 43.043)];
+        const rows: ImportedRow[] = [
+            {
+                ID: "1",
+                Source: "What do you make of this?",
+                timeStamp: "00:00:41.792 --> 00:00:43.043",
+                "Character Label": "ATTICUS",
+            },
+        ];
+        const result = await labelsFor(rows, cells, "Character Label");
+        assert.strictEqual(result[0].matched, true);
+        assert.strictEqual(result[0].cellId, "v");
+        assert.strictEqual(result[0].newLabel, "ATTICUS");
+    });
+
+    test("rows with an empty label are skipped and do not consume a cell", async () => {
+        const cells = [cell("c1", "Shalom.", 100, 101), cell("c2", "Shalom.", 100, 101)];
+        const rows: ImportedRow[] = [
+            { "TC In": "00:01:40:00", Character: "" },
+            { "TC In": "00:01:40:00", Character: "REAL SPEAKER" },
+        ];
+        const result = await labelsFor(rows, cells, "Character");
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].cellId, "c1", "blank row must not burn the first cell");
+        assert.strictEqual(result[0].newLabel, "REAL SPEAKER");
+    });
+});


### PR DESCRIPTION
## Summary
Closes #1096

Dialogue lists exported with SMPTE timecode (`TC In` / `TC Out` columns, `HH:MM:SS:FF` values)
imported as an empty table — every row was dropped before parsing because no header contained
"time", and SMPTE values parsed as 0 regardless. Separately, when several characters speak at
the same timestamp (group greetings, crowd recitations), the matcher indexed only the first
cell per start time, so simultaneous speakers collapsed onto one cell and overwrote each
other's labels on save.

This fixes both in the Cell Label Importer so the affected dialogue lists import as-is, with
no spreadsheet preprocessing.

Note one intentional behavior change: when more rows point at a timestamp than cells exist
there, surplus rows now show as unmatched in the review table instead of silently
overwriting the label an earlier row set.

## Changes
- Recognize `TC In` / `TC Out` (and de-duplicated variants like `TC In_1`) as timecode
  columns so dialogue-list rows pass the cue gate (`matcher.ts`, `isTimeishHeader` /
  `isStartTimeHeader` in `utils.ts`)
- Parse SMPTE `HH:MM:SS:FF` timecode, inferring the frame rate from the largest frame value
  in the file (`convertTimestampToSeconds`, `detectTimecodeFrameRate`)
- Index every cell sharing a start time and assign them to rows in order, so N simultaneous
  speakers fill N distinct cells; surplus rows stay unmatched (`cellMap` buckets +
  `takeCellAt` in `matcher.ts`)
- When several columns claim to be the start time, prefer one whose values are actually
  timecode-shaped, so a mislabeled column holding line numbers isn't read as seconds
  (`looksLikeTimecodeValue`)
- Add unit tests (`src/test/suite/cellLabelImporterMatching.test.ts`) and document the
  supported formats and the simultaneous-speaker behavior in the importer README

## Test Checklist

### Real dialogue lists (The Chosen S1, all 8 original .xlsx, unmodified)
- [x] Every episode now matches 100% of rows (101: 548, 102: 518, 103: 314, 104: 458,
      105: 852, 106: 818, 107: 530, 108: 675) — previously all imported as an empty table
- [x] Ep 103 group scenes: 61 previously unreachable simultaneous-speaker cells now each
      receive their own distinct label, in dialogue-list order
- [x] Ep 108 (duplicated `TC In` header where column A holds line numbers): 675/675 matched
      against the real timecode column; line numbers are no longer read as seconds

### Regression (formats that already worked)
- [x] `HH:MM:SS.mmm` CSV with `timeStamp` range column (ep 302, 1064 rows): output identical
      to the old matcher for every row except the CSV's own simultaneous-speaker pairs,
      which previously double-booked one cell and now surface as unmatched
- [x] Labels already applied in a production project (ciluba-lua 302) used as ground truth:
      new output agrees 1061/1061 (fr) and 880/881 (SingleSpeaker); the single disagreement
      is a pre-existing CSV-vs-project discrepancy, identical before and after this change
- [x] README's documented TSV shape (`type=cue`, `start`/`end`, `CHARACTER`) still matches