### PR TITLE
1130-Pattani Malay ETT USFM Export - Headings

### DIFF
--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -251,6 +251,8 @@ export enum CodexExportFormat {
 
 export interface ExportOptions {
     skipValidation?: boolean;
+    /** USFM: export unformatted paratext cells as \s1 section headings instead of \p paragraphs. */
+    paratextAsHeadings?: boolean;
     removeIds?: boolean;
     includeAudio?: boolean;
     includeTimestamps?: boolean;

--- a/src/exportHandler/usfmBodyBuilder.ts
+++ b/src/exportHandler/usfmBodyBuilder.ts
@@ -1,0 +1,249 @@
+import { CodexCellTypes } from "../../types/enums";
+import { isContentCellType } from "./exportHandlerUtils";
+
+/** Verse ref regex: "1TH 1:1", "GEN 1:1", etc. */
+const VERSE_REF_REGEX = /\b[A-Z0-9]{2,4}\s+\d+:\d+\b/;
+
+/** Section-heading markers: \s, \s1, \s2, ... (excludes \sp etc.) */
+const HEADING_MARKER_REGEX = /^\\s\d*$/;
+
+/** Minimal cell shape the USFM body builder needs. */
+export interface UsfmExportCell {
+    metadata?: any;
+    value: string;
+}
+
+export interface UsfmBodyOptions {
+    /** Export unformatted paratext cells as \s1 section headings instead of \p paragraphs. */
+    paratextAsHeadings?: boolean;
+}
+
+export interface UsfmBodyResult {
+    body: string;
+    verseCount: number;
+    hasVerses: boolean;
+}
+
+/**
+ * Gets the verse reference for a cell, from globalReferences (preferred) or metadata.id (legacy).
+ * Returns null if no verse-ref format found.
+ */
+export function getVerseRefForCell(cell: { metadata?: any; }): string | null {
+    const meta = cell.metadata as any;
+    const globalRefs = meta?.data?.globalReferences;
+    if (globalRefs && Array.isArray(globalRefs) && globalRefs.length > 0) {
+        const ref = globalRefs[0];
+        if (typeof ref === "string" && VERSE_REF_REGEX.test(ref)) {
+            return ref;
+        }
+    }
+    const id = meta?.id;
+    if (typeof id === "string" && VERSE_REF_REGEX.test(id)) {
+        return id;
+    }
+    return null;
+}
+
+function getChapterFromVerseRef(verseRef: string): number | null {
+    const match = verseRef.match(/\s(\d+):/);
+    return match ? parseInt(match[1], 10) : null;
+}
+
+export function convertHtmlToUsfm(html: string): string {
+    if (!html) return "";
+
+    let content = html;
+
+    content = content.replace(/<h1>(.*?)<\/h1>/gi, "\\s1 $1");
+    content = content.replace(/<h2>(.*?)<\/h2>/gi, "\\s1 $1");
+    content = content.replace(/<h3>(.*?)<\/h3>/gi, "\\s2 $1");
+    content = content.replace(/<h4>(.*?)<\/h4>/gi, "\\s3 $1");
+    content = content.replace(/<em>(.*?)<\/em>/gi, "\\em $1\\em*");
+    content = content.replace(/<i>(.*?)<\/i>/gi, "\\it $1\\it*");
+    content = content.replace(/<strong>(.*?)<\/strong>/gi, "\\bd $1\\bd*");
+    content = content.replace(/<b>(.*?)<\/b>/gi, "\\bd $1\\bd*");
+    content = content.replace(/<u>(.*?)<\/u>/gi, "\\ul $1\\ul*");
+    content = content.replace(/<sup>(.*?)<\/sup>/gi, "\\sup $1\\sup*");
+    content = content.replace(/<sub>(.*?)<\/sub>/gi, "\\sub $1\\sub*");
+
+    content = content.replace(/<ul>(.*?)<\/ul>/gis, (match, listContent) => {
+        const items = listContent.match(/<li>(.*?)<\/li>/gis);
+        if (!items) return match;
+        return items
+            .map((item: string) => "\\li " + item.replace(/<\/?li>/gi, "").trim())
+            .join("\n");
+    });
+
+    content = content.replace(/<ol>(.*?)<\/ol>/gis, (match, listContent) => {
+        const items = listContent.match(/<li>(.*?)<\/li>/gis);
+        if (!items) return match;
+        return items
+            .map(
+                (item: string, index: number) =>
+                    `\\li${index + 1} ` + item.replace(/<\/?li>/gi, "").trim()
+            )
+            .join("\n");
+    });
+
+    // Strip bracket-format footnotes (literal angle brackets) before HTML tag cleanup
+    content = content.replace(/<([^>]*\\[^>]*)>/g, "$1");
+
+    content = content.replace(/<[^>]*>/g, "");
+    content = content.replace(/&nbsp;/g, " ");
+    content = content.replace(/&lt;/g, "<");
+    content = content.replace(/&gt;/g, ">");
+    content = content.replace(/&amp;/g, "&");
+    content = content.replace(/&quot;/g, '"');
+    content = content.replace(/&apos;/g, "'");
+
+    // Strip entity-encoded bracket-format footnotes too
+    content = content.replace(/<([^>]*\\[^>]*)>/g, "$1");
+
+    return content;
+}
+
+/**
+ * Formats one paratext cell as a USFM line. Marker precedence:
+ * 1. Explicit heading tags in the content (already converted to \s markers by convertHtmlToUsfm)
+ * 2. The original USFM marker preserved in metadata by importers (e.g. \s, \q1)
+ * 3. \s1 when the user opted in to exporting paratext cells as headings, otherwise \p
+ */
+function formatParatextCell(
+    convertedContent: string,
+    metadata: any,
+    paratextAsHeadings: boolean
+): { line: string; isHeading: boolean; } {
+    if (convertedContent.startsWith("\\")) {
+        return {
+            line: convertedContent,
+            isHeading: convertedContent.startsWith("\\s"),
+        };
+    }
+    const marker =
+        typeof metadata?.marker === "string" && metadata.marker.startsWith("\\")
+            ? metadata.marker
+            : null;
+    if (marker) {
+        return {
+            line: `${marker} ${convertedContent}`,
+            isHeading: HEADING_MARKER_REGEX.test(marker),
+        };
+    }
+    if (paratextAsHeadings) {
+        return { line: `\\s1 ${convertedContent}`, isHeading: true };
+    }
+    return { line: `\\p ${convertedContent}`, isHeading: false };
+}
+
+/**
+ * Assembles the chapter/verse body of a USFM file from a book's cells
+ * (pre-filtered to active, non-milestone cells with content).
+ *
+ * Chapter boundaries come from verse refs, or from legacy paratext cells whose
+ * text is "Chapter N". Paratext cells that sit between chapters (e.g. a section
+ * heading entered before a chapter's first verse) are attached to the chapter
+ * they introduce, after its \c marker, rather than the still-open previous one.
+ */
+export function buildUsfmBody(
+    relevantCells: UsfmExportCell[],
+    options?: UsfmBodyOptions
+): UsfmBodyResult {
+    const paratextAsHeadings = !!options?.paratextAsHeadings;
+
+    // For each cell, the chapter of the nearest following verse cell — used to
+    // decide whether a paratext cell belongs to the upcoming chapter.
+    const nextVerseChapter: (number | null)[] = new Array(relevantCells.length).fill(null);
+    let upcomingChapter: number | null = null;
+    for (let i = relevantCells.length - 1; i >= 0; i--) {
+        nextVerseChapter[i] = upcomingChapter;
+        const cell = relevantCells[i];
+        if (isContentCellType(cell.metadata?.type)) {
+            const verseRef = getVerseRefForCell(cell);
+            const chapter = verseRef ? getChapterFromVerseRef(verseRef) : null;
+            if (chapter !== null) {
+                upcomingChapter = chapter;
+            }
+        }
+    }
+
+    let body = "";
+    let verseCount = 0;
+    let hasVerses = false;
+    let currentChapter = 0;
+    let chapterContent = "";
+    let isFirstChapter = true;
+    let pendingParatextLines: string[] = [];
+
+    const openChapter = (chapterNum: number) => {
+        if (chapterContent) {
+            body += chapterContent;
+        }
+        currentChapter = chapterNum;
+        isFirstChapter = false;
+        chapterContent = `\\c ${chapterNum}\n`;
+        for (const line of pendingParatextLines) {
+            chapterContent += `${line}\n`;
+        }
+        pendingParatextLines = [];
+        chapterContent += "\\p\n";
+    };
+
+    for (let i = 0; i < relevantCells.length; i++) {
+        const cell = relevantCells[i];
+        const cellMetadata = cell.metadata;
+        const cellContent = convertHtmlToUsfm(cell.value.trim());
+
+        if (cellMetadata?.type === CodexCellTypes.PARATEXT) {
+            // Legacy chapter-marker paratext cells: literal "Chapter N" text.
+            const plainText = cell.value.replace(/<[^>]*>/g, "").trim();
+            const chapterMatch = plainText.startsWith("Chapter ")
+                ? plainText.match(/Chapter (\d+)/i)
+                : null;
+            if (chapterMatch) {
+                openChapter(parseInt(chapterMatch[1], 10));
+                continue;
+            }
+
+            const { line, isHeading } = formatParatextCell(
+                cellContent,
+                cellMetadata,
+                paratextAsHeadings
+            );
+            const upcoming = nextVerseChapter[i];
+            if (upcoming !== null && upcoming !== currentChapter) {
+                // Belongs to the next chapter; hold until its \c is emitted.
+                pendingParatextLines.push(line);
+            } else {
+                chapterContent += `${line}\n`;
+                if (isHeading) {
+                    // Restart the paragraph so following verses don't attach to the heading.
+                    chapterContent += "\\p\n";
+                }
+            }
+        } else if (isContentCellType(cellMetadata?.type)) {
+            const verseRef = getVerseRefForCell(cell);
+            if (!verseRef) continue;
+
+            const chapterNum = getChapterFromVerseRef(verseRef);
+            const verseMatch = verseRef.match(/\d+$/);
+            if (chapterNum === null || !verseMatch) continue;
+
+            if (chapterNum !== currentChapter) {
+                openChapter(chapterNum);
+            } else if (isFirstChapter && currentChapter === 0) {
+                // Verse ref with chapter 0 and no chapter opened yet (legacy edge case).
+                openChapter(1);
+            }
+
+            chapterContent += `\\v ${verseMatch[0]} ${cellContent}\n`;
+            verseCount++;
+            hasVerses = true;
+        }
+    }
+
+    if (chapterContent) {
+        body += chapterContent;
+    }
+
+    return { body, verseCount, hasVerses };
+}

--- a/src/exportHandler/usfmExporter.ts
+++ b/src/exportHandler/usfmExporter.ts
@@ -3,31 +3,9 @@ import { basename } from "path";
 import * as grammar from "usfm-grammar";
 import { CodexCellTypes } from "../../types/enums";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { buildUsfmBody } from "./usfmBodyBuilder";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
-
-/** Verse ref regex: "1TH 1:1", "GEN 1:1", etc. */
-const VERSE_REF_REGEX = /\b[A-Z0-9]{2,4}\s+\d+:\d+\b/;
-
-/**
- * Gets the verse reference for a cell, from globalReferences (preferred) or metadata.id (legacy).
- * Returns null if no verse-ref format found.
- */
-function getVerseRefForCell(cell: { metadata?: any; }): string | null {
-    const meta = cell.metadata as any;
-    const globalRefs = meta?.data?.globalReferences;
-    if (globalRefs && Array.isArray(globalRefs) && globalRefs.length > 0) {
-        const ref = globalRefs[0];
-        if (typeof ref === "string" && VERSE_REF_REGEX.test(ref)) {
-            return ref;
-        }
-    }
-    const id = meta?.id;
-    if (typeof id === "string" && VERSE_REF_REGEX.test(id)) {
-        return id;
-    }
-    return null;
-}
 
 const DEBUG = false;
 function debug(...args: any[]) {
@@ -108,58 +86,6 @@ const bookCodeToName: Record<string, string> = {
 function getFullBookName(bookCode: string): string {
     const upperCode = bookCode.toUpperCase();
     return bookCodeToName[upperCode] || bookCode;
-}
-
-function convertHtmlToUsfm(html: string): string {
-    if (!html) return "";
-
-    let content = html;
-
-    content = content.replace(/<h2>(.*?)<\/h2>/gi, "\\s1 $1");
-    content = content.replace(/<h3>(.*?)<\/h3>/gi, "\\s2 $1");
-    content = content.replace(/<h4>(.*?)<\/h4>/gi, "\\s3 $1");
-    content = content.replace(/<em>(.*?)<\/em>/gi, "\\em $1\\em*");
-    content = content.replace(/<i>(.*?)<\/i>/gi, "\\it $1\\it*");
-    content = content.replace(/<strong>(.*?)<\/strong>/gi, "\\bd $1\\bd*");
-    content = content.replace(/<b>(.*?)<\/b>/gi, "\\bd $1\\bd*");
-    content = content.replace(/<u>(.*?)<\/u>/gi, "\\ul $1\\ul*");
-    content = content.replace(/<sup>(.*?)<\/sup>/gi, "\\sup $1\\sup*");
-    content = content.replace(/<sub>(.*?)<\/sub>/gi, "\\sub $1\\sub*");
-
-    content = content.replace(/<ul>(.*?)<\/ul>/gis, (match, listContent) => {
-        const items = listContent.match(/<li>(.*?)<\/li>/gis);
-        if (!items) return match;
-        return items
-            .map((item: string) => "\\li " + item.replace(/<\/?li>/gi, "").trim())
-            .join("\n");
-    });
-
-    content = content.replace(/<ol>(.*?)<\/ol>/gis, (match, listContent) => {
-        const items = listContent.match(/<li>(.*?)<\/li>/gis);
-        if (!items) return match;
-        return items
-            .map(
-                (item: string, index: number) =>
-                    `\\li${index + 1} ` + item.replace(/<\/?li>/gi, "").trim()
-            )
-            .join("\n");
-    });
-
-    // Strip bracket-format footnotes (literal angle brackets) before HTML tag cleanup
-    content = content.replace(/<([^>]*\\[^>]*)>/g, "$1");
-
-    content = content.replace(/<[^>]*>/g, "");
-    content = content.replace(/&nbsp;/g, " ");
-    content = content.replace(/&lt;/g, "<");
-    content = content.replace(/&gt;/g, ">");
-    content = content.replace(/&amp;/g, "&");
-    content = content.replace(/&quot;/g, '"');
-    content = content.replace(/&apos;/g, "'");
-
-    // Strip entity-encoded bracket-format footnotes too
-    content = content.replace(/<([^>]*\\[^>]*)>/g, "$1");
-
-    return content;
 }
 
 export async function exportCodexContentAsUsfm(
@@ -274,12 +200,6 @@ export async function exportCodexContentAsUsfm(
 
                 let usfmContent = "";
                 const fullBookName = getFullBookName(bookCode);
-                let verseCount = 0;
-                let hasVerses = false;
-                let currentChapter = 0;
-                let chapterContent = "";
-                let lastChapter = "";
-                let isFirstChapter = true;
 
                 usfmContent += `\\id ${bookCode} EN\n`;
                 usfmContent += `\\rem Exported from Codex Translation Editor v${extensionVersion}\n`;
@@ -305,147 +225,10 @@ export async function exportCodexContentAsUsfm(
 
                 totalCells += relevantCells.length;
 
-                const chapterCells: { [key: string]: number; } = {};
-                for (const cell of relevantCells) {
-                    const cellMetadata = cell.metadata;
-                    const cellContent = cell.value.trim();
-
-                    if (
-                        cellMetadata.type ===
-                        CodexCellTypes.PARATEXT &&
-                        cellContent.startsWith("<h1>")
-                    ) {
-                        const chapterTitle = cellContent
-                            .replace(/<\/?h1>/g, "")
-                            .trim();
-                        const chapterMatch = chapterTitle.match(
-                            /Chapter (\d+)/i
-                        );
-                        if (chapterMatch) {
-                            const chapterNum = parseInt(
-                                chapterMatch[1],
-                                10
-                            );
-                            chapterCells[cellMetadata.id] =
-                                chapterNum;
-                        }
-                    } else if (
-                        isContentCellType(cellMetadata.type)
-                    ) {
-                        const verseRef = getVerseRefForCell(cell);
-                        if (verseRef) {
-                            const chapterMatch =
-                                verseRef.match(/\s(\d+):/);
-                            if (chapterMatch) {
-                                const chapterNum = parseInt(
-                                    chapterMatch[1],
-                                    10
-                                );
-                                if (
-                                    !lastChapter ||
-                                    chapterNum > parseInt(
-                                        lastChapter,
-                                        10
-                                    )
-                                ) {
-                                    if (
-                                        !Object.values(
-                                            chapterCells
-                                        ).includes(chapterNum)
-                                    ) {
-                                        chapterCells[
-                                            `auto_${chapterNum}`
-                                        ] = chapterNum;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                for (const cell of relevantCells) {
-                    const cellMetadata = cell.metadata;
-                    let cellContent = cell.value.trim();
-
-                    cellContent = convertHtmlToUsfm(cellContent);
-
-                    if (
-                        cellMetadata.type ===
-                        CodexCellTypes.PARATEXT
-                    ) {
-                        if (cellContent.startsWith("Chapter ")) {
-                            const chapterMatch = cellContent.match(
-                                /Chapter (\d+)/i
-                            );
-                            if (chapterMatch) {
-                                if (lastChapter !== "") {
-                                    usfmContent += chapterContent;
-                                } else if (isFirstChapter) {
-                                    isFirstChapter = false;
-                                }
-
-                                const chapterNum = parseInt(
-                                    chapterMatch[1],
-                                    10
-                                );
-                                currentChapter = chapterNum;
-                                lastChapter =
-                                    chapterNum.toString();
-                                chapterContent = `\\c ${chapterNum}\n\\p\n`;
-                            } else {
-                                chapterContent += `\\p ${cellContent}\n`;
-                            }
-                        } else {
-                            chapterContent += `\\p ${cellContent}\n`;
-                        }
-                    } else if (
-                        isContentCellType(cellMetadata.type)
-                    ) {
-                        const verseRef = getVerseRefForCell(cell);
-                        if (verseRef) {
-                            const chapterMatch =
-                                verseRef.match(/\s(\d+):/);
-                            const verseMatch = verseRef.match(/\d+$/);
-
-                            if (chapterMatch && verseMatch) {
-                                const chapterNum = parseInt(
-                                    chapterMatch[1],
-                                    10
-                                );
-
-                                if (chapterNum !== currentChapter) {
-                                    if (chapterContent) {
-                                        usfmContent += chapterContent;
-                                    }
-
-                                    currentChapter = chapterNum;
-                                    lastChapter = chapterNum.toString();
-                                    chapterContent = `\\c ${chapterNum}\n\\p\n`;
-                                    isFirstChapter = false;
-                                }
-
-                                if (
-                                    lastChapter === "" &&
-                                    isFirstChapter
-                                ) {
-                                    lastChapter = "1";
-                                    currentChapter = 1;
-                                    chapterContent = `\\c 1\n\\p\n`;
-                                    isFirstChapter = false;
-                                }
-
-                                const verseNumber = verseMatch[0];
-                                chapterContent += `\\v ${verseNumber} ${cellContent}\n`;
-                                verseCount++;
-                                hasVerses = true;
-                            }
-                        }
-                    }
-                }
-
-                if (chapterContent) {
-                    usfmContent += chapterContent;
-                }
+                const { body, verseCount, hasVerses } = buildUsfmBody(relevantCells, {
+                    paratextAsHeadings: options?.paratextAsHeadings,
+                });
+                usfmContent += body;
 
                 usfmContent =
                     usfmContent.replace(/\n{2,}/g, "\n").trim() + "\n";

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1719,6 +1719,12 @@ function getWebviewContent(
                                         </div>
                                     </div>
                                 </div>
+                                <div class="format-section-suboption" id="usfmOptions" style="display: none;" data-option="usfm">
+                                    <label class="format-option-toggle" id="usfmParatextHeadingsToggle">
+                                        <input type="checkbox" id="usfmParatextHeadingsCb">
+                                        Export paratext cells as section headings (\\s1)
+                                    </label>
+                                </div>
                             </div>
                             <!-- Subtitle options -->
                             <div class="format-section" id="subtitle-section" data-option="subtitles">
@@ -4144,7 +4150,7 @@ function getWebviewContent(
                             option.classList.add('selected');
                             selectedFormat = option.dataset.format;
                             const usfmOptions = document.getElementById('usfmOptions');
-                            if (usfmOptions) usfmOptions.style.display = selectedFormat === 'usfm' ? 'block' : 'none';
+                            if (usfmOptions) usfmOptions.style.display = (selectedFormat === 'usfm' || selectedFormat === 'usfm-no-validate') ? 'block' : 'none';
 
                             checkTextSelectionMismatch();
 
@@ -4251,6 +4257,10 @@ function getWebviewContent(
                     if (formatToSend === 'usfm-no-validate') {
                         formatToSend = 'usfm';
                         options.skipValidation = true;
+                    }
+                    if (formatToSend === 'usfm') {
+                        const paratextHeadingsCb = document.getElementById('usfmParatextHeadingsCb');
+                        if (paratextHeadingsCb && paratextHeadingsCb.checked) options.paratextAsHeadings = true;
                     }
                     if (selectedAudioMode) {
                         options.includeAudio = true;

--- a/src/test/suite/export/usfmParatextHeadings.test.ts
+++ b/src/test/suite/export/usfmParatextHeadings.test.ts
@@ -1,0 +1,136 @@
+import * as assert from "assert";
+import { buildUsfmBody, type UsfmExportCell } from "../../../exportHandler/usfmBodyBuilder";
+
+function verseCell(ref: string, text: string): UsfmExportCell {
+    return {
+        metadata: {
+            type: "text",
+            id: "00000000-0000-0000-0000-000000000000",
+            data: { globalReferences: [ref] },
+        },
+        value: `<span>${text}</span>`,
+    };
+}
+
+function paratextCell(text: string, marker?: string): UsfmExportCell {
+    return {
+        metadata: {
+            type: "paratext",
+            id: "parent-id:paratext-1234567890-abcdefghi",
+            ...(marker ? { marker } : {}),
+        },
+        value: `<span>${text}</span>`,
+    };
+}
+
+/**
+ * Covers the Pattani Malay heading-export bug: paratext section headings
+ * entered before a chapter's first verse must land inside that chapter
+ * (after its \c marker), not in the previous chapter or book front matter.
+ */
+suite("USFM export - paratext heading placement and markers", () => {
+    test("chapter-leading paratext lands after its chapter's \\c marker as \\s1 when option is on", () => {
+        const { body, verseCount, hasVerses } = buildUsfmBody(
+            [
+                paratextCell("Heading A"),
+                verseCell("MAT 1:1", "Alpha"),
+                verseCell("MAT 1:2", "Beta"),
+                paratextCell("Heading B"),
+                verseCell("MAT 2:1", "Gamma"),
+            ],
+            { paratextAsHeadings: true }
+        );
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\s1 Heading A\n\\p\n\\v 1 Alpha\n\\v 2 Beta\n" +
+            "\\c 2\n\\s1 Heading B\n\\p\n\\v 1 Gamma\n"
+        );
+        assert.strictEqual(verseCount, 3);
+        assert.strictEqual(hasVerses, true);
+    });
+
+    test("mid-chapter paratext heading stays inline with a paragraph restart", () => {
+        const { body } = buildUsfmBody(
+            [
+                verseCell("MAT 1:1", "Alpha"),
+                paratextCell("Mid Heading"),
+                verseCell("MAT 1:2", "Beta"),
+            ],
+            { paratextAsHeadings: true }
+        );
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\s1 Mid Heading\n\\p\n\\v 2 Beta\n"
+        );
+    });
+
+    test("with option off, paratext exports as \\p but still in the correct chapter", () => {
+        const { body } = buildUsfmBody([
+            paratextCell("Heading A"),
+            verseCell("MAT 1:1", "Alpha"),
+        ]);
+
+        assert.strictEqual(body, "\\c 1\n\\p Heading A\n\\p\n\\v 1 Alpha\n");
+    });
+
+    test("importer-preserved markers pass through regardless of the option", () => {
+        const { body } = buildUsfmBody([
+            paratextCell("Section Title", "\\s"),
+            verseCell("MAT 1:1", "Alpha"),
+            paratextCell("Poetry line", "\\q1"),
+            verseCell("MAT 1:2", "Beta"),
+        ]);
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\s Section Title\n\\p\n\\v 1 Alpha\n\\q1 Poetry line\n\\v 2 Beta\n"
+        );
+    });
+
+    test("explicit heading tags in content map to \\s markers even with option off", () => {
+        const headingCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "parent:paratext-1-x" },
+            value: "<h2>Formatted Title</h2>",
+        };
+        const { body } = buildUsfmBody([
+            verseCell("MAT 1:1", "Alpha"),
+            headingCell,
+            verseCell("MAT 1:2", "Beta"),
+        ]);
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\s1 Formatted Title\n\\p\n\\v 2 Beta\n"
+        );
+    });
+
+    test("legacy 'Chapter N' paratext cells still open chapters without duplicate \\c markers", () => {
+        const legacyChapterCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "legacy-1" },
+            value: "<h1>Chapter 1</h1>",
+        };
+        const { body } = buildUsfmBody([
+            legacyChapterCell,
+            verseCell("MAT 1:1", "Alpha"),
+        ]);
+
+        assert.strictEqual(body, "\\c 1\n\\p\n\\v 1 Alpha\n");
+    });
+
+    test("paratext after the last verse stays in the final chapter", () => {
+        const { body } = buildUsfmBody(
+            [
+                verseCell("MAT 1:1", "Alpha"),
+                paratextCell("Trailing note"),
+            ],
+            { paratextAsHeadings: true }
+        );
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\s1 Trailing note\n\\p\n"
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Closes #1130

When exporting a project to USFM, chapter headings stored in paratext cells were
not coming out as headings. A heading typed before the first verse of a chapter
was placed in the wrong spot — at the end of the previous chapter, or before the
`\c 1` marker at the very top of the book — and it was written as a plain `\p`
paragraph instead of a `\s1` section heading. Tools that read the USFM file
(such as Paratext and ETT) dropped or ignored these lines, so the headings
looked like they were never exported.

This PR fixes the placement so every paratext cell lands inside the chapter it
belongs to, and adds a new export option, "Export paratext cells as section
headings (\s1)", for projects whose headings have no explicit formatting or
marker. The option is off by default, so no other project's exports change
unless the person exporting turns it on.

## Changes
- Moved the chapter/verse building logic out of `usfmExporter.ts` into a new
  pure function `buildUsfmBody()` in `src/exportHandler/usfmBodyBuilder.ts`, and
  removed an unused pre-pass loop (dead code).
- A paratext cell that sits between chapters is now held back and written right
  after the next chapter's `\c` marker, instead of leaking into the previous
  chapter or the book's front matter.
- Marker choice for paratext cells now follows a clear order: content formatted
  with `<h1>`–`<h4>` becomes `\s1`–`\s3` (the `<h1>` rule was missing before);
  a USFM marker saved by an importer (`metadata.marker`) is used as-is;
  everything else stays `\p` unless the new option is on.
- Added the "Export paratext cells as section headings (\s1)" checkbox to the
  USFM section of the export dialog, carried through as
  `ExportOptions.paratextAsHeadings`.
- After any heading line, a `\p` is written so the verses that follow do not
  attach to the heading.
- Added regression tests in
  `src/test/suite/export/usfmParatextHeadings.test.ts`.

## Test Checklist
### Real project data
- [x] Ran the new builder against the real Pattani Malay `MAT.codex`: the
      chapter 1 heading now appears as `\s1` after `\c 1` (it used to sit
      before `\c 1`), the chapter 2 heading appears after `\c 2` (it used to
      sit at the end of chapter 1), and mid-chapter headings get `\s1` with a
      `\p` restart — 137 headings and 1,068 verses total
- [x] With the option off, output for projects without paratext headings is
      unchanged from the old exporter

### Manual UI (needs a quick pass in the extension host)
- [x] The new checkbox shows when USFM or "USFM Without Validation" is
      selected, and hides for other formats
- [x] Exporting with the checkbox ticked produces `\s1` headings in the
      downloaded file