### PR TITLE
1128-bug-missing-verse-ranges-when-exporting-html-or-usfm

### DIFF
--- a/src/exportHandler/exportHandlerUtils.ts
+++ b/src/exportHandler/exportHandlerUtils.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { CodexNotebookAsJSONData } from "../../types";
 import { CodexCellTypes } from "../../types/enums";
+import { parseVerseRef } from "../utils/verseRefUtils";
 
 /**
  * Reads a .codex notebook from disk and parses its JSON content
@@ -33,4 +34,46 @@ export function getActiveCells(cells: CodexNotebookAsJSONData["cells"]) {
  */
 export function isContentCellType(type: string | undefined): boolean {
     return type === CodexCellTypes.TEXT || type === "markdown";
+}
+
+/** Verse-marker-shaped label part: digits with an optional segment letter (e.g. "1", "12a"). */
+const verseMarkerPartRegex = /^\d+[a-z]?$/i;
+
+/**
+ * Normalizes a cell label into a verse marker valid in USFM (`\v 1-3`), or
+ * returns null when the label is not verse-marker-shaped (e.g. "Narrator").
+ * Multi-part merge chains like "1-2-3" (from merging an already-merged cell)
+ * collapse to their span ("1-3") so the marker stays valid USFM.
+ */
+export function verseMarkerFromCellLabel(cellLabel: unknown): string | null {
+    if (typeof cellLabel !== "string") return null;
+    const trimmed = cellLabel.trim();
+    if (!trimmed) return null;
+    const parts = trimmed.split("-").map((part) => part.trim());
+    if (!parts.every((part) => verseMarkerPartRegex.test(part))) return null;
+    const first = parts[0]!;
+    const last = parts[parts.length - 1]!;
+    return first === last ? first : `${first}-${last}`;
+}
+
+/**
+ * Derives the verse marker to export for a cell (e.g. "3" or "1-3").
+ * A UI-merged cell keeps a single-verse globalReference and records the merged
+ * span in its cellLabel, so a verse-marker-shaped cellLabel wins; otherwise the
+ * ref itself may encode a range ("GEN 1:1-3"), which parseVerseRef resolves
+ * (including legacy cell-id-suffixed refs). Falls back to the trailing digits
+ * of the ref for anything parseVerseRef rejects.
+ */
+export function getVerseMarkerForCell(
+    cell: { metadata?: any; },
+    verseRef: string
+): string | null {
+    const labelMarker = verseMarkerFromCellLabel(cell.metadata?.cellLabel);
+    if (labelMarker) return labelMarker;
+
+    const parsed = parseVerseRef(verseRef);
+    if (parsed) return parsed.cellLabel;
+
+    const trailingDigits = verseRef.match(/\d+$/);
+    return trailingDigits ? trailingDigits[0] : null;
 }

--- a/src/exportHandler/htmlExporter.ts
+++ b/src/exportHandler/htmlExporter.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { basename } from "path";
 import { CodexCellTypes } from "../../types/enums";
