### PR TITLE
ci: make macOS extension-tests non-blocking (upstream test-electron ENOENT)

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -52,8 +52,27 @@ jobs:
                   NODE_OPTIONS: --max_old_space_size=4096
               run: xvfb-run -a npm test
 
-            - name: Test (macOS/Windows)
-              if: runner.os != 'Linux'
+            - name: Test (Windows)
+              if: runner.os == 'Windows'
+              env:
+                  NODE_OPTIONS: --max_old_space_size=4096
+              run: npm test
+
+            # macOS is intentionally non-blocking for now. The VS Code test
+            # harness (@vscode/test-electron 2.x) fails to launch the downloaded
+            # darwin-arm64 build on GitHub's macos-latest runner:
+            #   Error: spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT
+            # This is an upstream harness/runner incompatibility (see
+            # microsoft/vscode-test#348), not a problem with the extension —
+            # lint + compile pass on macOS and the full test suite passes on
+            # Linux and Windows. `continue-on-error` keeps the job running (so
+            # the failure stays visible in logs and the leg self-heals once the
+            # upstream fix lands) while preventing it from blocking merges.
+            # Remove this once @vscode/test-electron is upgraded (requires
+            # Node >= 22) and the arm64 launch is fixed upstream.
+            - name: Test (macOS, non-blocking)
+              if: runner.os == 'macOS'
+              continue-on-error: true
               env:
                   NODE_OPTIONS: --max_old_space_size=4096
               run: npm test


### PR DESCRIPTION
## Summary
The `Node 20 • macos-latest` extension-tests check is failing on every PR (including #1121, #1105, #1117) — but it's **not a code problem**. The `@vscode/test-electron` 2.x harness downloads VS Code and then fails to launch it on GitHub's `macos-latest` (darwin-arm64) runner, **before any test executes**:

```
✔ Downloaded VS Code into .../vscode-darwin-arm64-1.132.0
Test error: Error: spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT
```

`lint` + `compile` pass on macOS, and the **full test suite passes on Linux and Windows**. This is an upstream harness/runner incompatibility ([microsoft/vscode-test#348](https://github.com/microsoft/vscode-test/issues/348)).

## Change
- Split the shared macOS/Windows test step so **Windows stays blocking**.
- Mark the **macOS** leg `continue-on-error: true` so it still runs (failures remain visible in the logs and the leg self-heals once fixed upstream) but no longer blocks merges.

## Why not bump `@vscode/test-electron`?
The fix lives in the 3.x line, which requires **Node >= 22**, restructures the `out/runTest` import this repo uses, and per the upstream bug may still `ENOENT` on darwin-arm64. That's a larger, coordinated toolchain change and belongs in its own PR. This unblocks all open PRs now with minimal risk.

## Revert criteria
Remove `continue-on-error` once `@vscode/test-electron` is upgraded (Node 22) and the arm64 launch is fixed upstream.

## Test plan
- [x] CI: `macos-latest` job reports green (step still runs; failure shown as "continued")
- [x] CI: `ubuntu-latest` and `windows-latest` still run and remain blocking