### PR TITLE
feat: add built-in non-destructive audio editor

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -557,6 +557,9 @@ export type EditorPostMessages =
                 channels?: number; // 1 = mono, 2 = stereo
                 durationSec?: number; // seconds (float)
                 bitrateKbps?: number; // approximate kbps
+                derivedFromAudioId?: string;
+                editOperation?: "timeline";
+                clipCount?: number;
             };
         };
     }
@@ -2485,6 +2488,15 @@ type EditorReceiveMessages =
                         sampleRate?: number;
                         channels?: number;
                         bitrateKbps?: number;
+                        derivedFromAudioId?: string;
+                        editOperation?: "trim" | "timeline";
+                        trimStartSec?: number;
+                        trimEndSec?: number;
+                        clipCount?: number;
+                        gainDb?: number;
+                        normalized?: boolean;
+                        fadeInSec?: number;
+                        fadeOutSec?: number;
                     };
                 };
             }>;

--- a/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/AudioWaveformWithTranscription.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { CustomWaveformCanvas } from "./CustomWaveformCanvas.tsx";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
-import { MessageCircle, Copy, Loader2, Trash2, History, Mic, MicOff, Settings as SettingsIcon } from "lucide-react";
+import { MessageCircle, Copy, Loader2, Trash2, History, Mic, MicOff, Scissors, Settings as SettingsIcon } from "lucide-react";
 import type { ValidationStatusIconProps } from "./AudioValidationStatusIcon.tsx";
 import { AudioValidationBadge } from "./AudioValidationBadge.tsx";
 import type { AudioValidationPopoverProps } from "./AudioValidationBadge.tsx";
@@ -19,8 +19,11 @@ import {
     SelectValue,
 } from "../components/ui/select";
 import { Input } from "../components/ui/input";
+import { SimpleAudioEditorPanel } from "./audio-editor/SimpleAudioEditorPanel";
 
 interface AudioWaveformWithTranscriptionProps {
+    cellId?: string;
+    sourceAudioId?: string | null;
     audioUrl: string;
     audioBlob?: Blob | null;
     transcription?: {
@@ -65,11 +68,15 @@ interface AudioWaveformWithTranscriptionProps {
     noMicDetected?: boolean;
     /** Mic permission denied by the OS/browser. */
     micPermissionDenied?: boolean;
+    /** Prevents saving a new edited version, for example when the cell is locked. */
+    editDisabled?: boolean;
 }
 
 const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionProps> = ({
     audioUrl,
     audioBlob,
+    cellId,
+    sourceAudioId,
     transcription,
     isTranscribing,
     transcriptionProgress,
@@ -96,9 +103,11 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
     micUnavailable = false,
     noMicDetected = false,
     micPermissionDenied = false,
+    editDisabled = false,
 }) => {
     const [audioSrc, setAudioSrc] = useState<string>("");
     const [audioDuration, setAudioDuration] = useState<number | null>(null);
+    const [showAudioEditor, setShowAudioEditor] = useState(false);
 
     // The Script picker offers three "preset" choices plus a free-form 4-letter input for
     // power users (e.g. someone wants `swa_Cyrl` even though the resolver would never pick
@@ -136,6 +145,10 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
         }
         setAudioSrc("");
     }, [audioBlob, audioUrl]);
+
+    useEffect(() => {
+        setShowAudioEditor(false);
+    }, [sourceAudioId]);
 
     // Decode the audio blob to get its actual duration (best-effort).
     // Only needed when a target duration is supplied so we can render the comparison bar.
@@ -447,6 +460,23 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                     variant="outline"
                     size="sm"
                     className="h-8 px-2 text-xs"
+                    disabled={
+                        editDisabled ||
+                        !cellId ||
+                        !sourceAudioId ||
+                        !audioBlob ||
+                        !audioSrc
+                    }
+                    onClick={() => setShowAudioEditor((visible) => !visible)}
+                    title={editDisabled ? "Cannot edit audio: cell is locked" : "Trim audio"}
+                >
+                    <Scissors className="h-3 w-3" />
+                    <span className="ml-1">{showAudioEditor ? "Close editor" : "Edit"}</span>
+                </Button>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
                     onClick={() => onRequestRemove?.()}
                     title="Delete Audio"
                 >
@@ -504,6 +534,16 @@ const AudioWaveformWithTranscription: React.FC<AudioWaveformWithTranscriptionPro
                     <span className="ml-1">{micRecordLabel}</span>
                 </Button>
             </div>
+            {showAudioEditor && cellId && sourceAudioId && audioBlob && audioSrc && (
+                <SimpleAudioEditorPanel
+                    cellId={cellId}
+                    sourceAudioId={sourceAudioId}
+                    audioUrl={audioSrc}
+                    audioBlob={audioBlob}
+                    onClose={() => setShowAudioEditor(false)}
+                    onSaved={() => setShowAudioEditor(false)}
+                />
+            )}
         </div>
     );
 };