-import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { readCodexNotebookFromUri, getActiveCells, isContentCellType, getVerseMarkerForCell } from "./exportHandlerUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -222,10 +222,9 @@ export async function exportCodexContentAsHtml(
                                 const verseRef = getVerseRefForCell(cell);
                                 if (verseRef) {
                                     const chapterMatch = verseRef.match(/\s(\d+):/);
-                                    const verseMatch = verseRef.match(/\d+$/);
-                                    if (chapterMatch && verseMatch) {
+                                    const verseMarker = getVerseMarkerForCell(cell, verseRef);
+                                    if (chapterMatch && verseMarker) {
                                         const chapterNum = chapterMatch[1];
-                                        const verseNumber = verseMatch[0];
                                         if (!chapters[chapterNum]) {
                                             chapters[chapterNum] = `
                                             <div class="chapter">
@@ -233,7 +232,7 @@ export async function exportCodexContentAsHtml(
                                         }
                                         chapters[chapterNum] += `
                                             <div class="verse" x-type="verse" x-verse-ref="${verseRef}">
-                                                <span class="verse-number">${verseNumber}</span>
+                                                <span class="verse-number">${verseMarker}</span>
                                                 ${cellContent}
                                             </div>`;
                                         totalVerses++;

--- a/src/exportHandler/usfmExporter.ts
+++ b/src/exportHandler/usfmExporter.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { basename } from "path";
 import * as grammar from "usfm-grammar";
 import { CodexCellTypes } from "../../types/enums";
-import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { readCodexNotebookFromUri, getActiveCells, isContentCellType, getVerseMarkerForCell } from "./exportHandlerUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -405,9 +405,9 @@ export async function exportCodexContentAsUsfm(
                         if (verseRef) {
                             const chapterMatch =
                                 verseRef.match(/\s(\d+):/);
-                            const verseMatch = verseRef.match(/\d+$/);
+                            const verseMarker = getVerseMarkerForCell(cell, verseRef);
 
-                            if (chapterMatch && verseMatch) {
+                            if (chapterMatch && verseMarker) {
                                 const chapterNum = parseInt(
                                     chapterMatch[1],
                                     10
@@ -434,8 +434,7 @@ export async function exportCodexContentAsUsfm(
                                     isFirstChapter = false;
                                 }
 
-                                const verseNumber = verseMatch[0];
-                                chapterContent += `\\v ${verseNumber} ${cellContent}\n`;
+                                chapterContent += `\\v ${verseMarker} ${cellContent}\n`;
                                 verseCount++;
                                 hasVerses = true;
                             }

--- a/src/test/suite/exportHandlerUtils.test.ts
+++ b/src/test/suite/exportHandlerUtils.test.ts
@@ -1,7 +1,11 @@
 import * as assert from "assert";
 import type { CodexNotebookAsJSONData } from "../../../types";
 import { CodexCellTypes } from "../../../types/enums";
-import { getActiveCells } from "../../exportHandler/exportHandlerUtils";
+import {
+    getActiveCells,
+    getVerseMarkerForCell,
+    verseMarkerFromCellLabel,
+} from "../../exportHandler/exportHandlerUtils";
 
 type Cell = CodexNotebookAsJSONData["cells"][number];
 
@@ -36,5 +40,73 @@ suite("Export handler active-cell filtering", () => {
         );
 
         assert.deepStrictEqual(activeCellIds, ["first", "second", "third"]);
+    });
+});
+
+const cellWithLabel = (cellLabel?: string) => ({
+    metadata: { cellLabel },
+});
+
+suite("Export verse marker derivation", () => {
+    test("single-verse refs still export the bare verse number", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel(), "GEN 1:1"),
+            "1"
+        );
+    });
+
+    test("ranged refs export the full range instead of the trailing verse", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel(), "GEN 1:1-3"),
+            "1-3"
+        );
+    });
+
+    test("a range cellLabel from a UI merge wins over a single-verse ref", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel("1-3"), "GEN 1:1"),
+            "1-3"
+        );
+    });
+
+    test("a verse-segment cellLabel exports as the marker", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel("1b"), "GEN 1:1"),
+            "1b"
+        );
+    });
+
+    test("a multi-part merge-chain label collapses to its span", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel("1-2-3"), "GEN 1:1"),
+            "1-3"
+        );
+    });
+
+    test("a non-marker cellLabel is ignored in favor of the ref", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(cellWithLabel("Narrator"), "GEN 1:2"),
+            "2"
+        );
+    });
+
+    test("legacy cell-id-suffixed range refs export their range", () => {
+        assert.strictEqual(
+            getVerseMarkerForCell(
+                cellWithLabel(),
+                "GEN 1:11-12:1764564500321-k9yvyjy9o"
+            ),
+            "11-12"
+        );
+    });
+
+    test("verseMarkerFromCellLabel rejects empty and malformed labels", () => {
+        assert.strictEqual(verseMarkerFromCellLabel(""), null);
+        assert.strictEqual(verseMarkerFromCellLabel("   "), null);
+        assert.strictEqual(verseMarkerFromCellLabel("Narrator"), null);
+        assert.strictEqual(verseMarkerFromCellLabel("1-"), null);
+        assert.strictEqual(verseMarkerFromCellLabel(undefined), null);
+        assert.strictEqual(verseMarkerFromCellLabel("5"), "5");
+        assert.strictEqual(verseMarkerFromCellLabel(" 1 - 2 "), "1-2");
     });
 });


### PR DESCRIPTION
## Summary
Closes #1128

Both the USFM and HTML exporters extracted the verse marker with a trailing-digits regex (`/\d+$/`), so a cell spanning verses 1–3 exported as verse `3`, silently omitting the earlier verses. Merged-cell `cellLabel` values were ignored entirely, and legacy cell-id-suffixed refs (`GEN 1:11-12:1764...-k9yvyjy9o`) matched no trailing digits at all, so those cells were silently dropped from exports.

This adds a shared `getVerseMarkerForCell` helper in `exportHandlerUtils.ts` used by both exporters. It resolves the marker in priority order: a verse-marker-shaped `cellLabel` (where UI merges record the merged span), then the ref parsed via the existing `parseVerseRef` utility (which handles ranged and legacy suffixed refs), then the previous trailing-digits fallback so anything that exported before still exports.

## Changes
- Full ranges export: ranged refs (`GEN 1:1-3`) now emit `\v 1-3 <content>` in USFM and display `1-3` in the HTML verse-number span.
- Custom `cellLabel` values export as verse markers: verse-marker-shaped labels (`1-3`, `1b`) take priority over the ref, since UI merges keep a single-verse ref and record the span in the label. Merge chains like `1-2-3` collapse to `1-3`; non-marker labels like `Narrator` are ignored rather than emitted as an invalid `\v` marker.
- Single-verse cells remain unaffected: `GEN 1:1` with no label still exports `\v 1`.
- Exported USFM passes usfm-grammar validation: verified ranged (`\v 1-3`) and segment (`\v 5a`) markers parse cleanly under `usfm-grammar` RELAXED with the exporter's own warning filter.
- Ranged markers at chapter boundaries export correctly: chapter detection parses the chapter segment (`\s(\d+):`) independently of the verse portion, verified with ranges as the last verse of one chapter and the first of the next.
- Bonus fix: legacy cell-id-suffixed refs, which previously exported nothing, now export their range (`11-12`).

## Test Checklist
- [x] Export a `.codex` file with a merged cell (label `1-3`) to USFM from the extension host and confirm `\v 1-3` in the output
- [x] Repeat with HTML export and confirm the verse span displays `1-3`
- [x] Export an unmodified single-verse book and confirm output is byte-identical to pre-change output (aside from timestamps)