### PR TITLE
1116-kangri-project-episodes-206-207-and-208-missing-from-sync--request-to-recover-data

### DIFF
--- a/src/projectManager/utils/merge/fileDeletionGuard.ts
+++ b/src/projectManager/utils/merge/fileDeletionGuard.ts
@@ -1,0 +1,235 @@
+/**
+ * Guards against unintentional `.codex`/`.source` file deletions during sync
+ * (issue #1116: episodes deleted team-wide by a sync from a stale working tree).
+ *
+ * Intentional deletions made through the app are recorded in `metadata.json`
+ * edit history as `deletedFile` / `deletedCorpusMarker` project edits. Those
+ * records act as deletion tombstones:
+ *
+ * 1. Before sync commits local state, any tracked content file that is present
+ *    in git HEAD but missing from the working tree WITHOUT a tombstone is
+ *    restored from HEAD instead of being committed as a deletion.
+ * 2. During conflict resolution, a delete-vs-modify conflict on a content file
+ *    only resolves as "deleted" when a tombstone exists that is at least as
+ *    recent as the surviving content's latest edit. Otherwise the surviving
+ *    content is restored (mirroring the timestamp-based cell-level merge rules).
+ */
+import * as vscode from "vscode";
+import * as path from "path";
+import * as dugiteGit from "../../../utils/dugiteGit";
+
+export interface DeletionTombstone {
+    /** Path as recorded at deletion time (may be absolute from another machine). */
+    filePath: string;
+    /** Workspace-relative path, recorded by newer builds. */
+    relPath?: string;
+    /** When the deletion was recorded (ms epoch). */
+    timestamp: number;
+}
+
+const CONTENT_FILE_RULES = [
+    { prefix: "files/target/", suffix: ".codex" },
+    { prefix: ".project/sourceTexts/", suffix: ".source" },
+];
+
+function normalizePath(filepath: string): string {
+    return filepath.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+/**
+ * True for translation content files whose loss is unrecoverable user data:
+ * `files/target/*.codex` and `.project/sourceTexts/*.source`.
+ */
+export function isTrackedContentFile(filepath: string): boolean {
+    const normalized = normalizePath(filepath);
+    return CONTENT_FILE_RULES.some(
+        (rule) => normalized.startsWith(rule.prefix) && normalized.endsWith(rule.suffix)
+    );
+}
+
+/**
+ * Extracts deletion tombstones from one or more metadata.json contents
+ * (e.g. the local file plus both sides of a metadata.json conflict).
+ * Invalid JSON or unexpected shapes contribute nothing.
+ */
+export function collectDeletionTombstones(
+    ...metadataContents: Array<string | undefined>
+): DeletionTombstone[] {
+    const tombstones: DeletionTombstone[] = [];
+
+    const pushTombstone = (value: any, timestamp: number) => {
+        const filePath = value?.filePath;
+        if (typeof filePath !== "string" || filePath.length === 0) return;
+        const relPath = typeof value?.relPath === "string" ? value.relPath : undefined;
+        tombstones.push({ filePath, relPath, timestamp });
+    };
+
+    for (const content of metadataContents) {
+        if (!content) continue;
+        let metadata: any;
+        try {
+            metadata = JSON.parse(content);
+        } catch {
+            continue;
+        }
+
+        const edits = Array.isArray(metadata?.edits) ? metadata.edits : [];
+        for (const edit of edits) {
+            const editMap = Array.isArray(edit?.editMap) ? edit.editMap : [];
+            if (editMap.length !== 1) continue;
+            const timestamp = typeof edit?.timestamp === "number" ? edit.timestamp : 0;
+
+            if (editMap[0] === "deletedFile") {
+                pushTombstone(edit?.value, timestamp);
+            } else if (editMap[0] === "deletedCorpusMarker") {
+                const deletedFiles = Array.isArray(edit?.value?.deletedFiles)
+                    ? edit.value.deletedFiles
+                    : [];
+                for (const deletedFile of deletedFiles) {
+                    pushTombstone(deletedFile, timestamp);
+                }
+            }
+        }
+    }
+
+    return tombstones;
+}
+
+/**
+ * Returns the newest tombstone timestamp covering the given workspace-relative
+ * path, or undefined when no tombstone matches (i.e. no intentional deletion
+ * was ever recorded for it).
+ *
+ * Older builds recorded absolute machine-local paths, so matching falls back
+ * from exact/suffix path comparison to basename comparison. A `.source` file
+ * is matched via its paired `.codex` name — the delete flow removes the pair
+ * together but only records the codex path.
+ */
+export function findTombstoneTimestamp(
+    tombstones: DeletionTombstone[],
+    filepath: string
+): number | undefined {
+    const normalized = normalizePath(filepath);
+    const baseName = path.posix.basename(normalized);
+    const pairedCodexName = baseName.endsWith(".source")
+        ? baseName.slice(0, -".source".length) + ".codex"
+        : undefined;
+
+    let latest: number | undefined;
+    for (const tombstone of tombstones) {
+        const candidates = [tombstone.filePath, tombstone.relPath].filter(
+            (p): p is string => typeof p === "string" && p.length > 0
+        );
+        const matches = candidates.some((candidate) => {
+            const recorded = normalizePath(candidate);
+            if (recorded === normalized || recorded.endsWith("/" + normalized)) return true;
+            const recordedBase = path.posix.basename(recorded);
+            return recordedBase === baseName || recordedBase === pairedCodexName;
+        });
+        if (matches && (latest === undefined || tombstone.timestamp > latest)) {
+            latest = tombstone.timestamp;
+        }
+    }
+    return latest;
+}
+
+/**
+ * Latest edit activity (ms epoch) embedded in a `.codex`/`.source` notebook:
+ * the max over file-level and cell-level edit timestamps, including validation
+ * timestamps. Returns 0 for unparseable content or content with no edits.
+ */
+export function getLatestContentTimestamp(content: string): number {
+    let notebook: any;
+    try {
+        notebook = JSON.parse(content);
+    } catch {
+        return 0;
+    }
+
+    let latest = 0;
+    const considerEdits = (edits: any) => {
+        if (!Array.isArray(edits)) return;
+        for (const edit of edits) {
+            if (typeof edit?.timestamp === "number" && edit.timestamp > latest) {
+                latest = edit.timestamp;
+            }
+            const validatedBy = Array.isArray(edit?.validatedBy) ? edit.validatedBy : [];
+            for (const validation of validatedBy) {
+                if (
+                    typeof validation?.updatedTimestamp === "number" &&
+                    validation.updatedTimestamp > latest
+                ) {
+                    latest = validation.updatedTimestamp;
+                }
+            }
+        }
+    };
+
+    considerEdits(notebook?.metadata?.edits);
+    const cells = Array.isArray(notebook?.cells) ? notebook.cells : [];
+    for (const cell of cells) {
+        considerEdits(cell?.metadata?.edits);
+    }
+    return latest;
+}
+
+/** Reads the workspace's metadata.json content, or undefined when unreadable. */
+export async function readMetadataContent(workspaceDir: string): Promise<string | undefined> {
+    try {
+        const metadataUri = vscode.Uri.joinPath(vscode.Uri.file(workspaceDir), "metadata.json");
+        const bytes = await vscode.workspace.fs.readFile(metadataUri);
+        return new TextDecoder().decode(bytes);
+    } catch {
+        return undefined;
+    }
+}
+
+/** Git operations the pre-sync guard needs; injectable for tests. */
+export interface DeletionGuardGitOps {
+    statusMatrix: (dir: string) => Promise<Array<[string, 0 | 1 | 2, 0 | 1 | 2, 0 | 1 | 2]>>;
+    readBlobAtRef: (dir: string, ref: string, filepath: string) => Promise<Buffer>;
+}
+
+/**
+ * Pre-sync guard: finds tracked content files that exist in git HEAD but are
+ * missing from the working tree without a deletion tombstone, and restores
+ * them from HEAD so the upcoming stage-all commit cannot propagate the loss.
+ *
+ * Files covered by a tombstone are left deleted (intentional removals).
+ * Returns the workspace-relative paths of the files it restored.
+ */
+export async function restoreContentFilesMissingWithoutTombstone(
+    workspaceDir: string,
+    gitOps: DeletionGuardGitOps = dugiteGit
+): Promise<string[]> {
+    const matrix = await gitOps.statusMatrix(workspaceDir);
+    const missingFiles = matrix.filter(
+        ([filepath, head, workdir]) =>
+            head === 1 && workdir === 0 && isTrackedContentFile(filepath)
+    );
+    if (missingFiles.length === 0) return [];
+
+    const tombstones = collectDeletionTombstones(await readMetadataContent(workspaceDir));
+
+    const restored: string[] = [];
+    for (const [filepath] of missingFiles) {
+        if (findTombstoneTimestamp(tombstones, filepath) !== undefined) {
+            continue; // Intentionally deleted through the app — let the deletion sync.
+        }
+        try {
+            const blob = await gitOps.readBlobAtRef(workspaceDir, "HEAD", filepath);
+            const target = vscode.Uri.joinPath(
+                vscode.Uri.file(workspaceDir),
+                ...normalizePath(filepath).split("/")
+            );
+            await vscode.workspace.fs.writeFile(target, blob);
+            restored.push(filepath);
+        } catch (error) {
+            console.error(
+                `[Sync] Could not restore missing tracked file ${filepath} from HEAD:`,
+                error
+            );
+        }
+    }
+    return restored;
+}

--- a/src/projectManager/utils/merge/index.ts
+++ b/src/projectManager/utils/merge/index.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import * as dugiteGit from "../../../utils/dugiteGit";
 import { resolveConflictFiles } from "./resolvers";
+import { restoreContentFilesMissingWithoutTombstone } from "./fileDeletionGuard";
 import { getAuthApi } from "../../../extension";
 import { ConflictFile } from "./types";
 import { getFrontierVersionStatus } from "../../utils/versionChecks";
@@ -115,6 +116,28 @@ export async function stageAndCommitAllAndSync(
             return syncResult;
         }
 
+        // Deletion guard (issue #1116): the sync below stage-commits the whole
+        // working tree, so a tracked `.codex`/`.source` file missing from a stale
+        // tree would be committed — and propagated — as a deletion. Restore any
+        // such file from HEAD unless its deletion was intentionally recorded.
+        try {
+            const restoredFiles = await restoreContentFilesMissingWithoutTombstone(workspaceFolder);
+            if (restoredFiles.length > 0) {
+                console.warn(
+                    `[Sync] Restored ${restoredFiles.length} tracked file(s) missing from the working tree without a recorded deletion:`,
+                    restoredFiles
+                );
+                vscode.window.showWarningMessage(
+                    `${restoredFiles.length} translation file(s) were missing from your local project ` +
+                    `without a recorded deletion and were restored from your last sync to prevent data loss. ` +
+                    `To remove files permanently, delete them from the navigation panel.`
+                );
+            }
+        } catch (guardError) {
+            // The guard is best-effort; never block sync on it.
+            console.error("[Sync] File deletion guard failed:", guardError);
+        }
+
         const conflictsResponse = await authApi.syncChanges({ commitMessage });
         if (!conflictsResponse) {
             throw new Error("syncChanges returned an empty response — sync may not have completed");
@@ -191,6 +214,23 @@ export async function stageAndCommitAllAndSync(
             }
 
             const { resolved: resolvedFiles, failed: failedConflicts } = await resolveConflictFiles(conflicts, workspaceFolder);
+
+            // Reconcile with actual resolutions: a conflict flagged isDeleted may
+            // have been restored by the deletion guard. Downstream consumers treat
+            // deletedFiles as gone (e.g. closing their open editors), so restored
+            // files must be reported as changed instead.
+            const restoredPaths = new Set(
+                resolvedFiles
+                    .filter((f) => f.resolution === "created" || f.resolution === "modified")
+                    .map((f) => f.filepath)
+            );
+            const stillDeleted = syncResult.deletedFiles.filter((fp) => !restoredPaths.has(fp));
+            for (const fp of syncResult.deletedFiles) {
+                if (restoredPaths.has(fp)) {
+                    syncResult.changedFiles.push(fp);
+                }
+            }
+            syncResult.deletedFiles = stillDeleted;
 
             if (failedConflicts.length > 0) {
                 const failedList = failedConflicts

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -22,6 +22,14 @@ import {
     buildCellPositionContextMap,
     insertUniqueCellsPreservingRelativePositions,
 } from "./utils/positionPreservationUtils";
+import {
+    DeletionTombstone,
+    collectDeletionTombstones,
+    findTombstoneTimestamp,
+    getLatestContentTimestamp,
+    isTrackedContentFile,
+    readMetadataContent,
+} from "./fileDeletionGuard";
 import { reorderVerseRangeCells } from "./utils/verseRangeReorder";
 
 const DEBUG_MODE = false;
@@ -2579,6 +2587,26 @@ export async function resolveConflictFiles(
 
     const resolvedFiles: ResolvedFile[] = [];
     const failedFiles: Array<{ filepath: string; error: string }> = [];
+    // Content files flagged as deleted on one side but restored because the
+    // deletion wasn't intentionally recorded, or the surviving side has newer edits.
+    const restoredFromDeletion: string[] = [];
+
+    // Effective deletion tombstones: the local metadata.json plus any incoming
+    // copy that is part of this conflict batch (a deletion recorded remotely may
+    // not have reached the local metadata.json yet).
+    let deletionTombstones: DeletionTombstone[] = [];
+    try {
+        const metadataConflict = conflicts.find(
+            (c) => c?.filepath && c.filepath.replace(/\\/g, "/").replace(/^\/+/, "") === "metadata.json"
+        );
+        deletionTombstones = collectDeletionTombstones(
+            await readMetadataContent(workspaceDir),
+            metadataConflict?.ours,
+            metadataConflict?.theirs
+        );
+    } catch (error) {
+        console.warn("[Merge] Could not collect deletion tombstones:", error);
+    }
 
     await vscode.window.withProgress(
         {
@@ -2601,7 +2629,10 @@ export async function resolveConflictFiles(
             try {
                 const uniqueDirs = new Set<string>();
                 for (const conflict of conflicts) {
-                    if (!conflict || conflict.isDeleted) continue;
+                    if (!conflict) continue;
+                    // Deleted content files may be restored below, so their parent
+                    // directories must exist too; other deletions need no directory.
+                    if (conflict.isDeleted && !isTrackedContentFile(conflict.filepath)) continue;
                     const rel = conflict.filepath.replace(/\\/g, "/").replace(/^\/+/, "");
                     const dir = path.posix.dirname(rel);
                     if (dir && dir !== ".") uniqueDirs.add(dir);
@@ -2664,6 +2695,54 @@ export async function resolveConflictFiles(
 
                 // Handle deleted file
                 if (conflict.isDeleted) {
+                    // Delete-vs-modify guard (issue #1116): for translation content
+                    // files, a deletion on one side must not silently discard the
+                    // surviving side's content. Deletion only wins when a recorded
+                    // deletion tombstone is at least as recent as the surviving
+                    // content's latest edit — otherwise the content is restored,
+                    // mirroring the timestamp rules used for cell-level merges.
+                    const survivingContent = conflict.ours || conflict.theirs;
+                    if (isTrackedContentFile(normalizedFilepath) && survivingContent) {
+                        const tombstoneTimestamp = findTombstoneTimestamp(
+                            deletionTombstones,
+                            normalizedFilepath
+                        );
+                        const latestEditTimestamp = getLatestContentTimestamp(survivingContent);
+                        const deletionIsIntentional =
+                            tombstoneTimestamp !== undefined &&
+                            tombstoneTimestamp >= latestEditTimestamp;
+
+                        if (!deletionIsIntentional) {
+                            debugLog(`Restoring deleted file with surviving content: ${conflict.filepath}`);
+                            try {
+                                let existedOnDisk = true;
+                                try {
+                                    await vscode.workspace.fs.stat(filePath);
+                                } catch {
+                                    existedOnDisk = false;
+                                }
+                                await vscode.workspace.fs.writeFile(
+                                    filePath,
+                                    Buffer.from(survivingContent)
+                                );
+                                resolvedFiles.push({
+                                    filepath: conflict.filepath,
+                                    resolution: existedOnDisk ? "modified" : "created",
+                                });
+                                restoredFromDeletion.push(conflict.filepath);
+                            } catch (e) {
+                                const detail = e instanceof Error ? e.message : String(e);
+                                console.error(`Error restoring deleted file ${conflict.filepath}:`, e);
+                                failedFiles.push({
+                                    filepath: conflict.filepath,
+                                    error: `Restore of deleted file failed: ${detail}`,
+                                });
+                            }
+                            return;
+                        }
+                        debugLog(`Honoring recorded deletion for: ${conflict.filepath}`);
+                    }
+
                     debugLog(`Deleting file: ${conflict.filepath}`);
                     try {
                         await vscode.workspace.fs.delete(filePath);
@@ -2779,6 +2858,21 @@ export async function resolveConflictFiles(
             await Promise.all(Array.from({ length: workerCount }, () => worker()));
         }
     );
+
+    if (restoredFromDeletion.length > 0) {
+        const names = restoredFromDeletion.map((f) => path.posix.basename(f.replace(/\\/g, "/")));
+        const preview =
+            names.slice(0, 5).join(", ") +
+            (names.length > 5 ? ` and ${names.length - 5} more` : "");
+        console.warn(
+            `[Merge] Restored ${restoredFromDeletion.length} file(s) that were deleted on one side without a matching deletion record:`,
+            restoredFromDeletion
+        );
+        vscode.window.showWarningMessage(
+            `${restoredFromDeletion.length} file(s) were deleted by another sync but contained newer edits ` +
+            `or had no recorded deletion, so they were restored: ${preview}`
+        );
+    }
 
     return { resolved: resolvedFiles, failed: failedFiles };
 }

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -1555,12 +1555,24 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
         }
     }
 
+    /**
+     * Workspace-relative POSIX path for a deleted file. Recorded alongside the
+     * absolute path so deletion tombstones match on every team member's machine
+     * (used by the sync deletion guard, issue #1116).
+     */
+    private toWorkspaceRelativePath(workspaceFolder: vscode.Uri, filePath: string): string {
+        return path
+            .relative(workspaceFolder.fsPath, filePath)
+            .replace(/\\/g, "/");
+    }
+
     private async recordFileDeletionToEditHistory(filePath: string, label: string): Promise<void> {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceFolder) return;
 
         try {
             const author = await this.getCurrentUser();
+            const relPath = this.toWorkspaceRelativePath(workspaceFolder, filePath);
             await MetadataManager.safeUpdateMetadata(
                 workspaceFolder,
                 (metadata: { edits?: unknown[]; }) => {
@@ -1568,7 +1580,7 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                     addProjectMetadataEdit(
                         metadata,
                         EditMapUtils.deletedFile(),
-                        { filePath, label },
+                        { filePath, relPath, label },
                         author
                     );
                     return metadata;
@@ -1589,6 +1601,10 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
 
         try {
             const author = await this.getCurrentUser();
+            const deletedFilesWithRelPaths = deletedFiles.map((file) => ({
+                ...file,
+                relPath: this.toWorkspaceRelativePath(workspaceFolder, file.filePath),
+            }));
             await MetadataManager.safeUpdateMetadata(
                 workspaceFolder,
                 (metadata: { edits?: unknown[]; }) => {
@@ -1596,7 +1612,7 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                     addProjectMetadataEdit(
                         metadata,
                         EditMapUtils.deletedCorpusMarker(),
-                        { corpusMarker, deletedFiles },
+                        { corpusMarker, deletedFiles: deletedFilesWithRelPaths },
                         author
                     );
                     return metadata;

--- a/src/test/suite/fileDeletionGuard.test.ts
+++ b/src/test/suite/fileDeletionGuard.test.ts
@@ -1,0 +1,505 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os from "os";
+
+import {
+    collectDeletionTombstones,
+    findTombstoneTimestamp,
+    getLatestContentTimestamp,
+    isTrackedContentFile,
+    restoreContentFilesMissingWithoutTombstone,
+    DeletionGuardGitOps,
+} from "../../projectManager/utils/merge/fileDeletionGuard";
+import { resolveConflictFiles } from "../../projectManager/utils/merge/resolvers";
+import { ConflictFile } from "../../projectManager/utils/merge/types";
+
+/** Minimal `.codex` notebook whose newest edit carries the given timestamp. */
+function makeNotebookContent(latestEditTimestamp: number): string {
+    return JSON.stringify({
+        cells: [
+            {
+                kind: 2,
+                languageId: "html",
+                value: "<span>translated content</span>",
+                metadata: {
+                    id: "EP 1:1",
+                    type: "text",
+                    edits: [
+                        {
+                            editMap: ["value"],
+                            value: "<span>older draft</span>",
+                            timestamp: latestEditTimestamp - 5000,
+                            type: "user-edit",
+                            author: "translator",
+                        },
+                        {
+                            editMap: ["value"],
+                            value: "<span>translated content</span>",
+                            timestamp: latestEditTimestamp,
+                            type: "user-edit",
+                            author: "translator",
+                        },
+                    ],
+                    data: {},
+                },
+            },
+        ],
+        metadata: { id: "EP", edits: [] },
+    });
+}
+
+function makeMetadataContent(edits: unknown[]): string {
+    return JSON.stringify({ projectName: "Test", edits, meta: {} });
+}
+
+function deletedFileEdit(relPath: string, timestamp: number, absolutePrefix = "/Users/someone/project/") {
+    return {
+        editMap: ["deletedFile"],
+        value: { filePath: absolutePrefix + relPath, relPath, label: "Episode" },
+        timestamp,
+        type: "user-edit",
+        author: "reviewer",
+    };
+}
+
+async function makeTempWorkspace(): Promise<string> {
+    const dir = path.join(
+        os.tmpdir(),
+        `deletion-guard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+    return dir;
+}
+
+async function removeDir(dir: string): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(vscode.Uri.file(dir), { recursive: true });
+    } catch {
+        // best-effort cleanup
+    }
+}
+
+async function fileExists(dir: string, relPath: string): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(vscode.Uri.file(path.join(dir, relPath)));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function readFileText(dir: string, relPath: string): Promise<string> {
+    const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(dir, relPath)));
+    return new TextDecoder().decode(bytes);
+}
+
+async function writeFileText(dir: string, relPath: string, content: string): Promise<void> {
+    const target = vscode.Uri.file(path.join(dir, relPath));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(target.fsPath)));
+    await vscode.workspace.fs.writeFile(target, Buffer.from(content));
+}
+
+suite("fileDeletionGuard - helpers", () => {
+    test("isTrackedContentFile matches only content files", () => {
+        assert.strictEqual(isTrackedContentFile("files/target/EP206.codex"), true);
+        assert.strictEqual(isTrackedContentFile(".project/sourceTexts/EP206.source"), true);
+        assert.strictEqual(isTrackedContentFile("files\\target\\EP206.codex"), true);
+
+        assert.strictEqual(isTrackedContentFile("metadata.json"), false);
+        assert.strictEqual(isTrackedContentFile("files/target/notes.txt"), false);
+        assert.strictEqual(isTrackedContentFile("elsewhere/EP206.codex"), false);
+        assert.strictEqual(isTrackedContentFile("files/target/EP206.codex.tmp-123-abc"), false);
+    });
+
+    test("collectDeletionTombstones reads deletedFile and deletedCorpusMarker edits", () => {
+        const metadata = makeMetadataContent([
+            deletedFileEdit("files/target/A.codex", 1000),
+            {
+                editMap: ["deletedCorpusMarker"],
+                value: {
+                    corpusMarker: "EP",
+                    deletedFiles: [
+                        { filePath: "/abs/files/target/B.codex", label: "B" },
+                        { filePath: "/abs/files/target/C.codex", label: "C" },
+                    ],
+                },
+                timestamp: 2000,
+                type: "user-edit",
+                author: "reviewer",
+            },
+            // Unrelated edit must be ignored
+            { editMap: ["projectName"], value: "X", timestamp: 3000, type: "user-edit", author: "a" },
+        ]);
+
+        const tombstones = collectDeletionTombstones(metadata);
+        assert.strictEqual(tombstones.length, 3);
+        assert.deepStrictEqual(
+            tombstones.map((t) => t.timestamp),
+            [1000, 2000, 2000]
+        );
+    });
+
+    test("collectDeletionTombstones tolerates invalid inputs", () => {
+        assert.deepStrictEqual(collectDeletionTombstones(undefined, "not json", "{}"), []);
+    });
+
+    test("collectDeletionTombstones combines multiple metadata contents", () => {
+        const local = makeMetadataContent([deletedFileEdit("files/target/A.codex", 1000)]);
+        const incoming = makeMetadataContent([deletedFileEdit("files/target/B.codex", 2000)]);
+        const tombstones = collectDeletionTombstones(local, incoming);
+        assert.strictEqual(tombstones.length, 2);
+    });
+
+    test("findTombstoneTimestamp matches by relPath, absolute suffix, and basename", () => {
+        const tombstones = collectDeletionTombstones(
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
+        );
+
+        // Exact relative path
+        assert.strictEqual(findTombstoneTimestamp(tombstones, "files/target/EP206.codex"), 5000);
+
+        // Legacy record with only an absolute path from another machine
+        const legacy = collectDeletionTombstones(
+            makeMetadataContent([
+                {
+                    editMap: ["deletedFile"],
+                    value: { filePath: "C:\\Users\\other\\proj\\files\\target\\EP206.codex", label: "E" },
+                    timestamp: 6000,
+                    type: "user-edit",
+                    author: "reviewer",
+                },
+            ])
+        );
+        assert.strictEqual(findTombstoneTimestamp(legacy, "files/target/EP206.codex"), 6000);
+
+        // No match for a different file
+        assert.strictEqual(findTombstoneTimestamp(tombstones, "files/target/EP207.codex"), undefined);
+    });
+
+    test("findTombstoneTimestamp matches a .source file via its paired .codex tombstone", () => {
+        const tombstones = collectDeletionTombstones(
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
+        );
+        assert.strictEqual(
+            findTombstoneTimestamp(tombstones, ".project/sourceTexts/EP206.source"),
+            5000
+        );
+    });
+
+    test("findTombstoneTimestamp returns the newest matching tombstone", () => {
+        const tombstones = collectDeletionTombstones(
+            makeMetadataContent([
+                deletedFileEdit("files/target/EP206.codex", 5000),
+                deletedFileEdit("files/target/EP206.codex", 9000),
+            ])
+        );
+        assert.strictEqual(findTombstoneTimestamp(tombstones, "files/target/EP206.codex"), 9000);
+    });
+
+    test("getLatestContentTimestamp finds the max across cell edits and validations", () => {
+        assert.strictEqual(getLatestContentTimestamp(makeNotebookContent(7777)), 7777);
+
+        const withValidation = JSON.stringify({
+            cells: [
+                {
+                    metadata: {
+                        id: "EP 1:1",
+                        edits: [
+                            {
+                                editMap: ["value"],
+                                value: "x",
+                                timestamp: 100,
+                                validatedBy: [
+                                    {
+                                        username: "v",
+                                        creationTimestamp: 100,
+                                        updatedTimestamp: 500,
+                                        isDeleted: false,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+            metadata: { edits: [{ editMap: ["title"], value: "t", timestamp: 300 }] },
+        });
+        assert.strictEqual(getLatestContentTimestamp(withValidation), 500);
+
+        assert.strictEqual(getLatestContentTimestamp("not json"), 0);
+        assert.strictEqual(getLatestContentTimestamp("{}"), 0);
+    });
+});
+
+suite("fileDeletionGuard - pre-sync restore guard", () => {
+    let workspaceDir: string;
+
+    setup(async () => {
+        workspaceDir = await makeTempWorkspace();
+    });
+
+    teardown(async () => {
+        await removeDir(workspaceDir);
+    });
+
+    function fakeGitOps(
+        matrix: Array<[string, 0 | 1 | 2, 0 | 1 | 2, 0 | 1 | 2]>,
+        blobs: Record<string, string>
+    ): DeletionGuardGitOps & { readPaths: string[] } {
+        const readPaths: string[] = [];
+        return {
+            readPaths,
+            statusMatrix: async () => matrix,
+            readBlobAtRef: async (_dir: string, _ref: string, filepath: string) => {
+                readPaths.push(filepath);
+                if (!(filepath in blobs)) throw new Error(`no blob for ${filepath}`);
+                return Buffer.from(blobs[filepath]);
+            },
+        };
+    }
+
+    test("restores missing content files that have no tombstone", async () => {
+        const gitOps = fakeGitOps(
+            [
+                ["files/target/EP206.codex", 1, 0, 0],
+                [".project/sourceTexts/EP206.source", 1, 0, 0],
+                ["files/target/EP205.codex", 1, 1, 1], // present — untouched
+                ["notes.txt", 1, 0, 0], // not a content file — untouched
+            ],
+            {
+                "files/target/EP206.codex": makeNotebookContent(1000),
+                ".project/sourceTexts/EP206.source": makeNotebookContent(900),
+            }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+
+        assert.deepStrictEqual(restored.sort(), [
+            ".project/sourceTexts/EP206.source",
+            "files/target/EP206.codex",
+        ]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), true);
+        assert.strictEqual(
+            await fileExists(workspaceDir, ".project/sourceTexts/EP206.source"),
+            true
+        );
+        assert.strictEqual(await fileExists(workspaceDir, "notes.txt"), false);
+        assert.strictEqual(
+            await readFileText(workspaceDir, "files/target/EP206.codex"),
+            makeNotebookContent(1000)
+        );
+    });
+
+    test("leaves tombstoned deletions alone (and their paired .source)", async () => {
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
+        );
+
+        const gitOps = fakeGitOps(
+            [
+                ["files/target/EP206.codex", 1, 0, 0],
+                [".project/sourceTexts/EP206.source", 1, 0, 0],
+                ["files/target/EP207.codex", 1, 0, 0],
+            ],
+            { "files/target/EP207.codex": makeNotebookContent(1000) }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+
+        assert.deepStrictEqual(restored, ["files/target/EP207.codex"]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), false);
+        assert.strictEqual(
+            await fileExists(workspaceDir, ".project/sourceTexts/EP206.source"),
+            false
+        );
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP207.codex"), true);
+    });
+
+    test("does nothing when no tracked content files are missing", async () => {
+        const gitOps = fakeGitOps([["files/target/EP205.codex", 1, 1, 1]], {});
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+        assert.deepStrictEqual(restored, []);
+        assert.deepStrictEqual(gitOps.readPaths, []);
+    });
+
+    test("continues past files whose HEAD blob cannot be read", async () => {
+        const gitOps = fakeGitOps(
+            [
+                ["files/target/EP206.codex", 1, 0, 0],
+                ["files/target/EP207.codex", 1, 0, 0],
+            ],
+            { "files/target/EP207.codex": makeNotebookContent(1000) }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+        assert.deepStrictEqual(restored, ["files/target/EP207.codex"]);
+    });
+});
+
+suite("fileDeletionGuard - delete-vs-modify conflict resolution", () => {
+    let workspaceDir: string;
+
+    setup(async () => {
+        workspaceDir = await makeTempWorkspace();
+    });
+
+    teardown(async () => {
+        await removeDir(workspaceDir);
+    });
+
+    function deletionConflict(
+        filepath: string,
+        opts: { ours?: string; theirs?: string; base?: string }
+    ): ConflictFile {
+        return {
+            filepath,
+            ours: opts.ours ?? "",
+            theirs: opts.theirs ?? "",
+            base: opts.base ?? "",
+            isDeleted: true,
+            isNew: false,
+        };
+    }
+
+    test("restores a remotely-surviving file deleted locally without a tombstone", async () => {
+        const surviving = makeNotebookContent(1000);
+        const conflict = deletionConflict("files/target/EP206.codex", {
+            theirs: surviving,
+            base: surviving,
+        });
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP206.codex", resolution: "created" },
+        ]);
+        assert.strictEqual(
+            await readFileText(workspaceDir, "files/target/EP206.codex"),
+            surviving
+        );
+    });
+
+    test("restores a locally-surviving file deleted remotely without a tombstone", async () => {
+        const surviving = makeNotebookContent(2000);
+        await writeFileText(workspaceDir, "files/target/EP207.codex", surviving);
+        const conflict = deletionConflict("files/target/EP207.codex", {
+            ours: surviving,
+            base: surviving,
+        });
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP207.codex", resolution: "modified" },
+        ]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP207.codex"), true);
+    });
+
+    test("honors deletion when a tombstone is newer than the surviving content's edits", async () => {
+        const surviving = makeNotebookContent(1000);
+        await writeFileText(workspaceDir, "files/target/EP206.codex", surviving);
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 9999)])
+        );
+
+        const conflict = deletionConflict("files/target/EP206.codex", {
+            ours: surviving,
+            base: surviving,
+        });
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP206.codex", resolution: "deleted" },
+        ]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), false);
+    });
+
+    test("restores the file when its edits are newer than the tombstone", async () => {
+        const surviving = makeNotebookContent(9999); // edited AFTER the recorded deletion
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
+        );
+
+        const conflict = deletionConflict("files/target/EP206.codex", {
+            theirs: surviving,
+            base: makeNotebookContent(1000),
+        });
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP206.codex", resolution: "created" },
+        ]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), true);
+    });
+
+    test("honors a tombstone that only exists in the incoming metadata.json conflict", async () => {
+        const surviving = makeNotebookContent(1000);
+        await writeFileText(workspaceDir, "files/target/EP206.codex", surviving);
+        // Local metadata has no tombstone; the remote (theirs) copy in the same
+        // conflict batch records the deletion.
+        await writeFileText(workspaceDir, "metadata.json", makeMetadataContent([]));
+        const metadataConflict: ConflictFile = {
+            filepath: "metadata.json",
+            ours: makeMetadataContent([]),
+            theirs: makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 9999)]),
+            base: makeMetadataContent([]),
+            isDeleted: false,
+            isNew: false,
+        };
+        const conflict = deletionConflict("files/target/EP206.codex", {
+            ours: surviving,
+            base: surviving,
+        });
+
+        const { resolved } = await resolveConflictFiles(
+            [metadataConflict, conflict],
+            workspaceDir
+        );
+
+        const codexResolution = resolved.find(
+            (r) => r.filepath === "files/target/EP206.codex"
+        );
+        assert.deepStrictEqual(codexResolution, {
+            filepath: "files/target/EP206.codex",
+            resolution: "deleted",
+        });
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), false);
+    });
+
+    test("still deletes non-content files unconditionally", async () => {
+        await writeFileText(workspaceDir, "some/other/file.json", "{}");
+        const conflict = deletionConflict("some/other/file.json", { theirs: "{}" });
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "some/other/file.json", resolution: "deleted" },
+        ]);
+        assert.strictEqual(await fileExists(workspaceDir, "some/other/file.json"), false);
+    });
+
+    test("deletes a content file when both sides are empty (no surviving content)", async () => {
+        const conflict = deletionConflict("files/target/EP208.codex", {});
+
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP208.codex", resolution: "deleted" },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
Closes #1116

Fixes the sync data-loss bug where episodes 206, 207, and 208 in the Kangri project were deleted team-wide. A sync from a stale working tree committed missing `.codex` files as deletions, and the merge resolver's `isDeleted` branch then deleted them unconditionally on every other machine — ignoring the translator's July 24–27 edits.

The fix makes file existence follow the same timestamp-based rules as cell-level merges: intentional deletions made through the app are recorded as tombstones (`deletedFile` / `deletedCorpusMarker` edits in `metadata.json` edit history, which already sync and union-merge), and a deletion only wins when a tombstone exists that is at least as recent as the surviving content's latest edit. Files missing without a tombstone are restored instead of deleted.

## Changes
- **Timestamp-aware file-existence resolution** — delete-vs-modify conflicts on `files/target/*.codex` and `.project/sourceTexts/*.source` now compare the deletion tombstone's timestamp against the surviving content's newest edit (including validation timestamps). Newer edits win: the file is restored, staged, and pushed back to the team (`resolvers.ts`).
- **Deletion tombstones** — reuses the existing `deletedFile`/`deletedCorpusMarker` metadata edits as tombstones; the navigation delete flow now also records workspace-relative paths so tombstones match across machines. Legacy absolute-path records still match via suffix/basename, and `.source` files match through their paired `.codex` record (`fileDeletionGuard.ts`, `navigationWebviewProvider.ts`).
- **Pre-sync deletion guard** — before `syncChanges` commits the working tree, tracked content files present in git HEAD but missing from the working tree without a tombstone are restored from HEAD, with a warning to the user. A stale tree can no longer commit silent bulk deletions (`fileDeletionGuard.ts`, `merge/index.ts`).
- **User notification instead of silent conflicts** — both the pre-sync guard and the resolver surface a warning listing every file they restored. Deletion requires the app's existing delete-confirmation modal (which writes the tombstone), so background sync never has to block on a dialog. Restored files are reported as changed rather than deleted in the sync result, so their open editors aren't closed.

## Test Checklist

### Automated tests (19 new, in `fileDeletionGuard.test.ts`)
- [x] Tombstone helpers: collection from `deletedFile`/`deletedCorpusMarker` edits, matching by relative path, legacy absolute path, basename, and paired `.codex`↔`.source` names; newest tombstone wins; invalid JSON tolerated
- [x] Latest-content-timestamp extraction across cell edits, file-level edits, and validation timestamps
- [x] Pre-sync guard restores missing content files without tombstones, skips tombstoned files (and their paired `.source`), ignores non-content files, and continues past unreadable HEAD blobs
- [x] Resolver restores a deleted file when the surviving side has edits and no tombstone exists (both locally-deleted and remotely-deleted cases)
- [x] Resolver honors deletion when the tombstone is newer than the surviving content's edits, including a tombstone that only arrives in the incoming `metadata.json` conflict
- [x] Resolver still deletes non-content files and content files with no surviving content unconditionally

### Regression + build
- [x] Full merge-related suite passes (126 passing, 0 failing) — includes existing codex custom merge, metadata merge, and duplication-repair tests
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] ESLint clean on all changed files

### Validation against the real incident
- [x] Broken Kangri project's `metadata.json` contains zero deletion tombstones → under this fix the Aug 1 deletion would have been refused and the files restored
- [x] Episodes 206/207/208 at recovery commit `fe568da` have latest edits of Jul 21/24/27 — all newer than any deletion record, so every updated client would resurrect them during merge
- [x] Confirmed `.codex`/`.source` files are not LFS-tracked (restore-from-HEAD yields real content, not pointer files) and the temp-file cleanup migration (`*.tmp-*-*`) is unaffected by the guard

### Manual verification
- [x] Live two-machine sync smoke test (stale tree on machine A, newer edits on machine B) — not yet run; automated coverage simulates both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)