--- a/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/TextCellEditor.tsx
@@ -6053,6 +6053,8 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                         return (
                                             <div className="space-y-4">
                                                 <AudioWaveformWithTranscription
+                                                    cellId={cellMarkers[0]}
+                                                    sourceAudioId={currentSelectedAudioId}
                                                     audioUrl={audioUrl || ""}
                                                     audioBlob={audioBlob}
                                                     transcription={savedTranscription}
@@ -6071,6 +6073,7 @@ const CellEditor: React.FC<CellEditorProps> = ({
                                                     micUnavailable={micUnavailable}
                                                     noMicDetected={noMicDetected}
                                                     micPermissionDenied={micPermissionDenied}
+                                                    editDisabled={isCellLocked}
                                                     onShowRecorder={handleShowRecorder}
                                                     disabled={!audioBlob}
                                                     validationStatusProps={audioValidationIconProps}

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/audioEditModel.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/audioEditModel.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+    createAudioEditorClip,
+    deleteAudioTimelineRange,
+    getAudioEditorDuration,
+    insertAudioClipsAtTimelinePosition,
+    keepAudioTimelineRange,
+    locateAudioTimelinePosition,
+    splitClipRemovingSelection,
+    trimAudioEditorClip,
+} from "../audio-editor/audioEditModel";
+
+function clip(label = "Original", durationSec = 10) {
+    return createAudioEditorClip({
+        inputId: label,
+        label,
+        audioBlob: new Blob(["audio"]),
+        audioUrl: `blob:${label}`,
+        fileExtension: "webm",
+        durationSec,
+    });
+}
+
+describe("audioEditModel", () => {
+    it("trims a clip to the selected range", () => {
+        const trimmed = trimAudioEditorClip(clip(), { startSec: 2, endSec: 7 });
+        expect(trimmed.startSec).toBe(2);
+        expect(trimmed.endSec).toBe(7);
+    });
+
+    it("deletes a middle selection by splitting the clip", () => {
+        const pieces = splitClipRemovingSelection(clip(), { startSec: 3, endSec: 6 });
+        expect(pieces).toHaveLength(2);
+        expect(pieces.map((piece) => [piece.startSec, piece.endSec])).toEqual([
+            [0, 3],
+            [6, 10],
+        ]);
+        expect(pieces[0].inputId).toBe(pieces[1].inputId);
+    });
+
+    it("removes the entire clip when the full range is selected", () => {
+        expect(splitClipRemovingSelection(clip(), { startSec: 0, endSec: 10 })).toEqual([]);
+    });
+
+    it("adds the rendered duration of all clips", () => {
+        const first = { ...clip("first", 10), startSec: 2, endSec: 5 };
+        const second = { ...clip("second", 8), startSec: 1, endSec: 7 };
+        expect(getAudioEditorDuration([first, second])).toBe(9);
+    });
+
+    it("locates a playhead and inserts a clip by splitting the underlying source", () => {
+        const original = clip("original", 10);
+        const inserted = clip("inserted", 2);
+        const result = insertAudioClipsAtTimelinePosition([original], [inserted], 4);
+        expect(result.map((item) => item.label)).toEqual([
+            "original · left",
+            "inserted",
+            "original · right",
+        ]);
+        expect(result.map((item) => [item.startSec, item.endSec])).toEqual([
+            [0, 4],
+            [0, 2],
+            [4, 10],
+        ]);
+        expect(locateAudioTimelinePosition(result, 5)?.clipIndex).toBe(1);
+    });
+
+    it("deletes a global selection across clip boundaries", () => {
+        const result = deleteAudioTimelineRange(
+            [clip("first", 10), clip("second", 8)],
+            { startSec: 8, endSec: 12 }
+        );
+        expect(result.map((item) => [item.startSec, item.endSec])).toEqual([
+            [0, 8],
+            [2, 8],
+        ]);
+    });
+
+    it("deletes a selected range shorter than 0.10 seconds", () => {
+        const result = deleteAudioTimelineRange(
+            [clip()],
+            { startSec: 5.4, endSec: 5.49 }
+        );
+        expect(result.map((item) => [item.startSec, item.endSec])).toEqual([
+            [0, 5.4],
+            [5.49, 10],
+        ]);
+        expect(getAudioEditorDuration(result)).toBeCloseTo(9.91);
+    });
+
+    it("does not delete audio when the two pointers are equal", () => {
+        const original = clip();
+        expect(deleteAudioTimelineRange([original], { startSec: 5, endSec: 5 })).toEqual([original]);
+    });
+
+    it("preserves a remaining audio fragment shorter than 0.10 seconds", () => {
+        const result = deleteAudioTimelineRange(
+            [clip()],
+            { startSec: 0, endSec: 9.95 }
+        );
+        expect(result.map((item) => [item.startSec, item.endSec])).toEqual([[9.95, 10]]);
+    });
+
+    it("keeps a global selection across clip boundaries", () => {
+        const result = keepAudioTimelineRange(
+            [clip("first", 10), clip("second", 8)],
+            { startSec: 8, endSec: 12 }
+        );
+        expect(result.map((item) => [item.startSec, item.endSec])).toEqual([
+            [8, 10],
+            [0, 2],
+        ]);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/audioTrimMath.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/audioTrimMath.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+    formatAudioEditTime,
+    isWholeAudioSelected,
+    normalizeAudioTrimRange,
+    updateAudioTrimEnd,
+    updateAudioTrimStart,
+} from "../audio-editor/audioTrimMath";
+
+describe("audioTrimMath", () => {
+    it("orders and clamps slider values", () => {
+        expect(normalizeAudioTrimRange([8, -2], 10)).toEqual({ startSec: 0, endSec: 8 });
+        expect(normalizeAudioTrimRange([2, 20], 10)).toEqual({ startSec: 2, endSec: 10 });
+    });
+
+    it("keeps a minimum editable selection", () => {
+        expect(normalizeAudioTrimRange([5, 5.01], 10)).toEqual({ startSec: 5, endSec: 5.1 });
+        expect(normalizeAudioTrimRange([9.99, 10], 10)).toEqual({ startSec: 9.9, endSec: 10 });
+    });
+
+    it("allows a collapsed range when the minimum duration is zero", () => {
+        expect(normalizeAudioTrimRange([5, 5], 10, 0)).toEqual({ startSec: 5, endSec: 5 });
+        expect(updateAudioTrimStart(4, 4, 10, 0)).toEqual({ startSec: 4, endSec: 4 });
+        expect(updateAudioTrimEnd(4, 4, 10, 0)).toEqual({ startSec: 4, endSec: 4 });
+    });
+
+    it("constrains precise start and end edits", () => {
+        expect(updateAudioTrimStart(9, 4, 10)).toEqual({ startSec: 3.9, endSec: 4 });
+        expect(updateAudioTrimEnd(1, 3, 10)).toEqual({ startSec: 3, endSec: 3.1 });
+    });
+
+    it("detects an unchanged full-length selection", () => {
+        expect(isWholeAudioSelected({ startSec: 0, endSec: 10 }, 10)).toBe(true);
+        expect(isWholeAudioSelected({ startSec: 0.2, endSec: 10 }, 10)).toBe(false);
+    });
+
+    it("formats editor time with hundredths", () => {
+        expect(formatAudioEditTime(65.25)).toBe("1:05.25");
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/browserAudioRenderer.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/browserAudioRenderer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { encodeMonoPcmWav } from "../audio-editor/browserAudioRenderer";
+
+describe("browserAudioRenderer", () => {
+    it("encodes mono PCM samples with a valid WAV header", () => {
+        const bytes = encodeMonoPcmWav(new Float32Array([-1, 0, 1]), 44100);
+        const view = new DataView(bytes.buffer);
+        const text = (offset: number, length: number) =>
+            String.fromCharCode(...bytes.slice(offset, offset + length));
+
+        expect(text(0, 4)).toBe("RIFF");
+        expect(text(8, 4)).toBe("WAVE");
+        expect(text(36, 4)).toBe("data");
+        expect(view.getUint16(22, true)).toBe(1);
+        expect(view.getUint32(24, true)).toBe(44100);
+        expect(view.getUint32(40, true)).toBe(6);
+        expect(view.getInt16(44, true)).toBe(-32768);
+        expect(view.getInt16(46, true)).toBe(0);
+        expect(view.getInt16(48, true)).toBe(32767);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioEditHistory.test.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/__tests___/useAudioEditHistory.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useAudioEditHistory } from "../audio-editor/useAudioEditHistory";
+
+describe("useAudioEditHistory", () => {
+    it("undoes and redoes committed edits", () => {
+        const { result } = renderHook(() => useAudioEditHistory({ clips: 1 }));
+
+        act(() => result.current.commit({ clips: 2 }));
+        expect(result.current.value.clips).toBe(2);
+        expect(result.current.canUndo).toBe(true);
+
+        act(() => result.current.undo());
+        expect(result.current.value.clips).toBe(1);
+        expect(result.current.canRedo).toBe(true);
+
+        act(() => result.current.redo());
+        expect(result.current.value.clips).toBe(2);
+    });
+
+    it("replaces initialization data without adding an undo entry", () => {
+        const { result } = renderHook(() => useAudioEditHistory({ duration: 0 }));
+        act(() => result.current.replace({ duration: 10 }));
+        expect(result.current.value.duration).toBe(10);
+        expect(result.current.canUndo).toBe(false);
+    });
+
+    it("clears history when reset", () => {
+        const { result } = renderHook(() => useAudioEditHistory(1));
+        act(() => result.current.commit(2));
+        act(() => result.current.reset(5));
+        expect(result.current.value).toBe(5);
+        expect(result.current.canUndo).toBe(false);
+        expect(result.current.canRedo).toBe(false);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/AudioPointerTimeControl.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/AudioPointerTimeControl.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { Minus, Plus } from "lucide-react";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { formatAudioEditTime } from "./audioTrimMath";
+
+interface AudioPointerTimeControlProps {
+    label: string;
+    valueSec: number;
+    minSec: number;
+    maxSec: number;
+    colorClass: string;
+    disabled?: boolean;
+    onChange: (valueSec: number) => void;
+}
+
+const NUDGE_SEC = 0.01;
+
+/** Precise numeric control shared by the Start, End, and Insert pointers. */
+export function AudioPointerTimeControl({
+    label,
+    valueSec,
+    minSec,
+    maxSec,
+    colorClass,
+    disabled = false,
+    onChange,
+}: AudioPointerTimeControlProps) {
+    // Clamp keyboard edits and nudge buttons to the constraints of the active mode.
+    const clamp = (value: number) => Math.min(maxSec, Math.max(minSec, value));
+    const update = (value: number) => onChange(Number(clamp(value).toFixed(2)));
+
+    return (
+        <div className="rounded-md border border-[var(--vscode-panel-border)] bg-muted/20 p-2.5">
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <span className={`text-xs font-medium ${colorClass}`}>{label}</span>
+                <span className="font-mono text-sm font-semibold">{formatAudioEditTime(valueSec)}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8 shrink-0"
+                    disabled={disabled || valueSec <= minSec}
+                    onClick={() => update(valueSec - NUDGE_SEC)}
+                    title="Move backward by 0.01 seconds"
+                >
+                    <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <Input
+                    type="number"
+                    min={minSec}
+                    max={maxSec}
+                    step={NUDGE_SEC}
+                    value={valueSec.toFixed(2)}
+                    disabled={disabled}
+                    onChange={(event) => update(Number(event.target.value))}
+                    className="h-8 min-w-0 text-center font-mono"
+                    aria-label={`${label} in seconds`}
+                />
+                <span className="text-xs text-muted-foreground">sec</span>
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8 shrink-0"
+                    disabled={disabled || valueSec >= maxSec}
+                    onClick={() => update(valueSec + NUDGE_SEC)}
+                    title="Move forward by 0.01 seconds"
+                >
+                    <Plus className="h-3.5 w-3.5" />
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/SimpleAudioEditorPanel.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/SimpleAudioEditorPanel.tsx
@@ -1,0 +1,359 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FilePlus2, Loader2, Save, Scissors, Undo2, X, ZoomIn, ZoomOut } from "lucide-react";
+import type { EditorPostMessages } from "../../../../../types";
+import { Button } from "../../components/ui/button";
+import { useMessageHandler } from "../hooks/useCentralizedMessageDispatcher";
+import { AudioPointerTimeControl } from "./AudioPointerTimeControl";
+import { audioFileExtension, blobToDataUrl, decodeAudioDuration } from "./audioFileUtils";
+import {
+    MIN_AUDIO_CLIP_DURATION_SEC,
+    PRIMARY_AUDIO_INPUT_ID,
+    createAudioEditorClip,
+    deleteAudioTimelineRange,
+    getAudioEditorDuration,
+    insertAudioClipsAtTimelinePosition,
+    keepAudioTimelineRange,
+    type AudioEditorDraft,
+} from "./audioEditModel";
+import {
+    formatAudioEditTime,
+    normalizeAudioTrimRange,
+    updateAudioTrimEnd,
+    updateAudioTrimStart,
+    type AudioTrimRange,
+} from "./audioTrimMath";
+import { renderAudioClipsInBrowser } from "./browserAudioRenderer";
+import { SimpleAudioTimeline } from "./SimpleAudioTimeline";
+import { useAudioEditHistory } from "./useAudioEditHistory";
+
+type SimpleEditMode = "delete" | "insert" | "keep";
+
+interface SimpleAudioEditorPanelProps {
+    cellId: string;
+    sourceAudioId: string;
+    audioUrl: string;
+    audioBlob: Blob;
+    onClose: () => void;
+    onSaved?: (audioId: string) => void;
+}
+
+const makeId = (prefix: string): string =>
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+function createInitialDraft(audioBlob: Blob, audioUrl: string): AudioEditorDraft {
+    return {
+        clips: [createAudioEditorClip({
+            inputId: PRIMARY_AUDIO_INPUT_ID,
+            label: "Original audio",
+            audioBlob,
+            audioUrl,
+            fileExtension: "source",
+            durationSec: 0,
+            isPrimary: true,
+        })],
+    };
+}
+
+/**
+ * Focused editor for three operations: delete a range, keep a range, or insert
+ * one audio file. Rendering stays in the webview and saving uses the existing
+ * saveAudioAttachment message so the original attachment remains unchanged.
+ */
+export function SimpleAudioEditorPanel({
+    cellId,
+    sourceAudioId,
+    audioUrl,
+    audioBlob,
+    onClose,
+    onSaved,
+}: SimpleAudioEditorPanelProps) {
+    const initialDraft = useMemo(
+        () => createInitialDraft(audioBlob, audioUrl),
+        [audioBlob, audioUrl]
+    );
+    const { value: draft, commit, replace, reset, undo, canUndo } = useAudioEditHistory(initialDraft);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const ownedUrlsRef = useRef<Set<string>>(new Set());
+    const [mode, setMode] = useState<SimpleEditMode>("delete");
+    const [range, setRange] = useState<AudioTrimRange>({ startSec: 0, endSec: 0 });
+    const [insertTimeSec, setInsertTimeSec] = useState(0);
+    const [zoom, setZoom] = useState(1);
+    const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const durationSec = getAudioEditorDuration(draft.clips);
+    const disabled = pendingRequestId !== null;
+    const rangeDurationSec = Math.max(0, range.endSec - range.startSec);
+    // Delete mode may use a zero-width selection; Keep mode must remain playable.
+    const minimumPointerGapSec = mode === "delete" ? 0 : MIN_AUDIO_CLIP_DURATION_SEC;
+
+    // A new source attachment starts a fresh, full-length editing session.
+    useEffect(() => {
+        reset(initialDraft);
+        setMode("delete");
+        setRange({ startSec: 0, endSec: 0 });
+        setInsertTimeSec(0);
+        setError(null);
+    }, [initialDraft, reset, sourceAudioId]);
+
+    // Object URLs must remain alive for undo, then are released when the panel closes.
+    useEffect(() => {
+        const ownedUrls = ownedUrlsRef.current;
+        return () => {
+            ownedUrls.forEach((url) => URL.revokeObjectURL(url));
+            ownedUrls.clear();
+        };
+    }, []);
+
+    // Keep pointers valid whenever an insert, delete, keep, or undo changes duration.
+    useEffect(() => {
+        if (durationSec <= 0) return;
+        setRange((current) => normalizeAudioTrimRange([
+            Math.min(current.startSec, durationSec),
+            Math.min(current.endSec > 0 ? current.endSec : durationSec, durationSec),
+        ], durationSec, minimumPointerGapSec));
+        setInsertTimeSec((current) => Math.min(durationSec, Math.max(0, current)));
+    }, [durationSec, minimumPointerGapSec]);
+
+    useMessageHandler(
+        `simple-audio-editor-${cellId}-${sourceAudioId}`,
+        (event: MessageEvent) => {
+            const message = event.data;
+            if (
+                message?.type !== "audioAttachmentSaved" ||
+                message.content?.cellId !== cellId ||
+                !pendingRequestId ||
+                message.content?.requestId !== pendingRequestId
+            ) return;
+            setPendingRequestId(null);
+            if (message.content.success) onSaved?.(message.content.audioId);
+            else setError(message.content.error || "Could not save the edited audio.");
+        },
+        [cellId, onSaved, pendingRequestId, sourceAudioId]
+    );
+
+    const handleInputDuration = useCallback((inputId: string, decodedDuration: number) => {
+        if (!Number.isFinite(decodedDuration) || decodedDuration <= 0) return;
+        replace((current) => ({
+            ...current,
+            clips: current.clips.map((clip) =>
+                clip.inputId === inputId && clip.sourceDurationSec <= 0
+                    ? { ...clip, sourceDurationSec: decodedDuration, endSec: decodedDuration }
+                    : clip
+            ),
+        }));
+    }, [replace]);
+
+    const switchMode = (nextMode: SimpleEditMode) => {
+        setMode(nextMode);
+        // Expand a collapsed Delete selection before entering Keep mode.
+        if (nextMode !== "delete") {
+            setRange((current) => normalizeAudioTrimRange(
+                [current.startSec, current.endSec],
+                durationSec
+            ));
+        }
+        setError(null);
+    };
+
+    const deleteRange = () => {
+        const nextClips = deleteAudioTimelineRange(draft.clips, range);
+        const nextDuration = getAudioEditorDuration(nextClips);
+        if (nextDuration <= 0) {
+            setError("You cannot delete the entire recording. Move the pointers closer together.");
+            return;
+        }
+        commit({ ...draft, clips: nextClips });
+        setRange({ startSec: 0, endSec: nextDuration });
+        setInsertTimeSec(Math.min(range.startSec, nextDuration));
+        setError(null);
+    };
+
+    const keepRange = () => {
+        const nextClips = keepAudioTimelineRange(draft.clips, range);
+        const nextDuration = getAudioEditorDuration(nextClips);
+        if (nextDuration < MIN_AUDIO_CLIP_DURATION_SEC) {
+            setError("Keep at least 0.10 seconds between the two pointers.");
+            return;
+        }
+        commit({ ...draft, clips: nextClips });
+        setRange({ startSec: 0, endSec: nextDuration });
+        setInsertTimeSec(0);
+        setError(null);
+    };
+
+    const insertAudioFile = async (file: File) => {
+        try {
+            if (file.size > 50 * 1024 * 1024) throw new Error("The inserted audio must be 50 MB or smaller.");
+            const insertedDuration = await decodeAudioDuration(file);
+            const url = URL.createObjectURL(file);
+            ownedUrlsRef.current.add(url);
+            const clip = createAudioEditorClip({
+                inputId: makeId("inserted"),
+                label: file.name,
+                audioBlob: file,
+                audioUrl: url,
+                fileExtension: audioFileExtension(file.name, file.type),
+                durationSec: insertedDuration,
+            });
+            const nextClips = insertAudioClipsAtTimelinePosition(
+                draft.clips,
+                [clip],
+                insertTimeSec
+            );
+            commit({ ...draft, clips: nextClips });
+            setInsertTimeSec(insertTimeSec + insertedDuration);
+            setError(null);
+        } catch (insertError) {
+            setError(insertError instanceof Error ? insertError.message : "Could not insert this audio file.");
+        }
+    };
+
+    const saveNewVersion = async () => {
+        const requestId = makeId("browser-audio-edit-request");
+        setPendingRequestId(requestId);
+        setError(null);
+        try {
+            const rendered = await renderAudioClipsInBrowser(draft.clips);
+            const outputAudioId = makeId("audio-edit");
+            const dataUrl = await blobToDataUrl(new Blob([rendered.bytes], { type: "audio/wav" }));
+            const audioData = dataUrl.split(",")[1] ?? "";
+            // Reuse the provider's normal attachment save path; no FFmpeg command is sent.
+            window.vscodeApi.postMessage({
+                command: "saveAudioAttachment",
+                requestId,
+                content: {
+                    cellId,
+                    audioId: outputAudioId,
+                    audioData,
+                    fileExtension: "wav",
+                    metadata: {
+                        mimeType: "audio/wav",
+                        sizeBytes: rendered.bytes.length,
+                        sampleRate: rendered.sampleRate,
+                        channels: rendered.channels,
+                        bitrateKbps: rendered.bitrateKbps,
+                        durationSec: rendered.durationSec,
+                        derivedFromAudioId: sourceAudioId,
+                        editOperation: "timeline",
+                        clipCount: draft.clips.length,
+                    },
+                },
+            } as EditorPostMessages);
+        } catch (saveError) {
+            setPendingRequestId(null);
+            setError(saveError instanceof Error ? saveError.message : "Could not generate the edited audio.");
+        }
+    };
+
+    const rangeMode = mode !== "insert";
+    return (
+        <section className="mt-3 space-y-3 rounded-md border border-[var(--vscode-panel-border)] bg-[var(--vscode-editor-background)] p-3 sm:p-4">
+            <div className="flex items-start justify-between gap-3">
+                <div>
+                    <div className="flex items-center gap-2 text-sm font-semibold"><Scissors className="h-4 w-4" />Audio Editor</div>
+                    <p className="mt-1 text-xs text-muted-foreground">Choose an action, then drag the pointers on the waveform.</p>
+                </div>
+                <Button variant="ghost" size="icon" className="h-7 w-7" disabled={disabled} onClick={onClose}><X className="h-4 w-4" /></Button>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <Button variant={mode === "delete" ? "destructive" : "outline"} size="sm" onClick={() => switchMode("delete")}>Delete range</Button>
+                <Button variant={mode === "insert" ? "default" : "outline"} size="sm" onClick={() => switchMode("insert")}>Insert audio</Button>
+                <Button variant={mode === "keep" ? "default" : "outline"} size="sm" onClick={() => switchMode("keep")}>Keep range</Button>
+                <Button variant="outline" size="icon" className="h-8 w-8" disabled={!canUndo || disabled} onClick={() => { undo(); setError(null); }} title="Undo last edit"><Undo2 className="h-4 w-4" /></Button>
+                <div className="ml-auto flex items-center gap-1 text-xs text-muted-foreground">
+                    <span>Waveform</span>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setZoom((value) => Math.max(.75, value / 1.25))} title="Zoom out"><ZoomOut className="h-4 w-4" /></Button>
+                    <span className="w-10 text-center font-mono">{Math.round(zoom * 100)}%</span>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setZoom((value) => Math.min(8, value * 1.25))} title="Zoom in"><ZoomIn className="h-4 w-4" /></Button>
+                </div>
+            </div>
+
+            <SimpleAudioTimeline
+                clips={draft.clips}
+                mode={rangeMode ? "range" : "insert"}
+                range={range}
+                insertTimeSec={insertTimeSec}
+                zoom={zoom}
+                minimumRangeSec={minimumPointerGapSec}
+                disabled={disabled}
+                onRangeChange={(nextRange) => setRange(normalizeAudioTrimRange(
+                    [nextRange.startSec, nextRange.endSec],
+                    durationSec,
+                    minimumPointerGapSec
+                ))}
+                onInsertTimeChange={(timeSec) => setInsertTimeSec(Math.min(durationSec, Math.max(0, timeSec)))}
+                onZoomChange={setZoom}
+                onInputDuration={handleInputDuration}
+            />
+
+            {rangeMode ? (
+                <div className="grid gap-2 sm:grid-cols-2">
+                    <AudioPointerTimeControl
+                        label="Start pointer"
+                        valueSec={range.startSec}
+                        minSec={0}
+                        maxSec={Math.max(0, range.endSec - minimumPointerGapSec)}
+                        colorClass="text-sky-600 dark:text-sky-400"
+                        disabled={disabled}
+                        onChange={(value) => setRange(updateAudioTrimStart(
+                            value,
+                            range.endSec,
+                            durationSec,
+                            minimumPointerGapSec
+                        ))}
+                    />
+                    <AudioPointerTimeControl
+                        label="End pointer"
+                        valueSec={range.endSec}
+                        minSec={Math.min(durationSec, range.startSec + minimumPointerGapSec)}
+                        maxSec={durationSec}
+                        colorClass="text-blue-700 dark:text-blue-400"
+                        disabled={disabled}
+                        onChange={(value) => setRange(updateAudioTrimEnd(
+                            value,
+                            range.startSec,
+                            durationSec,
+                            minimumPointerGapSec
+                        ))}
+                    />
+                </div>
+            ) : (
+                <AudioPointerTimeControl
+                    label="Insert pointer"
+                    valueSec={insertTimeSec}
+                    minSec={0}
+                    maxSec={durationSec}
+                    colorClass="text-orange-600 dark:text-orange-400"
+                    disabled={disabled}
+                    onChange={(value) => setInsertTimeSec(Math.min(durationSec, Math.max(0, value)))}
+                />
+            )}
+
+            <div className="flex items-center justify-between gap-2 rounded-md border border-[var(--vscode-panel-border)] bg-muted/20 p-2.5">
+                <span className="text-xs text-muted-foreground">
+                    {rangeMode
+                        ? `Selected ${formatAudioEditTime(rangeDurationSec)}`
+                        : `Insert at ${formatAudioEditTime(insertTimeSec)}`}
+                </span>
+                <div className="flex shrink-0 items-center gap-2">
+                    {/* Delete accepts any positive-width selection; equal pointers contain no audio. */}
+                    {mode === "delete" && <Button variant="destructive" size="sm" disabled={disabled || rangeDurationSec <= 0} onClick={deleteRange}>Delete selected audio</Button>}
+                    {mode === "keep" && <Button size="sm" disabled={disabled || rangeDurationSec < MIN_AUDIO_CLIP_DURATION_SEC} onClick={keepRange}>Keep selected audio</Button>}
+                    {mode === "insert" && <Button size="sm" disabled={disabled} onClick={() => fileInputRef.current?.click()}><FilePlus2 className="mr-2 h-4 w-4" />Choose audio to insert</Button>}
+                    <Button size="sm" disabled={disabled || durationSec <= 0} onClick={() => void saveNewVersion()}>
+                        {disabled ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+                        {disabled ? "Generating..." : "Save as new version"}
+                    </Button>
+                </div>
+                <input ref={fileInputRef} type="file" accept="audio/*" className="hidden" onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    event.target.value = "";
+                    if (file) void insertAudioFile(file);
+                }} />
+            </div>
+
+            {error && <div className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>}
+        </section>
+    );
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/SimpleAudioTimeline.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/SimpleAudioTimeline.tsx
@@ -1,0 +1,298 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { decodeAudio, generatePeaks } from "../../utils/audioProcessing";
+import { getAudioEditorDuration, type AudioEditorClip } from "./audioEditModel";
+import { formatAudioEditTime, type AudioTrimRange } from "./audioTrimMath";
+
+type PointerMode = "range" | "insert";
+type DragTarget = "start" | "end" | "insert";
+
+interface SimpleAudioTimelineProps {
+    clips: AudioEditorClip[];
+    mode: PointerMode;
+    range: AudioTrimRange;
+    insertTimeSec: number;
+    zoom: number;
+    minimumRangeSec: number;
+    disabled?: boolean;
+    onRangeChange: (range: AudioTrimRange) => void;
+    onInsertTimeChange: (timeSec: number) => void;
+    onZoomChange: (zoom: number) => void;
+    onInputDuration: (inputId: string, durationSec: number) => void;
+}
+
+const HEIGHT = 198;
+const TRACK_TOP = 38;
+const TRACK_HEIGHT = 148;
+const BASE_PIXELS_PER_SECOND = 82;
+function tickInterval(pixelsPerSecond: number): number {
+    const minimum = 75 / Math.max(1, pixelsPerSecond);
+    return [0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60].find((value) => value >= minimum) ?? 120;
+}
+
+function drawMarker(
+    context: CanvasRenderingContext2D,
+    x: number,
+    canvasWidth: number,
+    color: string,
+    label: string,
+    align: "left" | "right"
+): void {
+    context.strokeStyle = color;
+    context.lineWidth = 2;
+    context.beginPath();
+    context.moveTo(x, 28);
+    context.lineTo(x, TRACK_TOP + TRACK_HEIGHT);
+    context.stroke();
+    context.fillStyle = color;
+    context.beginPath();
+    context.moveTo(x - 6, 28);
+    context.lineTo(x + 6, 28);
+    context.lineTo(x, 36);
+    context.closePath();
+    context.fill();
+
+    context.font = "600 11px sans-serif";
+    const width = context.measureText(label).width + 12;
+    const preferredX = align === "left" ? x + 5 : x - width - 5;
+    const labelX = Math.max(2, Math.min(canvasWidth - width - 2, preferredX));
+    context.fillRect(labelX, 3, width, 21);
+    context.fillStyle = "white";
+    context.textBaseline = "middle";
+    context.fillText(label, labelX + 6, 13.5);
+}
+
+/**
+ * Canvas timeline that draws waveform peaks and either two range pointers or
+ * one insert pointer. Pointer edits use global timeline seconds, not source time.
+ */
+export function SimpleAudioTimeline({
+    clips,
+    mode,
+    range,
+    insertTimeSec,
+    zoom,
+    minimumRangeSec,
+    disabled = false,
+    onRangeChange,
+    onInsertTimeChange,
+    onZoomChange,
+    onInputDuration,
+}: SimpleAudioTimelineProps) {
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const dragTargetRef = useRef<DragTarget | null>(null);
+    const zoomAnchorRef = useRef<{ timeSec: number; viewportX: number } | null>(null);
+    const onInputDurationRef = useRef(onInputDuration);
+    const wheelStateRef = useRef({ disabled, onZoomChange, pixelsPerSecond: 1, zoom });
+    const [viewportWidth, setViewportWidth] = useState(640);
+    const [peaksByInput, setPeaksByInput] = useState<Map<string, number[]>>(new Map());
+    const durationSec = getAudioEditorDuration(clips);
+    const pixelsPerSecond = BASE_PIXELS_PER_SECOND * Math.min(8, Math.max(0.75, zoom));
+    const canvasWidth = Math.min(30000, Math.max(viewportWidth - 2, durationSec * pixelsPerSecond));
+    onInputDurationRef.current = onInputDuration;
+    wheelStateRef.current = { disabled, onZoomChange, pixelsPerSecond, zoom };
+
+    // Split clips can share a Blob, so waveform decoding is keyed by input ID.
+    const uniqueInputs = useMemo(() => {
+        const inputs = new Map<string, Blob>();
+        clips.forEach((clip) => inputs.set(clip.inputId, clip.audioBlob));
+        return [...inputs.entries()];
+    }, [clips]);
+    const inputSignature = uniqueInputs
+        .map(([inputId, blob]) => `${inputId}:${blob.size}:${blob.type}`)
+        .join("|");
+
+    // Track the visible width so short recordings still fill the editor panel.
+    useEffect(() => {
+        const viewport = viewportRef.current;
+        if (!viewport) return;
+        const update = () => setViewportWidth(Math.max(320, viewport.clientWidth));
+        update();
+        const observer = new ResizeObserver(update);
+        observer.observe(viewport);
+        return () => observer.disconnect();
+    }, []);
+
+    // Keep Ctrl+wheel zoom centered on the time currently under the mouse.
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const handleWheel = (event: WheelEvent) => {
+            const state = wheelStateRef.current;
+            if (!event.ctrlKey || state.disabled) return;
+            event.preventDefault();
+            const viewport = viewportRef.current;
+            if (viewport) {
+                const rect = viewport.getBoundingClientRect();
+                const viewportX = event.clientX - rect.left;
+                zoomAnchorRef.current = {
+                    timeSec: (viewport.scrollLeft + viewportX) / state.pixelsPerSecond,
+                    viewportX,
+                };
+            }
+            const factor = event.deltaY > 0 ? 0.9 : 1.1;
+            state.onZoomChange(Math.min(8, Math.max(0.75, state.zoom * factor)));
+        };
+        // A non-passive listener prevents the surrounding webview from zooming.
+        canvas.addEventListener("wheel", handleWheel, { passive: false });
+        return () => canvas.removeEventListener("wheel", handleWheel);
+    }, []);
+
+    // Reapply the mouse-time anchor after React has rendered the new canvas width.
+    useEffect(() => {
+        const viewport = viewportRef.current;
+        const anchor = zoomAnchorRef.current;
+        if (!viewport || !anchor) return;
+        viewport.scrollLeft = Math.max(0, anchor.timeSec * pixelsPerSecond - anchor.viewportX);
+        zoomAnchorRef.current = null;
+    }, [pixelsPerSecond]);
+
+    // Decode waveform peaks only when the underlying source inputs change.
+    useEffect(() => {
+        let cancelled = false;
+        void Promise.all(uniqueInputs.map(async ([inputId, blob]) => {
+            const bytes = await blob.arrayBuffer();
+            const buffer = await decodeAudio(bytes.slice(0));
+            onInputDurationRef.current(inputId, buffer.duration);
+            const raw = generatePeaks(buffer, 2400);
+            const maximum = Math.max(0.01, ...raw);
+            return [inputId, raw.map((peak) => peak / maximum)] as const;
+        })).then((entries) => {
+            if (!cancelled) setPeaksByInput(new Map(entries));
+        }).catch((error) => {
+            console.warn("[SimpleAudioTimeline] Unable to decode waveform:", error);
+        });
+        return () => { cancelled = true; };
+        // The signature changes only when an underlying audio input changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [inputSignature]);
+
+    // Redraw scale, waveform, selection shading, and pointer labels as one canvas.
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const context = canvas?.getContext("2d");
+        if (!canvas || !context) return;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.max(1, Math.floor(canvasWidth * dpr));
+        canvas.height = Math.floor(HEIGHT * dpr);
+        context.setTransform(dpr, 0, 0, dpr, 0, 0);
+        context.clearRect(0, 0, canvasWidth, HEIGHT);
+
+        context.fillStyle = "rgba(127,127,127,.06)";
+        context.fillRect(0, TRACK_TOP, canvasWidth, TRACK_HEIGHT);
+        const interval = tickInterval(pixelsPerSecond);
+        context.font = "10px sans-serif";
+        context.textBaseline = "top";
+        for (let second = 0; second <= durationSec; second += interval) {
+            const x = second * pixelsPerSecond;
+            context.strokeStyle = "rgba(127,127,127,.22)";
+            context.beginPath();
+            context.moveTo(x, TRACK_TOP);
+            context.lineTo(x, TRACK_TOP + TRACK_HEIGHT);
+            context.stroke();
+            context.fillStyle = "rgba(127,127,127,.85)";
+            context.fillText(formatAudioEditTime(second), x + 3, TRACK_TOP + 3);
+        }
+
+        let globalStart = 0;
+        clips.forEach((clip) => {
+            const clipDuration = Math.max(0, clip.endSec - clip.startSec);
+            const clipX = globalStart * pixelsPerSecond;
+            const clipWidth = Math.max(1, clipDuration * pixelsPerSecond);
+            const peaks = peaksByInput.get(clip.inputId) ?? [];
+            const bars = Math.max(1, Math.floor(clipWidth / 2));
+            for (let bar = 0; bar < bars; bar++) {
+                const ratio = bar / bars;
+                const sourceTime = clip.startSec + ratio * clipDuration;
+                const peakIndex = Math.min(
+                    peaks.length - 1,
+                    Math.max(0, Math.floor(sourceTime / Math.max(clip.sourceDurationSec, .001) * peaks.length))
+                );
+                const barHeight = Math.max(2, (peaks[peakIndex] ?? 0) * (TRACK_HEIGHT - 30));
+                context.fillStyle = "rgba(37,99,235,.9)";
+                context.fillRect(
+                    clipX + ratio * clipWidth,
+                    TRACK_TOP + (TRACK_HEIGHT - barHeight) / 2,
+                    1.25,
+                    barHeight
+                );
+            }
+            globalStart += clipDuration;
+        });
+
+        if (mode === "range") {
+            const startX = range.startSec * pixelsPerSecond;
+            const endX = range.endSec * pixelsPerSecond;
+            context.fillStyle = "rgba(59,130,246,.15)";
+            context.fillRect(startX, TRACK_TOP, Math.max(0, endX - startX), TRACK_HEIGHT);
+            context.fillStyle = "rgba(15,23,42,.14)";
+            context.fillRect(0, TRACK_TOP, startX, TRACK_HEIGHT);
+            context.fillRect(endX, TRACK_TOP, Math.max(0, canvasWidth - endX), TRACK_HEIGHT);
+            drawMarker(context, startX, canvasWidth, "#0284c7", `Start ${formatAudioEditTime(range.startSec)}`, "left");
+            drawMarker(context, endX, canvasWidth, "#2563eb", `End ${formatAudioEditTime(range.endSec)}`, "right");
+        } else {
+            const insertX = insertTimeSec * pixelsPerSecond;
+            drawMarker(context, insertX, canvasWidth, "#ea580c", `Insert ${formatAudioEditTime(insertTimeSec)}`, "left");
+        }
+    }, [canvasWidth, clips, durationSec, insertTimeSec, mode, peaksByInput, pixelsPerSecond, range]);
+
+    const pointerTime = (event: React.PointerEvent<HTMLCanvasElement>) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        return Math.min(durationSec, Math.max(0, (event.clientX - rect.left) / pixelsPerSecond));
+    };
+
+    const updatePointer = (target: DragTarget, timeSec: number) => {
+        if (target === "insert") {
+            onInsertTimeChange(timeSec);
+        } else if (target === "start") {
+            onRangeChange({
+                startSec: Math.min(timeSec, Math.max(0, range.endSec - minimumRangeSec)),
+                endSec: range.endSec,
+            });
+        } else {
+            onRangeChange({
+                startSec: range.startSec,
+                endSec: Math.max(timeSec, Math.min(durationSec, range.startSec + minimumRangeSec)),
+            });
+        }
+    };
+
+    return (
+        <div className="space-y-1.5">
+            <div ref={viewportRef} className="w-full overflow-x-auto rounded-md border border-[var(--vscode-panel-border)] bg-[var(--vscode-editor-background)]">
+                <canvas
+                    ref={canvasRef}
+                    className={`block select-none ${disabled ? "cursor-not-allowed opacity-60" : "cursor-ew-resize"}`}
+                    style={{ width: canvasWidth, height: HEIGHT, touchAction: "none" }}
+                    aria-label={mode === "range" ? "Drag the start and end pointers to select an audio range" : "Drag the insert pointer to choose an insertion position"}
+                    onPointerDown={(event) => {
+                        if (disabled || durationSec <= 0) return;
+                        const timeSec = pointerTime(event);
+                        let target: DragTarget = "insert";
+                        if (mode === "range") {
+                            // Clicking the waveform moves whichever range pointer is closer.
+                            target = Math.abs(timeSec - range.startSec) <= Math.abs(timeSec - range.endSec)
+                                ? "start"
+                                : "end";
+                        }
+                        dragTargetRef.current = target;
+                        event.currentTarget.setPointerCapture(event.pointerId);
+                        updatePointer(target, timeSec);
+                    }}
+                    onPointerMove={(event) => {
+                        if (!dragTargetRef.current || disabled) return;
+                        updatePointer(dragTargetRef.current, pointerTime(event));
+                    }}
+                    onPointerUp={(event) => {
+                        dragTargetRef.current = null;
+                        event.currentTarget.releasePointerCapture(event.pointerId);
+                    }}
+                />
+            </div>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                <span>{mode === "range" ? "Drag the blue pointers or click the waveform · Ctrl + mouse wheel to zoom" : "Drag the orange pointer or click the waveform · Ctrl + mouse wheel to zoom"}</span>
+                <span className="font-mono">Total {formatAudioEditTime(durationSec)}</span>
+            </div>
+        </div>
+    );
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioEditModel.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioEditModel.ts
@@ -1,0 +1,255 @@
+import type { AudioTrimRange } from "./audioTrimMath";
+
+/** Minimum duration enforced by Keep mode and near-edge insertion handling. */
+export const MIN_AUDIO_CLIP_DURATION_SEC = 0.1;
+/** Stable input ID used for the attachment that was already present in the cell. */
+export const PRIMARY_AUDIO_INPUT_ID = "primary";
+
+/** A non-destructive slice of an underlying audio Blob on the edited timeline. */
+export interface AudioEditorClip {
+    id: string;
+    inputId: string;
+    label: string;
+    audioBlob: Blob;
+    audioUrl: string;
+    fileExtension: string;
+    sourceDurationSec: number;
+    startSec: number;
+    endSec: number;
+    isPrimary: boolean;
+}
+
+/** Complete non-destructive state stored by the editor's undo history. */
+export interface AudioEditorDraft {
+    clips: AudioEditorClip[];
+}
+
+const createClipId = (prefix: string): string =>
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/** Creates a full-length timeline clip for an original or inserted audio input. */
+export function createAudioEditorClip(options: {
+    inputId: string;
+    label: string;
+    audioBlob: Blob;
+    audioUrl: string;
+    fileExtension: string;
+    durationSec: number;
+    isPrimary?: boolean;
+}): AudioEditorClip {
+    return {
+        id: createClipId("clip"),
+        inputId: options.inputId,
+        label: options.label,
+        audioBlob: options.audioBlob,
+        audioUrl: options.audioUrl,
+        fileExtension: options.fileExtension,
+        sourceDurationSec: options.durationSec,
+        startSec: 0,
+        endSec: options.durationSec,
+        isPrimary: options.isPrimary ?? false,
+    };
+}
+
+/** Narrows a clip to the source-time interval covered by a selection. */
+export function trimAudioEditorClip(
+    clip: AudioEditorClip,
+    selection: AudioTrimRange
+): AudioEditorClip {
+    const startSec = Math.max(clip.startSec, selection.startSec);
+    const endSec = Math.min(clip.endSec, selection.endSec);
+    if (endSec - startSec < MIN_AUDIO_CLIP_DURATION_SEC) return clip;
+    return { ...clip, startSec, endSec };
+}
+
+/**
+ * Removes a source-time interval from one clip and returns the remaining left
+ * and right pieces. Both pieces continue to reference the same source Blob.
+ */
+export function splitClipRemovingSelection(
+    clip: AudioEditorClip,
+    selection: AudioTrimRange
+): AudioEditorClip[] {
+    const removeStart = Math.max(clip.startSec, selection.startSec);
+    const removeEnd = Math.min(clip.endSec, selection.endSec);
+    // Delete accepts every positive-width selection, including ranges below 0.10 seconds.
+    if (removeEnd <= removeStart) return [clip];
+
+    const result: AudioEditorClip[] = [];
+    if (removeStart > clip.startSec) {
+        result.push({
+            ...clip,
+            id: createClipId("clip-left"),
+            label: `${clip.label} · left`,
+            endSec: removeStart,
+        });
+    }
+    if (clip.endSec > removeEnd) {
+        result.push({
+            ...clip,
+            id: createClipId("clip-right"),
+            label: `${clip.label} · right`,
+            startSec: removeEnd,
+        });
+    }
+    return result;
+}
+
+/** Returns the sum of every visible clip duration on the edited timeline. */
+export const getAudioEditorDuration = (clips: AudioEditorClip[]): number =>
+    clips.reduce((total, clip) => total + Math.max(0, clip.endSec - clip.startSec), 0);
+
+export interface AudioTimelinePosition {
+    clipIndex: number;
+    globalClipStartSec: number;
+    sourceTimeSec: number;
+}
+
+/** Maps a global timeline time to a clip and its source-audio time. */
+export function locateAudioTimelinePosition(
+    clips: AudioEditorClip[],
+    timelineTimeSec: number
+): AudioTimelinePosition | null {
+    if (clips.length === 0) return null;
+    const totalDuration = getAudioEditorDuration(clips);
+    const target = Math.min(totalDuration, Math.max(0, timelineTimeSec));
+    let globalClipStartSec = 0;
+
+    for (let clipIndex = 0; clipIndex < clips.length; clipIndex++) {
+        const clip = clips[clipIndex];
+        const clipDuration = Math.max(0, clip.endSec - clip.startSec);
+        const isLast = clipIndex === clips.length - 1;
+        if (target < globalClipStartSec + clipDuration || isLast) {
+            const offset = Math.min(clipDuration, Math.max(0, target - globalClipStartSec));
+            return {
+                clipIndex,
+                globalClipStartSec,
+                sourceTimeSec: clip.startSec + offset,
+            };
+        }
+        globalClipStartSec += clipDuration;
+    }
+    return null;
+}
+
+/** Returns the global timeline time at which a clip begins. */
+export function getAudioClipGlobalStart(
+    clips: AudioEditorClip[],
+    clipIndex: number
+): number {
+    return clips
+        .slice(0, Math.max(0, clipIndex))
+        .reduce((total, clip) => total + Math.max(0, clip.endSec - clip.startSec), 0);
+}
+
+/**
+ * Inserts clips at a global timeline position. When the position is inside an
+ * existing clip, that clip is split non-destructively around the insertion.
+ */
+export function insertAudioClipsAtTimelinePosition(
+    clips: AudioEditorClip[],
+    additions: AudioEditorClip[],
+    timelineTimeSec: number
+): AudioEditorClip[] {
+    if (clips.length === 0) return [...additions];
+    const located = locateAudioTimelinePosition(clips, timelineTimeSec);
+    if (!located) return [...clips, ...additions];
+    const clip = clips[located.clipIndex];
+    const offset = located.sourceTimeSec - clip.startSec;
+    const clipDuration = clip.endSec - clip.startSec;
+
+    if (offset < MIN_AUDIO_CLIP_DURATION_SEC) {
+        return [
+            ...clips.slice(0, located.clipIndex),
+            ...additions,
+            ...clips.slice(located.clipIndex),
+        ];
+    }
+    if (clipDuration - offset < MIN_AUDIO_CLIP_DURATION_SEC) {
+        return [
+            ...clips.slice(0, located.clipIndex + 1),
+            ...additions,
+            ...clips.slice(located.clipIndex + 1),
+        ];
+    }
+
+    const left: AudioEditorClip = {
+        ...clip,
+        id: createClipId("clip-left"),
+        label: `${clip.label} · left`,
+        endSec: located.sourceTimeSec,
+    };
+    const right: AudioEditorClip = {
+        ...clip,
+        id: createClipId("clip-right"),
+        label: `${clip.label} · right`,
+        startSec: located.sourceTimeSec,
+    };
+    return [
+        ...clips.slice(0, located.clipIndex),
+        left,
+        ...additions,
+        right,
+        ...clips.slice(located.clipIndex + 1),
+    ];
+}
+
+/** Removes one global range, including ranges that cross clip boundaries. */
+export function deleteAudioTimelineRange(
+    clips: AudioEditorClip[],
+    selection: AudioTrimRange
+): AudioEditorClip[] {
+    const startSec = Math.min(selection.startSec, selection.endSec);
+    const endSec = Math.max(selection.startSec, selection.endSec);
+    if (endSec <= startSec) return clips;
+
+    const result: AudioEditorClip[] = [];
+    let globalClipStart = 0;
+    for (const clip of clips) {
+        const clipDuration = Math.max(0, clip.endSec - clip.startSec);
+        const globalClipEnd = globalClipStart + clipDuration;
+        const overlapStart = Math.max(startSec, globalClipStart);
+        const overlapEnd = Math.min(endSec, globalClipEnd);
+        if (overlapEnd <= overlapStart) {
+            result.push(clip);
+        } else {
+            result.push(
+                ...splitClipRemovingSelection(clip, {
+                    startSec: clip.startSec + overlapStart - globalClipStart,
+                    endSec: clip.startSec + overlapEnd - globalClipStart,
+                })
+            );
+        }
+        globalClipStart = globalClipEnd;
+    }
+    return result;
+}
+
+/** Keeps only one global range, including portions from multiple clips. */
+export function keepAudioTimelineRange(
+    clips: AudioEditorClip[],
+    selection: AudioTrimRange
+): AudioEditorClip[] {
+    const startSec = Math.min(selection.startSec, selection.endSec);
+    const endSec = Math.max(selection.startSec, selection.endSec);
+    if (endSec - startSec < MIN_AUDIO_CLIP_DURATION_SEC) return clips;
+
+    const result: AudioEditorClip[] = [];
+    let globalClipStart = 0;
+    for (const clip of clips) {
+        const clipDuration = Math.max(0, clip.endSec - clip.startSec);
+        const globalClipEnd = globalClipStart + clipDuration;
+        const overlapStart = Math.max(startSec, globalClipStart);
+        const overlapEnd = Math.min(endSec, globalClipEnd);
+        if (overlapEnd - overlapStart >= MIN_AUDIO_CLIP_DURATION_SEC) {
+            result.push(
+                trimAudioEditorClip(clip, {
+                    startSec: clip.startSec + overlapStart - globalClipStart,
+                    endSec: clip.startSec + overlapEnd - globalClipStart,
+                })
+            );
+        }
+        globalClipStart = globalClipEnd;
+    }
+    return result;
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioFileUtils.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioFileUtils.ts
@@ -1,0 +1,40 @@
+const ALLOWED_AUDIO_EXTENSIONS = new Set(["webm", "wav", "mp3", "m4a", "ogg", "aac", "flac"]);
+
+/** Resolves a safe extension from the file name, then falls back to its MIME type. */
+export function audioFileExtension(fileName: string, mimeType: string): string {
+    const named = fileName.split(".").pop()?.toLowerCase();
+    if (named && ALLOWED_AUDIO_EXTENSIONS.has(named)) return named;
+    if (mimeType.includes("wav")) return "wav";
+    if (mimeType.includes("mpeg")) return "mp3";
+    if (mimeType.includes("mp4") || mimeType.includes("m4a")) return "m4a";
+    if (mimeType.includes("ogg")) return "ogg";
+    return "webm";
+}
+
+/** Decodes only enough metadata to obtain an inserted file's playable duration. */
+export async function decodeAudioDuration(audioBlob: Blob): Promise<number> {
+    const AudioContextClass = window.AudioContext ||
+        (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) throw new Error("Audio decoding is not available.");
+    const context = new AudioContextClass();
+    try {
+        const bytes = await audioBlob.arrayBuffer();
+        const decoded = await context.decodeAudioData(bytes.slice(0));
+        if (!Number.isFinite(decoded.duration) || decoded.duration <= 0) {
+            throw new Error("The audio file has no playable duration.");
+        }
+        return decoded.duration;
+    } finally {
+        await context.close().catch(() => undefined);
+    }
+}
+
+/** Converts a Blob to a data URL for transport through the existing webview protocol. */
+export function blobToDataUrl(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onerror = () => reject(new Error("Could not read the added audio file."));
+        reader.onload = () => resolve(String(reader.result ?? ""));
+        reader.readAsDataURL(blob);
+    });
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioTrimMath.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/audioTrimMath.ts
@@ -1,0 +1,96 @@
+/** Default minimum range used when an operation must produce playable audio. */
+export const MIN_AUDIO_TRIM_DURATION_SEC = 0.1;
+
+export interface AudioTrimRange {
+    startSec: number;
+    endSec: number;
+}
+
+const finiteOr = (value: number, fallback: number): number =>
+    Number.isFinite(value) ? value : fallback;
+
+/** Clamps an arbitrary time value to the inclusive audio duration. */
+export const clampAudioTime = (value: number, durationSec: number): number => {
+    const duration = Math.max(0, finiteOr(durationSec, 0));
+    return Math.min(duration, Math.max(0, finiteOr(value, 0)));
+};
+
+/**
+ * Orders and clamps two pointer values. Callers may pass a zero minimum to
+ * allow Start and End to overlap in Delete mode.
+ */
+export const normalizeAudioTrimRange = (
+    values: readonly number[],
+    durationSec: number,
+    minimumDurationSec = MIN_AUDIO_TRIM_DURATION_SEC
+): AudioTrimRange => {
+    const duration = Math.max(0, finiteOr(durationSec, 0));
+    if (duration === 0) return { startSec: 0, endSec: 0 };
+
+    const first = clampAudioTime(values[0] ?? 0, duration);
+    const second = clampAudioTime(values[1] ?? duration, duration);
+    let startSec = Math.min(first, second);
+    let endSec = Math.max(first, second);
+    const minimum = Math.min(Math.max(0, finiteOr(minimumDurationSec, 0)), duration);
+
+    if (endSec - startSec < minimum) {
+        if (startSec + minimum <= duration) {
+            endSec = startSec + minimum;
+        } else {
+            startSec = Math.max(0, endSec - minimum);
+        }
+    }
+
+    return { startSec, endSec };
+};
+
+/** Moves the Start pointer without allowing it to cross the End pointer. */
+export const updateAudioTrimStart = (
+    value: number,
+    currentEndSec: number,
+    durationSec: number,
+    minimumDurationSec = MIN_AUDIO_TRIM_DURATION_SEC
+): AudioTrimRange => {
+    const duration = Math.max(0, finiteOr(durationSec, 0));
+    const endSec = clampAudioTime(currentEndSec, duration);
+    const minimum = Math.min(Math.max(0, finiteOr(minimumDurationSec, 0)), duration);
+    const maximumStart = Math.max(0, endSec - minimum);
+    return {
+        startSec: Math.min(clampAudioTime(value, duration), maximumStart),
+        endSec,
+    };
+};
+
+/** Moves the End pointer without allowing it to cross the Start pointer. */
+export const updateAudioTrimEnd = (
+    value: number,
+    currentStartSec: number,
+    durationSec: number,
+    minimumDurationSec = MIN_AUDIO_TRIM_DURATION_SEC
+): AudioTrimRange => {
+    const duration = Math.max(0, finiteOr(durationSec, 0));
+    const startSec = clampAudioTime(currentStartSec, duration);
+    const minimum = Math.min(Math.max(0, finiteOr(minimumDurationSec, 0)), duration);
+    const minimumEnd = Math.min(duration, startSec + minimum);
+    return {
+        startSec,
+        endSec: Math.max(clampAudioTime(value, duration), minimumEnd),
+    };
+};
+
+/** Reports whether the pointers still cover the complete source duration. */
+export const isWholeAudioSelected = (
+    range: AudioTrimRange,
+    durationSec: number,
+    toleranceSec = 0.01
+): boolean =>
+    range.startSec <= toleranceSec &&
+    Math.abs(range.endSec - durationSec) <= toleranceSec;
+
+/** Formats seconds as M:SS.hh for pointer labels and precise controls. */
+export const formatAudioEditTime = (seconds: number): string => {
+    const safeSeconds = Math.max(0, finiteOr(seconds, 0));
+    const minutes = Math.floor(safeSeconds / 60);
+    const remainder = safeSeconds - minutes * 60;
+    return `${minutes}:${remainder.toFixed(2).padStart(5, "0")}`;
+};

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/browserAudioRenderer.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/browserAudioRenderer.ts
@@ -1,0 +1,130 @@
+import type { AudioEditorClip } from "./audioEditModel";
+
+export const BROWSER_AUDIO_SAMPLE_RATE = 44100;
+export const BROWSER_AUDIO_CHANNELS = 1;
+const MAX_WAV_BYTES = 200 * 1024 * 1024;
+
+export interface BrowserAudioRenderResult {
+    bytes: Uint8Array;
+    durationSec: number;
+    sampleRate: number;
+    channels: number;
+    bitrateKbps: number;
+}
+
+/** Writes an ASCII chunk identifier into a WAV DataView. */
+function writeAscii(view: DataView, offset: number, value: string): void {
+    for (let index = 0; index < value.length; index++) {
+        view.setUint8(offset + index, value.charCodeAt(index));
+    }
+}
+
+/** Writes the standard 44-byte PCM WAV header used by the saved attachment. */
+function writeWavHeader(view: DataView, sampleCount: number, sampleRate: number): void {
+    const dataSize = sampleCount * 2;
+    writeAscii(view, 0, "RIFF");
+    view.setUint32(4, 36 + dataSize, true);
+    writeAscii(view, 8, "WAVE");
+    writeAscii(view, 12, "fmt ");
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, BROWSER_AUDIO_CHANNELS, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true);
+    view.setUint16(32, 2, true);
+    view.setUint16(34, 16, true);
+    writeAscii(view, 36, "data");
+    view.setUint32(40, dataSize, true);
+}
+
+/** Encodes normalized mono floating-point samples as little-endian PCM16 WAV. */
+export function encodeMonoPcmWav(samples: Float32Array, sampleRate: number): Uint8Array {
+    const output = new ArrayBuffer(44 + samples.length * 2);
+    const view = new DataView(output);
+    writeWavHeader(view, samples.length, sampleRate);
+    for (let index = 0; index < samples.length; index++) {
+        const sample = Math.max(-1, Math.min(1, samples[index] ?? 0));
+        view.setInt16(44 + index * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+    }
+    return new Uint8Array(output);
+}
+
+/**
+ * Reads one mono sample at an arbitrary source time. Linear interpolation
+ * handles source files whose sample rate differs from the output sample rate.
+ */
+function readInterpolatedMonoSample(buffer: AudioBuffer, timeSec: number): number {
+    const sourceIndex = Math.max(0, timeSec * buffer.sampleRate);
+    const lower = Math.min(buffer.length - 1, Math.floor(sourceIndex));
+    const upper = Math.min(buffer.length - 1, lower + 1);
+    const fraction = sourceIndex - lower;
+    let mixed = 0;
+    for (let channel = 0; channel < buffer.numberOfChannels; channel++) {
+        const samples = buffer.getChannelData(channel);
+        mixed += (samples[lower] ?? 0) * (1 - fraction) + (samples[upper] ?? 0) * fraction;
+    }
+    return mixed / Math.max(1, buffer.numberOfChannels);
+}
+
+/**
+ * Decodes each unique source Blob with Web Audio, renders the non-destructive
+ * clip list in timeline order, and returns a WAV attachment without FFmpeg.
+ */
+export async function renderAudioClipsInBrowser(
+    clips: AudioEditorClip[]
+): Promise<BrowserAudioRenderResult> {
+    if (clips.length === 0) throw new Error("There is no audio to save.");
+    const durationSec = clips.reduce(
+        (total, clip) => total + Math.max(0, clip.endSec - clip.startSec),
+        0
+    );
+    const sampleCount = Math.ceil(durationSec * BROWSER_AUDIO_SAMPLE_RATE);
+    if (44 + sampleCount * 2 > MAX_WAV_BYTES) {
+        throw new Error("The edited audio is too long to export safely. Please edit it in shorter sections.");
+    }
+
+    const AudioContextClass = window.AudioContext ||
+        (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) throw new Error("This VS Code environment does not support built-in audio processing.");
+    const context = new AudioContextClass();
+    try {
+        // Decode each source once even when delete/insert operations split it into many clips.
+        const inputs = new Map<string, Blob>();
+        clips.forEach((clip) => inputs.set(clip.inputId, clip.audioBlob));
+        const decoded = new Map<string, AudioBuffer>();
+        await Promise.all([...inputs.entries()].map(async ([inputId, blob]) => {
+            const bytes = await blob.arrayBuffer();
+            decoded.set(inputId, await context.decodeAudioData(bytes.slice(0)));
+        }));
+
+        // Copy every source-time clip into one continuous output buffer.
+        const samples = new Float32Array(sampleCount);
+        let outputOffset = 0;
+        for (const clip of clips) {
+            const input = decoded.get(clip.inputId);
+            if (!input) throw new Error(`Could not read the inserted audio: ${clip.label}`);
+            const clipSamples = Math.max(
+                0,
+                Math.round((clip.endSec - clip.startSec) * BROWSER_AUDIO_SAMPLE_RATE)
+            );
+            for (let index = 0; index < clipSamples && outputOffset + index < samples.length; index++) {
+                const sourceTime = clip.startSec + index / BROWSER_AUDIO_SAMPLE_RATE;
+                samples[outputOffset + index] = readInterpolatedMonoSample(input, sourceTime);
+            }
+            outputOffset += clipSamples;
+        }
+
+        return {
+            bytes: encodeMonoPcmWav(samples, BROWSER_AUDIO_SAMPLE_RATE),
+            durationSec,
+            sampleRate: BROWSER_AUDIO_SAMPLE_RATE,
+            channels: BROWSER_AUDIO_CHANNELS,
+            bitrateKbps: Math.round(BROWSER_AUDIO_SAMPLE_RATE * 16 / 1000),
+        };
+    } catch (error) {
+        if (error instanceof Error && error.message.startsWith("Could not")) throw error;
+        throw new Error("Could not decode this audio format. Try a WAV, MP3, M4A, OGG, or WebM file.");
+    } finally {
+        await context.close().catch(() => undefined);
+    }
+}

--- a/webviews/codex-webviews/src/CodexCellEditor/audio-editor/useAudioEditHistory.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/audio-editor/useAudioEditHistory.ts
@@ -1,0 +1,83 @@
+import { useCallback, useState } from "react";
+
+interface HistoryState<T> {
+    past: T[];
+    present: T;
+    future: T[];
+}
+
+const MAX_HISTORY_ENTRIES = 50;
+
+/**
+ * Small immutable history store for non-destructive audio edits. `replace`
+ * updates decoded metadata without creating a user-visible undo step.
+ */
+export function useAudioEditHistory<T>(initialValue: T) {
+    const [history, setHistory] = useState<HistoryState<T>>({
+        past: [],
+        present: initialValue,
+        future: [],
+    });
+
+    const commit = useCallback((updater: T | ((current: T) => T)) => {
+        setHistory((current) => {
+            const next = typeof updater === "function"
+                ? (updater as (value: T) => T)(current.present)
+                : updater;
+            if (Object.is(next, current.present)) return current;
+            return {
+                past: [...current.past, current.present].slice(-MAX_HISTORY_ENTRIES),
+                present: next,
+                future: [],
+            };
+        });
+    }, []);
+
+    const replace = useCallback((updater: T | ((current: T) => T)) => {
+        setHistory((current) => ({
+            ...current,
+            present: typeof updater === "function"
+                ? (updater as (value: T) => T)(current.present)
+                : updater,
+        }));
+    }, []);
+
+    const reset = useCallback((value: T) => {
+        setHistory({ past: [], present: value, future: [] });
+    }, []);
+
+    const undo = useCallback(() => {
+        setHistory((current) => {
+            const previous = current.past[current.past.length - 1];
+            if (!previous) return current;
+            return {
+                past: current.past.slice(0, -1),
+                present: previous,
+                future: [current.present, ...current.future],
+            };
+        });
+    }, []);
+
+    const redo = useCallback(() => {
+        setHistory((current) => {
+            const next = current.future[0];
+            if (!next) return current;
+            return {
+                past: [...current.past, current.present].slice(-MAX_HISTORY_ENTRIES),
+                present: next,
+                future: current.future.slice(1),
+            };
+        });
+    }, []);
+
+    return {
+        value: history.present,
+        commit,
+        replace,
+        reset,
+        undo,
+        redo,
+        canUndo: history.past.length > 0,
+        canRedo: history.future.length > 0,
+    };
+}


### PR DESCRIPTION
## Summary

Adds a built-in, non-destructive audio editor to the Codex Cell Editor.

## Features

- Delete any selected audio range longer than zero seconds
- Keep audio inside a selected range
- Insert an audio file at a selected timeline position
- Drag Start, End, and Insert pointers directly on the waveform
- Precisely adjust pointer positions in 0.01-second increments
- Zoom the waveform with Ctrl + mouse wheel
- Undo delete, keep, and insert operations
- Save edited audio as a new WAV version
- Preserve the original recording
- No FFmpeg installation required

## Implementation

Audio decoding and rendering are handled inside the webview using the Web Audio API.

Edits are represented as non-destructive timeline clips. The original attachment is not modified, and a new WAV attachment is generated only when the user selects "Save as new version."

## Testing

- Extension build passed
- ESLint passed
- 1,276 extension tests passed
- Full webview test suite passed
- Added tests for:
  - Pointer range normalization
  - Equal Start and End pointers
  - Short-range deletion
  - Cross-clip deletion
  - Audio insertion
  - Browser WAV encoding
  - Undo history