### PR TITLE
Fix ghost tags and fix warnings

### DIFF
--- a/sharedUtils/htmlStructureUtils.ts
+++ b/sharedUtils/htmlStructureUtils.ts
@@ -75,35 +75,6 @@ const stripEmptyParagraphs = (html: string): string =>
 const stripEmptyBareSpans = (html: string): string =>
     (html || "").replace(/<span>(?:\s|&nbsp;)*<\/span>/gi, "");
 
-const attrsLookLike = (attrs: string, token: RegExp): boolean => token.test(attrs);
-
-/**
- * Drop InDesign editor-only markup that a translator cannot type and that
- * export already restores from `idmlStructure` metadata:
- * - empty `idml-eoc` glue spans,
- * - attributed EOC `<br>`s (same role as a user line break),
- * - `idml-segment` character-style runs (apostrophes, etc.).
- * Semantic spans (`data-tag`, inline styles) are left intact.
- */
-const stripIdmlInternalMarkup = (html: string): string => {
-    let result = (html || "")
-        .replace(/<span\b([^>]*)>\s*<\/span>/gi, (full, attrs: string) =>
-            attrsLookLike(attrs, /\bidml-eoc\b|\bdata-eoc=/) ? "" : full
-        )
-        .replace(/<br\b([^>]*)\/?>/gi, (full, attrs: string) =>
-            attrsLookLike(attrs, /\bidml-eoc\b|\bdata-eoc=/) ? " " : full
-        );
-
-    let previous = "";
-    while (previous !== result) {
-        previous = result;
-        result = result.replace(/<span\b([^>]*)>([\s\S]*?)<\/span>/gi, (full, attrs: string, inner: string) =>
-            attrsLookLike(attrs, /\bidml-segment\b|\bdata-segment-index=/) ? inner : full
-        );
-    }
-    return result;
-};
-
 const summarizeTagList = (tags: string[]): string => {
     const counts = new Map<string, number>();
     for (const tag of tags) {
@@ -164,20 +135,18 @@ export const joinMergedCellHtml = (previousHtml: string, currentHtml: string): s
 };
 
 /**
- * Normalize an HTML fragment for structure comparison. Structure enforcement
- * exists for round-trip export fidelity, and line breaks are user content
- * that neither exporter's mapping depends on — so differences a line break
- * creates must never surface as mismatch errors (or worse, get stripped by a
- * resolve). Applied to both sides:
+ * Normalize an HTML fragment for structure comparison. User line breaks are
+ * allowed (Enter / Shift+Enter); InDesign spans, EOC markers, and other
+ * real tags are still enforced. Applied to both sides:
  * - empty paragraphs (blank lines) are dropped,
- * - InDesign segment/EOC markup is dropped (export uses cell metadata),
  * - empty bare `<span>` spacers from cell merge are dropped,
- * - bare `<br>` tags are dropped,
+ * - bare `<br>` tags are dropped (attributed breaks such as InDesign's
+ *   `<br class="idml-eoc">` still count as structure),
  * - adjacent bare-paragraph boundaries are collapsed, so a paragraph the
  *   user split with Enter still compares as one block.
  */
 const normalizeForStructureComparison = (html: string): string =>
-    stripEmptyBareSpans(stripIdmlInternalMarkup(stripEmptyParagraphs(html)))
+    stripEmptyBareSpans(stripEmptyParagraphs(html))
         .replace(/<br\s*\/?>/gi, " ")
         .replace(/<\/p>\s*<p>/gi, " ");
 

--- a/sharedUtils/htmlStructureUtils.ts
+++ b/sharedUtils/htmlStructureUtils.ts
@@ -75,6 +75,45 @@ const stripEmptyParagraphs = (html: string): string =>
 const stripEmptyBareSpans = (html: string): string =>
     (html || "").replace(/<span>(?:\s|&nbsp;)*<\/span>/gi, "");
 
+const attrsLookLike = (attrs: string, token: RegExp): boolean => token.test(attrs);
+
+/**
+ * Drop InDesign editor-only markup that a translator cannot type and that
+ * export already restores from `idmlStructure` metadata:
+ * - empty `idml-eoc` glue spans,
+ * - attributed EOC `<br>`s (same role as a user line break),
+ * - `idml-segment` character-style runs (apostrophes, etc.).
+ * Semantic spans (`data-tag`, inline styles) are left intact.
+ */
+const stripIdmlInternalMarkup = (html: string): string => {
+    let result = (html || "")
+        .replace(/<span\b([^>]*)>\s*<\/span>/gi, (full, attrs: string) =>
+            attrsLookLike(attrs, /\bidml-eoc\b|\bdata-eoc=/) ? "" : full
+        )
+        .replace(/<br\b([^>]*)\/?>/gi, (full, attrs: string) =>
+            attrsLookLike(attrs, /\bidml-eoc\b|\bdata-eoc=/) ? " " : full
+        );
+
+    let previous = "";
+    while (previous !== result) {
+        previous = result;
+        result = result.replace(/<span\b([^>]*)>([\s\S]*?)<\/span>/gi, (full, attrs: string, inner: string) =>
+            attrsLookLike(attrs, /\bidml-segment\b|\bdata-segment-index=/) ? inner : full
+        );
+    }
+    return result;
+};
+
+const summarizeTagList = (tags: string[]): string => {
+    const counts = new Map<string, number>();
+    for (const tag of tags) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+        .map(([tag, count]) => (count > 1 ? `${count}× ${tag}` : tag))
+        .join(", ");
+};
+
 /**
  * Extract normalized plain text from an HTML fragment. Used to detect when a
  * "resolved" translation actually reverted to the source-language text, and
@@ -129,16 +168,16 @@ export const joinMergedCellHtml = (previousHtml: string, currentHtml: string): s
  * exists for round-trip export fidelity, and line breaks are user content
  * that neither exporter's mapping depends on — so differences a line break
  * creates must never surface as mismatch errors (or worse, get stripped by a
- * resolve). Four normalizations, applied to both sides:
+ * resolve). Applied to both sides:
  * - empty paragraphs (blank lines) are dropped,
+ * - InDesign segment/EOC markup is dropped (export uses cell metadata),
  * - empty bare `<span>` spacers from cell merge are dropped,
- * - bare `<br>` tags are dropped (attributed breaks such as InDesign's
- *   `<br class="idml-eoc">` still count as structure),
+ * - bare `<br>` tags are dropped,
  * - adjacent bare-paragraph boundaries are collapsed, so a paragraph the
  *   user split with Enter still compares as one block.
  */
 const normalizeForStructureComparison = (html: string): string =>
-    stripEmptyBareSpans(stripEmptyParagraphs(html))
+    stripEmptyBareSpans(stripIdmlInternalMarkup(stripEmptyParagraphs(html)))
         .replace(/<br\s*\/?>/gi, " ")
         .replace(/<\/p>\s*<p>/gi, " ");
 
@@ -164,10 +203,10 @@ export const compareHtmlStructure = (
     const missingInTarget = tagDifference(sourceTags, targetTags);
     const extraInTarget = tagDifference(targetTags, sourceTags);
     if (missingInTarget.length > 0) {
-        errors.push(`Missing tags: ${missingInTarget.join(", ")}`);
+        errors.push(`Missing tags: ${summarizeTagList(missingInTarget)}`);
     }
     if (extraInTarget.length > 0) {
-        errors.push(`Extra tags: ${extraInTarget.join(", ")}`);
+        errors.push(`Extra tags: ${summarizeTagList(extraInTarget)}`);
     }
     if (errors.length === 0 && sourceSkeleton !== targetSkeleton) {
         errors.push("Tag order or nesting differs from source");

--- a/sharedUtils/htmlStructureUtils.ts
+++ b/sharedUtils/htmlStructureUtils.ts
@@ -68,19 +68,77 @@ const stripEmptyParagraphs = (html: string): string =>
     (html || "").replace(/<p\b[^>]*>(?:\s|&nbsp;|<br\s*\/?>)*<\/p>/gi, "");
 
 /**
+ * Drop attribute-less empty `<span>&nbsp;</span>` spacers (the join marker
+ * cell merge inserts between two cells). They are not round-trip structure.
+ * Spans with attributes are preserved.
+ */
+const stripEmptyBareSpans = (html: string): string =>
+    (html || "").replace(/<span>(?:\s|&nbsp;)*<\/span>/gi, "");
+
+/**
+ * Extract normalized plain text from an HTML fragment. Used to detect when a
+ * "resolved" translation actually reverted to the source-language text, and
+ * to treat untranslated/placeholder cells as empty for structure checks.
+ */
+export const extractPlainTextFromHtml = (html: string): string =>
+    (html || "")
+        .replace(/<[^>]*>/g, " ")
+        .replace(/&nbsp;/g, " ")
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, " ")
+        .trim();
+
+/**
+ * Untranslated cells and merge-spacer-only cells are not translations.
+ * Flagging them as structure mismatches (and offering Resolve) is wrong:
+ * there is no translation yet, and Resolve cannot invent one without
+ * copying source-language text.
+ */
+export const isEmptyOrPlaceholderHtml = (html: string | undefined | null): boolean => {
+    if (!html) return true;
+    const text = extractPlainTextFromHtml(html).toLowerCase();
+    return text.length === 0 || text === "click to translate" || text === "no text";
+};
+
+/** Inserted between two non-empty cells when they are merged. */
+export const MERGE_CELL_SEPARATOR = "<span>&nbsp;</span>";
+
+/**
+ * Join two cell HTML fragments for a merge. Empty/placeholder cells stay
+ * empty so they are not mistaken for translated content (which would trip
+ * HTML structure enforcement). The spacer is only used when both sides
+ * have real text.
+ */
+export const joinMergedCellHtml = (previousHtml: string, currentHtml: string): string => {
+    const previousEmpty = isEmptyOrPlaceholderHtml(previousHtml);
+    const currentEmpty = isEmptyOrPlaceholderHtml(currentHtml);
+    if (!previousEmpty && !currentEmpty) {
+        return `${previousHtml}${MERGE_CELL_SEPARATOR}${currentHtml}`;
+    }
+    if (!previousEmpty) return previousHtml;
+    if (!currentEmpty) return currentHtml;
+    return "";
+};
+
+/**
  * Normalize an HTML fragment for structure comparison. Structure enforcement
  * exists for round-trip export fidelity, and line breaks are user content
  * that neither exporter's mapping depends on — so differences a line break
  * creates must never surface as mismatch errors (or worse, get stripped by a
- * resolve). Three normalizations, applied to both sides:
+ * resolve). Four normalizations, applied to both sides:
  * - empty paragraphs (blank lines) are dropped,
+ * - empty bare `<span>` spacers from cell merge are dropped,
  * - bare `<br>` tags are dropped (attributed breaks such as InDesign's
  *   `<br class="idml-eoc">` still count as structure),
  * - adjacent bare-paragraph boundaries are collapsed, so a paragraph the
  *   user split with Enter still compares as one block.
  */
 const normalizeForStructureComparison = (html: string): string =>
-    stripEmptyParagraphs(html)
+    stripEmptyBareSpans(stripEmptyParagraphs(html))
         .replace(/<br\s*\/?>/gi, " ")
         .replace(/<\/p>\s*<p>/gi, " ");
 
@@ -88,6 +146,13 @@ export const compareHtmlStructure = (
     sourceHtml: string,
     targetHtml: string,
 ): HtmlStructureDiff => {
+    // Untranslated / spacer-only targets are not mismatches. Checking them
+    // would flag every empty cell against a paragraph-based source (IDML,
+    // docx) and make Resolve fail after merging two untranslated cells.
+    if (isEmptyOrPlaceholderHtml(targetHtml)) {
+        return { isMatch: true, errors: [] };
+    }
+
     const sourceSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(sourceHtml));
     const targetSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(targetHtml));
     if (sourceSkeleton === targetSkeleton) {
@@ -320,19 +385,3 @@ export const tryDeterministicStructureFix = (
     }
     return null;
 };
-
-/**
- * Extract normalized plain text from an HTML fragment. Used to detect when a
- * "resolved" translation actually reverted to the source-language text.
- */
-export const extractPlainTextFromHtml = (html: string): string =>
-    (html || "")
-        .replace(/<[^>]*>/g, " ")
-        .replace(/&nbsp;/g, " ")
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'")
-        .replace(/\s+/g, " ")
-        .trim();

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -1132,7 +1132,7 @@ function getWebviewContent(
                     overflow-y: auto;
                 }
                 .popup-file-list div { padding: 2px 0; display: flex; align-items: center; }
-                .popup-footer { display: flex; justify-content: flex-end; margin-top: 16px; flex-shrink: 0; }
+                .popup-footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; flex-shrink: 0; }
 
                 /* Step 4: Exporting screen */
                 .export-progress-card {
@@ -2053,8 +2053,13 @@ function getWebviewContent(
                         <p id="htmlMismatchSummary"></p>
                         <div class="popup-file-list" id="htmlMismatchFileList"></div>
                         <p style="margin-top: 8px; color: var(--vscode-descriptionForeground); font-size: 0.85em;">
-                            Review and resolve these in the editor before exporting, or proceed with the export anyway.
+                            These cells may not round-trip with their original formatting. You can still export.
                         </p>
+                    </div>
+                    <div class="popup-footer">
+                        <button type="button" onclick="continueHtmlMismatchAnyway()">
+                            Continue anyway
+                        </button>
                     </div>
                 </div>
             </div>
@@ -4242,6 +4247,11 @@ function getWebviewContent(
                 function closeHtmlMismatchPopup() {
                     const popup = document.getElementById('htmlMismatchPopup');
                     if (popup) popup.classList.remove('visible');
+                }
+
+                function continueHtmlMismatchAnyway() {
+                    closeHtmlMismatchPopup();
+                    advanceFromStep2();
                 }
 
                 function exportProject() {

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -676,8 +676,10 @@ interface MessageHandlerContext {
 }
 
 /**
- * Sends updated milestone index and current cells to the webview so milestone edits appear immediately.
- * Used after updateMilestoneValue, by refreshWebviewAfterMilestoneEdits, and by refreshWebviewsForFiles.
+ * Sends updated milestone index and current cells to the webview so milestone
+ * edits appear immediately, without remounting HTML or re-requesting the page
+ * (either of which would jump scroll). Used after updateMilestoneValue, by
+ * refreshWebviewAfterMilestoneEdits, and by refreshWebviewsForFiles.
  */
 export async function sendMilestoneRefreshToWebview(
     document: CodexCellDocument,
@@ -759,15 +761,10 @@ export async function sendMilestoneRefreshToWebview(
             enableMilestonePlacementEditing,
             force: true,
         });
-
-        safePostMessageToPanel(webviewPanel, {
-            type: "refreshCurrentPage",
-            rev,
-            milestoneIndex: currentPosition.milestoneIndex,
-            subsectionIndex: currentPosition.subsectionIndex,
-            force: true,
-        });
-        debug(`[sendMilestoneRefreshToWebview] Sent updated milestone index and refreshCurrentPage for milestone ${currentPosition.milestoneIndex}, subsection ${currentPosition.subsectionIndex}`);
+        // Do not also send refreshCurrentPage: that clears cell caches and
+        // re-requests the same page, which remounts the list and jumps scroll
+        // to the top of the chapter. The paginated payload already has the cells.
+        debug(`[sendMilestoneRefreshToWebview] Sent updated milestone index for milestone ${currentPosition.milestoneIndex}, subsection ${currentPosition.subsectionIndex}`);
     } else {
         // Don't remount the webview HTML — that resets scroll to the top of the file.
         // The webview already knows its current page; ask it to reload those cells.

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -718,9 +718,16 @@ export async function sendMilestoneRefreshToWebview(
             sourceCellMap
         );
 
-        const authApi = await provider.getAuthApi();
-        const userInfo = await authApi?.getUserInfo();
-        const username = userInfo?.username || "anonymous";
+        let username = "anonymous";
+        try {
+            const authApi = await provider.getAuthApi();
+            if (authApi && typeof authApi.getUserInfo === "function") {
+                const userInfo = await authApi.getUserInfo();
+                username = userInfo?.username || "anonymous";
+            }
+        } catch (error) {
+            debug("sendMilestoneRefreshToWebview: failed to resolve username from authApi", error);
+        }
 
         const rev = provider.getDocumentRevision(docUri);
         const useSubdivisionNumberLabels = config.get(
@@ -762,7 +769,14 @@ export async function sendMilestoneRefreshToWebview(
         });
         debug(`[sendMilestoneRefreshToWebview] Sent updated milestone index and refreshCurrentPage for milestone ${currentPosition.milestoneIndex}, subsection ${currentPosition.subsectionIndex}`);
     } else {
-        provider.refreshWebview(webviewPanel, document);
+        // Don't remount the webview HTML — that resets scroll to the top of the file.
+        // The webview already knows its current page; ask it to reload those cells.
+        const rev = provider.getDocumentRevision(docUri);
+        safePostMessageToPanel(webviewPanel, {
+            type: "refreshCurrentPage",
+            rev,
+        });
+        debug("[sendMilestoneRefreshToWebview] No tracked position; sent refreshCurrentPage so the webview keeps its place");
     }
 }
 
@@ -4564,8 +4578,8 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 vscode.window.showWarningMessage("Could not fully undo the merge — no project folder found.");
             }
 
-            // Refresh the webview to show the updated state
-            provider.refreshWebview(webviewPanel, document);
+            // Refresh in place so unmerge doesn't jump the editor to the top
+            await sendMilestoneRefreshToWebview(document, webviewPanel, provider);
 
         } catch (error) {
             console.error("Error canceling merge for cell:", cellId, error);
@@ -5813,7 +5827,9 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 webviewPanel,
                 provider,
                 updateWebview: () => {
-                    provider.refreshWebview(webviewPanel, document);
+                    sendMilestoneRefreshToWebview(document, webviewPanel, provider).catch((error) => {
+                        console.warn("[confirmCellMerge] Failed to refresh webview after merge:", error);
+                    });
                 }
             });
 
@@ -6318,8 +6334,9 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
 
             debug(`Successfully merged cell ${currentCellId} with ${previousCellId}`);
 
-            // Refresh the webview content
-            provider.refreshWebview(webviewPanel, document);
+            // Refresh in place so the source/target editor keeps its chapter and
+            // scroll position. refreshWebview() remounts the HTML and jumps to the top.
+            await sendMilestoneRefreshToWebview(document, webviewPanel, provider);
 
         } catch (error) {
             console.error("Error merging cells:", error);

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -37,6 +37,7 @@ import {
     type SourceCellMapEntry,
 } from "./utils/sourceCellTimestampsUtils";
 import { MAX_AUDIO_ATTACHMENT_BYTES } from "../../../sharedUtils";
+import { joinMergedCellHtml } from "../../../sharedUtils/htmlStructureUtils";
 import { transcodeWavToOpusWebm } from "../../utils/audioProcessor";
 
 // Enable debug logging if needed
@@ -5888,8 +5889,10 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 } as any);
             }
 
-            // 1. Concatenate content and create merged edit
-            const mergedContent = previousContent + "<span>&nbsp;</span>" + currentContent;
+            // 1. Concatenate content and create merged edit.
+            // Empty cells stay empty — a spacer-only result would look like
+            // translated content and fail HTML structure enforcement.
+            const mergedContent = joinMergedCellHtml(previousContent, currentContent);
             const mergeEdit: EditHistory = {
                 editMap: EditMapUtils.value(),
                 value: mergedContent,

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -3724,7 +3724,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                 mergeEvent,
                 panelForMerge,
                 documentForMerge,
-                async () => await this.refreshWebview(panelForMerge, documentForMerge),
+                async () => await sendMilestoneRefreshToWebview(documentForMerge, panelForMerge, this),
                 this
             );
 
@@ -3850,10 +3850,10 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
 
             debug(`Successfully unmerged cell ${cellIdToUnmerge} in ${isSourceToTarget ? 'target' : 'source'} file ${targetFileName}`);
 
-            // Refresh the target webview if it's open
+            // Refresh the target webview if it's open, in place so it doesn't jump to the top
             const targetPanel = this.webviewPanels.get(targetDocumentUri);
             if (targetPanel) {
-                await this.refreshWebview(targetPanel, targetDocument);
+                await sendMilestoneRefreshToWebview(targetDocument, targetPanel, this);
             }
 
             vscode.window.showInformationMessage(

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -684,9 +684,21 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         openContext: { backupId?: string; },
         _token: vscode.CancellationToken
     ): Promise<CodexCellDocument> {
-        // Check if document is already open
-        const existingDoc = this.documents.get(uri.toString());
+        // Check if document is already open (exact URI, then fsPath for Uri.file vs joinPath)
+        const existingDoc = this.documents.get(uri.toString())
+            ?? this.findLiveEditorForUri(uri).document;
         if (existingDoc) {
+            // Never replace a document that a webview is bound to. Reloading
+            // from disk here created a detached instance after source-side
+            // cell merges saved the target, so later merges persisted but the
+            // live target editor kept showing only the first merge until a
+            // window reload. Dirty documents without a live editor still
+            // reload when mtime is newer so tests (and callers) that write
+            // then reopen pick up the on-disk state.
+            const hasLiveWebview = !!this.findLiveEditorForUri(existingDoc.uri).panel;
+            if (hasLiveWebview) {
+                return existingDoc;
+            }
             // Check if file has changed on disk (for test scenarios where file is modified externally)
             try {
                 const fileStat = await vscode.workspace.fs.stat(uri);
@@ -2252,6 +2264,41 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
     }
 
     /**
+     * Finds the live editor (document + panel) for `uri`, matching on URI
+     * string first and falling back to normalized fsPath so `Uri.file` vs
+     * `Uri.joinPath` lookups still hit the instance the webview is bound to.
+     */
+    private findLiveEditorForUri(uri: vscode.Uri): {
+        document: CodexCellDocument | undefined;
+        panel: vscode.WebviewPanel | undefined;
+    } {
+        const exactKey = uri.toString();
+        const exactPanel = this.webviewPanels.get(exactKey);
+        const exactDoc = this.documents.get(exactKey);
+        if (exactPanel && exactDoc) {
+            return { document: exactDoc, panel: exactPanel };
+        }
+
+        const normalized = path.normalize(uri.fsPath);
+        for (const [key, panel] of this.webviewPanels.entries()) {
+            const doc = this.documents.get(key);
+            const candidatePath = doc?.uri.fsPath ?? vscode.Uri.parse(key).fsPath;
+            if (path.normalize(candidatePath) === normalized) {
+                return { document: doc, panel };
+            }
+        }
+        for (const [key, doc] of this.documents.entries()) {
+            if (path.normalize(doc.uri.fsPath) === normalized) {
+                return { document: doc, panel: this.webviewPanels.get(key) ?? exactPanel };
+            }
+        }
+        if (exactPanel || exactDoc) {
+            return { document: exactDoc, panel: exactPanel };
+        }
+        return { document: undefined, panel: undefined };
+    }
+
+    /**
      * Returns an open `CodexCellDocument` for `uri` when one is already backing
      * a webview panel; otherwise opens a fresh instance via
      * `openCustomDocument`. Callers receive a document they can mutate and save
@@ -2261,6 +2308,10 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         uri: vscode.Uri
     ): Promise<CodexCellDocument> {
         const uriString = uri.toString();
+        const live = this.findLiveEditorForUri(uri);
+        if (live.document && live.panel) {
+            return live.document;
+        }
         for (const [panelUri] of this.webviewPanels.entries()) {
             if (this.isMatchingFilePair(uriString, panelUri) && panelUri === uriString) {
                 // Reuse the document backing the open panel. openCustomDocument
@@ -3615,94 +3666,65 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         debug("Merging matching cells in target file:", { cellIdOfCellToMerge, cellIdOfTargetCell, uri });
 
         try {
-            // 1. Construct target file path
             const normalizedPath = uri.replace(/\\/g, "/");
             const baseFileName = path.basename(normalizedPath);
             const targetFileName = baseFileName.replace(".source", ".codex");
-
-            // 2. Open or find the target document if it is not already open
             const targetPath = vscode.Uri.joinPath(workspaceFolder.uri, "files", "target", targetFileName);
-            const sourcePath = vscode.Uri.joinPath(workspaceFolder.uri, ".project", "sourceTexts", baseFileName);
 
+            // Reuse the document already backing the open target editor. Re-opening
+            // the pair (and reloading from disk after the previous merge saved)
+            // used to create a detached instance, so later merges persisted but
+            // the live target webview kept showing only the first merge until reload.
+            let { document: targetDocument, panel: targetPanel } = this.findLiveEditorForUri(targetPath);
 
-            // Open the source file in the left-most group (ViewColumn.One)
-            await vscode.commands.executeCommand(
-                "vscode.openWith",
-                sourcePath,
-                "codex.cellEditor",
-                { viewColumn: vscode.ViewColumn.One }
-            );
-
-            // Wait for source webview to be ready before opening target
-            const sourceReady = await this.waitForWebviewReady(sourcePath.toString(), 3000);
-            if (!sourceReady) {
-                debug("Source webview not ready, opening target anyway");
-            }
-
-            // Open the codex file in the right-most group (ViewColumn.Two)
-            await vscode.commands.executeCommand(
-                "vscode.openWith",
-                targetPath,
-                "codex.cellEditor",
-                { viewColumn: vscode.ViewColumn.Two }
-            );
-            // Find the target document instance
-            let targetDocument: CodexCellDocument | undefined;
-
-            // Check if the target document is already open in our webview panels
-            const targetDocumentUri = targetPath.toString();
-            for (const [panelUri, panel] of this.webviewPanels.entries()) {
-                if (this.isMatchingFilePair(targetDocumentUri, panelUri)) {
-                    // Try to get the document from the provider's current document or create it
-                    targetDocument = await this.openCustomDocument(
-                        vscode.Uri.parse(panelUri),
-                        {},
-                        new vscode.CancellationTokenSource().token
-                    );
-                    break;
-                }
+            if (!targetPanel || !targetDocument) {
+                await vscode.commands.executeCommand(
+                    "vscode.openWith",
+                    targetPath,
+                    "codex.cellEditor",
+                    { viewColumn: vscode.ViewColumn.Two }
+                );
+                const liveEditor = this.findLiveEditorForUri(targetPath);
+                targetPanel = liveEditor.panel;
+                targetDocument = liveEditor.document;
             }
 
             if (!targetDocument) {
-                // If not found in panels, create a new document instance
-                targetDocument = await this.openCustomDocument(
-                    targetPath,
-                    {},
-                    new vscode.CancellationTokenSource().token
-                );
+                targetDocument = await this.getOrOpenDocumentForUri(targetPath);
             }
 
-            // 3. Get the content from both cells
-            const currentCellContent = this.currentDocument?.getCellContent(cellIdOfCellToMerge);
-            const targetCellContent = targetDocument.getCellContent(cellIdOfTargetCell);
+            const currentCellContent = targetDocument.getCellContent(cellIdOfCellToMerge);
+            const previousCellContent = targetDocument.getCellContent(cellIdOfTargetCell);
 
-            if (!currentCellContent || !targetCellContent) {
+            if (!currentCellContent || !previousCellContent) {
                 throw new Error("Could not find one or both cells for merge operation");
             }
 
-            // 4. Use the existing mergeCellWithPrevious command
-            const targetPanel = this.webviewPanels.get(targetDocumentUri);
+            if (!targetPanel) {
+                targetPanel = this.getWebviewPanelForUri(targetDocument.uri);
+            }
             if (!targetPanel) {
                 throw new Error("Could not find target webview panel");
             }
 
-            // Create a merge event to reuse existing handler
+            const panelForMerge = targetPanel;
+            const documentForMerge = targetDocument;
+
             const mergeEvent: EditorPostMessages = {
                 command: "mergeCellWithPrevious" as const,
                 content: {
                     currentCellId: cellIdOfCellToMerge,
                     previousCellId: cellIdOfTargetCell,
                     currentContent: currentCellContent.cellContent || "",
-                    previousContent: targetCellContent.cellContent || ""
-                }
+                    previousContent: previousCellContent.cellContent || "",
+                },
             };
 
-            // Call the existing merge handler directly
             await handleMessages(
                 mergeEvent,
-                targetPanel,
-                targetDocument,
-                async () => await this.refreshWebview(targetPanel, targetDocument),
+                panelForMerge,
+                documentForMerge,
+                async () => await this.refreshWebview(panelForMerge, documentForMerge),
                 this
             );
 

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -5127,9 +5127,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
         this.isCorrectionEditorMode = !this.isCorrectionEditorMode;
         debug("Correction editor mode toggled:", this.isCorrectionEditorMode);
 
-        // Removed bulk preservation of original content to avoid mass edits on toggle
-
-        // Broadcast the change to all webviews
+        // Broadcast the change to all webviews so React state updates without a remount
         this.webviewPanels.forEach((panel) => {
             this.postMessageToWebview(panel, {
                 type: "correctionEditorModeChanged",
@@ -5137,18 +5135,26 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
             });
         });
 
-        // Refresh all open webviews so hidden/merged cells are shown or filtered correctly
+        // Re-process cells (merged/hidden visibility) in place so source and target
+        // keep their chapter and scroll position. refreshWebview() remounts HTML and
+        // jumps to the top; doing that only for currentDocument also remounted the
+        // other pane when focus shifted mid-loop.
         for (const [docUri, panel] of this.webviewPanels) {
-            if (this.currentDocument && docUri === this.currentDocument.uri.toString()) {
-                await this.refreshWebview(panel, this.currentDocument);
+            const document = this.documents.get(docUri);
+            if (document) {
+                await sendMilestoneRefreshToWebview(document, panel, this);
             } else {
                 const rev = this.getDocumentRevision(docUri);
                 const currentPosition = this.currentMilestoneSubsectionMap.get(docUri);
                 safePostMessageToPanel(panel, {
                     type: "refreshCurrentPage",
                     rev,
-                    milestoneIndex: currentPosition?.milestoneIndex ?? 0,
-                    subsectionIndex: currentPosition?.subsectionIndex ?? 0,
+                    ...(currentPosition
+                        ? {
+                            milestoneIndex: currentPosition.milestoneIndex,
+                            subsectionIndex: currentPosition.subsectionIndex,
+                        }
+                        : {}),
                 });
             }
         }

--- a/src/test/suite/codexCellEditorProvider.test.ts
+++ b/src/test/suite/codexCellEditorProvider.test.ts
@@ -2723,6 +2723,83 @@ suite("CodexCellEditorProvider Test Suite", () => {
         }
     });
 
+    test("sequential mergeMatchingCellsInTargetFile calls keep applying to the live target document", async function () {
+        this.timeout(20000);
+        const provider = new CodexCellEditorProvider(context);
+
+        const wsDir = path.join(os.tmpdir(), `ws-seq-merge-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        const wsUri = vscode.Uri.file(wsDir);
+        await vscode.workspace.fs.createDirectory(wsUri);
+
+        const baseFile = `seq-merge-${Date.now()}.source`;
+        const sourceUri = vscode.Uri.file(path.join(wsDir, ".project", "sourceTexts", baseFile));
+        const targetUri = vscode.Uri.file(path.join(wsDir, "files", "target", baseFile.replace(".source", ".codex")));
+
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(sourceUri.fsPath)));
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(targetUri.fsPath)));
+
+        const baseline = JSON.parse(JSON.stringify(codexSubtitleContent));
+        const labeledCells = (baseline.cells as any[]).filter((c: any) => c?.metadata?.type === "text").slice(0, 3);
+        assert.ok(labeledCells.length >= 3, "Mock notebook should have at least 3 text cells");
+        labeledCells[0].metadata.cellLabel = "9";
+        labeledCells[1].metadata.cellLabel = "10";
+        labeledCells[2].metadata.cellLabel = "11";
+        await vscode.workspace.fs.writeFile(sourceUri, Buffer.from(JSON.stringify(baseline, null, 2)));
+        await vscode.workspace.fs.writeFile(targetUri, Buffer.from(JSON.stringify(baseline, null, 2)));
+
+        const sourceDoc = await provider.openCustomDocument(sourceUri, { backupId: undefined }, new vscode.CancellationTokenSource().token);
+        const targetDoc = await provider.openCustomDocument(targetUri, { backupId: undefined }, new vscode.CancellationTokenSource().token);
+        const sourcePanel = createMockWebviewPanel().panel;
+        const targetPanel = createMockWebviewPanel().panel;
+        await provider.resolveCustomEditor(sourceDoc, sourcePanel, new vscode.CancellationTokenSource().token);
+        await provider.resolveCustomEditor(targetDoc, targetPanel, new vscode.CancellationTokenSource().token);
+
+        const cellA = labeledCells[0].metadata.id as string;
+        const cellB = labeledCells[1].metadata.id as string;
+        const cellC = labeledCells[2].metadata.id as string;
+        const workspaceFolder: vscode.WorkspaceFolder = { uri: wsUri, name: "tmp", index: 0 } as vscode.WorkspaceFolder;
+
+        const originalExec = vscode.commands.executeCommand;
+        // @ts-expect-error test stub
+        vscode.commands.executeCommand = async (command: string, ...args: any[]) => {
+            if (command === "vscode.openWith") {
+                return undefined;
+            }
+            return originalExec(command, ...args);
+        };
+
+        try {
+            await provider.mergeMatchingCellsInTargetFile(cellB, cellA, sourceUri.toString(), workspaceFolder);
+
+            const afterFirstOpen = await provider.openCustomDocument(
+                targetUri,
+                { backupId: undefined },
+                new vscode.CancellationTokenSource().token
+            );
+            assert.strictEqual(
+                afterFirstOpen,
+                targetDoc,
+                "After the first target merge save, openCustomDocument must return the live editor instance, not a disk reload"
+            );
+
+            await provider.mergeMatchingCellsInTargetFile(cellC, cellA, sourceUri.toString(), workspaceFolder);
+
+            const liveTarget = JSON.parse((targetDoc as any).getText());
+            const parent = (liveTarget.cells || []).find((c: any) => c?.metadata?.id === cellA);
+            const childB = (liveTarget.cells || []).find((c: any) => c?.metadata?.id === cellB);
+            const childC = (liveTarget.cells || []).find((c: any) => c?.metadata?.id === cellC);
+            assert.ok(parent && childB && childC, "Live target should still contain all three cells");
+            assert.strictEqual(parent.metadata?.cellLabel, "9-10-11", "Sequential merges should accumulate the parent label on the live target document");
+            assert.strictEqual(!!childB.metadata?.data?.merged, true, "First merged child should stay marked merged");
+            assert.strictEqual(!!childC.metadata?.data?.merged, true, "Second merged child should be marked merged without a window reload");
+        } finally {
+            vscode.commands.executeCommand = originalExec;
+            await deleteIfExists(sourceUri);
+            await deleteIfExists(targetUri);
+            try { await vscode.workspace.fs.delete(wsUri, { recursive: true }); } catch { /* ignore */ }
+        }
+    });
+
     test("LLM completion records an LLM_GENERATION edit in edit history", async () => {
         const provider = new CodexCellEditorProvider(context);
         const document = await provider.openCustomDocument(
@@ -3598,6 +3675,10 @@ suite("CodexCellEditorProvider Test Suite", () => {
             const serializer = new CodexContentSerializer();
             const content = await serializer.serializeNotebook(notebookData, new vscode.CancellationTokenSource().token);
             await vscode.workspace.fs.writeFile(tempUri, content);
+
+            // Give the filesystem a chance to bump mtime so openCustomDocument
+            // reloads from disk instead of returning the pre-write cached instance.
+            await sleep(20);
 
             // Reload document
             const reloadedDoc = await provider.openCustomDocument(

--- a/src/test/suite/codexCellEditorProvider.test.ts
+++ b/src/test/suite/codexCellEditorProvider.test.ts
@@ -4852,7 +4852,6 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 // Track all postMessage calls
                 const postMessageCalls: any[] = [];
                 let webviewHtml = "";
-                let messageCallback: ((message: any) => Promise<void> | void) | null = null;
 
                 const webviewPanel = {
                     webview: {
@@ -4865,9 +4864,7 @@ suite("CodexCellEditorProvider Test Suite", () => {
                         options: { enableScripts: true },
                         asWebviewUri: (uri: vscode.Uri) => uri,
                         cspSource: "https://example.com",
-                        onDidReceiveMessage: (callback: (message: any) => void) => {
-                            // Store the callback so we can invoke it to trigger markWebviewReady
-                            messageCallback = callback;
+                        onDidReceiveMessage: (_callback: (message: any) => void) => {
                             return { dispose: () => { } };
                         },
                         postMessage: (message: any) => {
@@ -4912,64 +4909,40 @@ suite("CodexCellEditorProvider Test Suite", () => {
                     "correctionEditorModeChanged should have enabled: true"
                 );
 
-                // Verify that the HTML contains isCorrectionEditorMode: true
-                // The HTML is set during refreshWebview which is called after toggleCorrectionEditorMode
+                // Toggle must refresh cells in place (so merged/hidden visibility updates)
+                // without remounting the webview HTML, which would jump the editor to the top.
+                const refreshMessage = postMessageCalls.find(
+                    (msg) =>
+                        msg.type === "providerSendsInitialContentPaginated" ||
+                        msg.type === "refreshCurrentPage"
+                );
                 assert.ok(
-                    webviewHtml.includes("isCorrectionEditorMode: true"),
-                    "HTML should contain isCorrectionEditorMode: true when source editing mode is on"
+                    refreshMessage,
+                    `in-place cell refresh should be sent after toggle (found messages: ${postMessageCalls.map((m) => m.type).join(", ")})`
                 );
 
-                // Simulate webview-ready message to trigger pending updates
-                // refreshWebview resets the webview ready state, so scheduled messages won't be sent
-                // until the webview reports ready
-                // Call the actual message callback that was registered during resolveCustomEditor
-                // This will trigger markWebviewReady which executes the scheduled messages
-                if (messageCallback) {
-                    await (messageCallback as (message: any) => Promise<void> | void)({ command: 'webviewReady' });
-                }
-
-                // Wait for scheduled messages to be sent with polling/retries
-                // CI environments may be slower, so we poll with exponential backoff
-                // With milestone-based pagination, the provider sends providerSendsInitialContentPaginated
-                let initialContentMessage = postMessageCalls.find(
+                const paginatedContent = postMessageCalls.find(
                     (msg) => msg.type === "providerSendsInitialContentPaginated"
                 );
-                let attempts = 0;
-                const maxAttempts = 20;
-                while (!initialContentMessage && attempts < maxAttempts) {
-                    await sleep(50 * (attempts + 1)); // Exponential backoff: 50ms, 100ms, 150ms...
-                    initialContentMessage = postMessageCalls.find(
-                        (msg) => msg.type === "providerSendsInitialContentPaginated"
+                if (paginatedContent) {
+                    assert.strictEqual(
+                        paginatedContent.isSourceText,
+                        true,
+                        "isSourceText should be true for source files"
                     );
-                    attempts++;
+
+                    const cellContent = paginatedContent.cells || [];
+                    assert.ok(
+                        Array.isArray(cellContent) && cellContent.length >= 2,
+                        "Source file should have at least 2 cells for merge buttons to appear (merge buttons only show on non-first cells)"
+                    );
+
+                    const secondCell = cellContent[1];
+                    assert.ok(
+                        secondCell && !secondCell.merged,
+                        "Second cell should exist and not be merged for merge button to appear"
+                    );
                 }
-
-                // Verify that providerSendsInitialContentPaginated message is sent with isSourceText: true
-                // This ensures the webview knows it's displaying source text, which is required for merge buttons
-                assert.ok(
-                    initialContentMessage,
-                    `providerSendsInitialContentPaginated message should be sent after refresh (attempted ${attempts} times, found messages: ${postMessageCalls.map(m => m.type).join(', ')})`
-                );
-                assert.strictEqual(
-                    initialContentMessage.isSourceText,
-                    true,
-                    "isSourceText should be true for source files"
-                );
-
-                // Verify that we have multiple cells (merge buttons only show on non-first cells)
-                // With milestone-based pagination, cells are in the 'cells' property, not 'content'
-                const cellContent = initialContentMessage.cells || [];
-                assert.ok(
-                    Array.isArray(cellContent) && cellContent.length >= 2,
-                    "Source file should have at least 2 cells for merge buttons to appear (merge buttons only show on non-first cells)"
-                );
-
-                // Verify that the second cell is not merged (merged cells show cancel merge button, not merge button)
-                const secondCell = cellContent[1];
-                assert.ok(
-                    secondCell && !secondCell.merged,
-                    "Second cell should exist and not be merged for merge button to appear"
-                );
 
                 document.dispose();
             } finally {
@@ -5199,6 +5172,13 @@ suite("CodexCellEditorProvider Test Suite", () => {
     });
 
     suite("refreshWebviewsForFiles", () => {
+        const findInPlaceRefresh = (messages: any[]) =>
+            messages.find(
+                (msg) =>
+                    msg.type === "providerSendsInitialContentPaginated" ||
+                    msg.type === "refreshCurrentPage"
+            );
+
         // Skip: URI encoding differences between test environment and production
         // The function works correctly in production with actual sync operations
         test.skip("refreshWebviewsForFiles sends refreshCurrentPage to matching webview", async function () {
@@ -5236,10 +5216,9 @@ suite("CodexCellEditorProvider Test Suite", () => {
             // Wait for async operations to complete (revert() may trigger other messages)
             await sleep(200);
 
-            // Verify refreshCurrentPage message was sent
-            // Note: revert() may trigger other messages, but refreshCurrentPage should be among them
-            const refreshMessage = postedMessages.find(msg => msg.type === "refreshCurrentPage");
-            assert.ok(refreshMessage, "refreshCurrentPage message should have been posted");
+            // Verify an in-place refresh was sent
+            const refreshMessage = findInPlaceRefresh(postedMessages);
+            assert.ok(refreshMessage, "in-place cell refresh should have been posted");
 
             document.dispose();
         });
@@ -5322,10 +5301,9 @@ suite("CodexCellEditorProvider Test Suite", () => {
             // Wait for async operations to complete (revert() may trigger other messages)
             await sleep(200);
 
-            // Verify refreshCurrentPage message was sent (only for .codex file)
-            // Note: revert() may trigger other messages, but refreshCurrentPage should be among them
-            const refreshMessage = postedMessages.find(msg => msg.type === "refreshCurrentPage");
-            assert.ok(refreshMessage, "refreshCurrentPage message should have been posted for .codex file");
+            // Verify an in-place refresh was sent (only for .codex file)
+            const refreshMessage = findInPlaceRefresh(postedMessages);
+            assert.ok(refreshMessage, "in-place cell refresh should have been posted for .codex file");
 
             document.dispose();
         });
@@ -5383,7 +5361,7 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 panel,
                 new vscode.CancellationTokenSource().token
             );
-            // Simulate webview ready so currentMilestoneSubsectionMap gets set (required for sendMilestoneRefreshToWebview to send refreshCurrentPage)
+            // Simulate webview ready so currentMilestoneSubsectionMap gets set (required for sendMilestoneRefreshToWebview)
             await onDidReceiveMessageRef.current?.({ command: "webviewReady" });
             await sleep(50);
             postedMessages.length = 0;
@@ -5392,8 +5370,8 @@ suite("CodexCellEditorProvider Test Suite", () => {
             await provider.refreshWebviewsForFiles([document.uri.toString()]);
             await sleep(200);
 
-            const refreshMessage = postedMessages.find(msg => msg.type === "refreshCurrentPage");
-            assert.ok(refreshMessage, "refreshCurrentPage should be sent for .codex with default options");
+            const refreshMessage = findInPlaceRefresh(postedMessages);
+            assert.ok(refreshMessage, "in-place cell refresh should be sent for .codex with default options");
 
             document.dispose();
         });
@@ -5432,8 +5410,8 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 await provider.refreshWebviewsForFiles([document.uri.toString()]);
                 await sleep(200);
 
-                const refreshMessage = postedMessages.find(msg => msg.type === "refreshCurrentPage");
-                assert.ok(refreshMessage, "refreshCurrentPage should be sent for .source with default options");
+                const refreshMessage = findInPlaceRefresh(postedMessages);
+                assert.ok(refreshMessage, "in-place cell refresh should be sent for .source with default options");
 
                 document.dispose();
             } finally {
@@ -5483,8 +5461,8 @@ suite("CodexCellEditorProvider Test Suite", () => {
                 await provider.refreshWebviewsForFiles([document.uri.toString()]);
                 await sleep(200);
 
-                const refreshMessage = postedMessages.find(msg => msg.type === "refreshCurrentPage");
-                assert.ok(refreshMessage, "refreshCurrentPage message should have been posted");
+                const refreshMessage = findInPlaceRefresh(postedMessages);
+                assert.ok(refreshMessage, "in-place cell refresh should have been posted");
 
                 document.dispose();
             } finally {
@@ -5546,8 +5524,8 @@ suite("CodexCellEditorProvider Test Suite", () => {
             await provider.refreshWebviewsForFiles([fsPathFromKey]);
             await sleep(200);
 
-            const refreshMessage = postedMessages.find((msg) => msg.type === "refreshCurrentPage");
-            assert.ok(refreshMessage, "refreshCurrentPage message should have been posted");
+            const refreshMessage = findInPlaceRefresh(postedMessages);
+            assert.ok(refreshMessage, "in-place cell refresh should have been posted");
 
             assert.ok(revertSpy.called, "Expected document.revert() to be called before refresh");
 

--- a/src/test/suite/externalChangeMilestoneRefresh.test.ts
+++ b/src/test/suite/externalChangeMilestoneRefresh.test.ts
@@ -166,6 +166,10 @@ suite("External file change - milestone index refresh", () => {
         );
 
         const pageRefreshes = messages.filter((m) => m.type === "refreshCurrentPage");
-        assert.ok(pageRefreshes.length >= 1, "Should still refresh the current page");
+        assert.strictEqual(
+            pageRefreshes.length,
+            0,
+            "Must not send a follow-up refreshCurrentPage; that reloads cells and jumps scroll"
+        );
     });
 });

--- a/src/test/suite/providerMergeResolve.test.ts
+++ b/src/test/suite/providerMergeResolve.test.ts
@@ -221,6 +221,10 @@ suite("Provider + Merge Integration - multi-user multi-field edits", () => {
         await vscode.workspace.fs.writeFile(localOursUri, Buffer.from(JSON.stringify(oursParsed1, null, 2)));
         await vscode.workspace.fs.writeFile(localTheirsUri, Buffer.from(JSON.stringify(theirsParsed1, null, 2)));
 
+        // Give the filesystem a chance to bump mtime so the documents reload
+        // with the persisted selectionTimestamp rather than the dirty in-memory copies.
+        await sleep(20);
+
         // Reload documents to reflect persisted selectionTimestamp
         const oursDocReloaded = await provider.openCustomDocument(
             localOursUri,

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, useContext, useCallback } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef, useMemo, useContext, useCallback } from "react";
 import Quill from "quill";
 import type { ReactPlayerRef } from "./types/reactPlayerTypes";
 import {
@@ -36,6 +36,11 @@ import "./TranslationAnimations.css";
 import { getVSCodeAPI } from "../shared/vscodeApi";
 import { Subsection, ProgressPercentages } from "../lib/types";
 import { buildSubsectionsForMilestone } from "./utils/subdivisionUtils";
+import {
+    captureScrollAnchor,
+    restoreScrollAnchor,
+    type ScrollAnchor,
+} from "./utils/scrollAnchorUtils";
 import { ABTestVariantSelector } from "./components/ABTestVariantSelector";
 import { useMessageHandler } from "./hooks/useCentralizedMessageDispatcher";
 import { clearCachedAudio } from "../lib/audioCache";
@@ -402,6 +407,10 @@ const CodexCellEditor: React.FC = () => {
 
     // Track whether initial paginated content has been received (used to allow first content through stale guard)
     const hasReceivedInitialContentRef = useRef(false);
+
+    // Keep the first visible cell in place across in-place refreshes (merge, source-editing toggle)
+    const scrollableContentRef = useRef<HTMLDivElement>(null);
+    const pendingScrollAnchorRef = useRef<ScrollAnchor | null>(null);
 
     // Ref to store requestCellsForMilestone function so it can be used in message handlers
     const requestCellsForMilestoneRef = useRef<
@@ -1065,6 +1074,12 @@ const CodexCellEditor: React.FC = () => {
 
             // Handle correction editor mode changes from provider
             if (message.type === "correctionEditorModeChanged") {
+                // Hidden/merged cells appear or disappear in the list when this
+                // flag flips; pin the first visible cell so they don't shove the
+                // viewport back toward the top of the chapter.
+                pendingScrollAnchorRef.current = captureScrollAnchor(
+                    scrollableContentRef.current
+                );
                 setIsCorrectionEditorMode(message.enabled);
             }
 
@@ -1078,6 +1093,20 @@ const CodexCellEditor: React.FC = () => {
 
             // Handle current page refresh (e.g., when a paratext cell is added, after sync, or after migration)
             if (message.type === "refreshCurrentPage") {
+                // Pin the current viewport before we swap cells, so this
+                // in-place reload doesn't jump to the top of the chapter.
+                const forcedToDifferentPage =
+                    message.force === true &&
+                    typeof message.milestoneIndex === "number" &&
+                    typeof message.subsectionIndex === "number" &&
+                    (message.milestoneIndex !== currentMilestoneIndexRef.current ||
+                        message.subsectionIndex !== currentSubsectionIndexRef.current);
+                if (!forcedToDifferentPage && hasReceivedInitialContentRef.current) {
+                    pendingScrollAnchorRef.current = captureScrollAnchor(
+                        scrollableContentRef.current
+                    );
+                }
+
                 // After sync/migration, changes can occur in any cell range, not just the current page
                 // Clear ALL caches to ensure fresh data is loaded when navigating to any page
                 cellsCacheRef.current.clear();
@@ -1583,6 +1612,17 @@ const CodexCellEditor: React.FC = () => {
         []
     );
 
+    const captureScrollAnchorIfSamePage = (milestoneIdx: number, subsectionIdx: number) => {
+        if (
+            !hasReceivedInitialContentRef.current ||
+            currentMilestoneIndexRef.current !== milestoneIdx ||
+            currentSubsectionIndexRef.current !== subsectionIdx
+        ) {
+            return;
+        }
+        pendingScrollAnchorRef.current = captureScrollAnchor(scrollableContentRef.current);
+    };
+
     useVSCodeMessageHandler({
         setContent: (
             content: QuillCellContent[],
@@ -2030,7 +2070,17 @@ const CodexCellEditor: React.FC = () => {
                 // drop any in-flight navigation request so it doesn't reapply
                 // the pre-edit position over the new state.
                 latestRequestRef.current = null;
+                // Other pages may still have pre-edit cells; drop them so later
+                // navigation isn't stale. The current page is re-cached below.
+                cellsCacheRef.current.clear();
+                loadedPagesRef.current.clear();
+                milestoneCellsCacheRef.current.clear();
+                progressCacheRef.current.clear();
             }
+
+            // Pin the first visible cell before swapping the list so merge /
+            // source-editing-toggle refreshes don't jump to the top of the chapter.
+            captureScrollAnchorIfSamePage(currentMilestoneIdx, currentSubsectionIdx);
 
             // Mark that we've received initial content so subsequent messages go through the stale guard
             hasReceivedInitialContentRef.current = true;
@@ -2369,6 +2419,30 @@ const CodexCellEditor: React.FC = () => {
     useEffect(() => {
         requestCellsForMilestoneRef.current = requestCellsForMilestone;
     }, [requestCellsForMilestone]);
+
+    // Restore the pre-refresh viewport after in-place cell list updates.
+    // Runs before paint so the user never sees the chapter-top jump.
+    // Keep the anchor briefly so a follow-up cells payload (after toggling
+    // source-editing mode) can re-pin before we drop it.
+    useLayoutEffect(() => {
+        const anchor = pendingScrollAnchorRef.current;
+        if (!anchor) {
+            return;
+        }
+        restoreScrollAnchor(scrollableContentRef.current, anchor);
+        const frame = requestAnimationFrame(() => {
+            restoreScrollAnchor(scrollableContentRef.current, anchor);
+        });
+        const timeoutId = window.setTimeout(() => {
+            if (pendingScrollAnchorRef.current === anchor) {
+                pendingScrollAnchorRef.current = null;
+            }
+        }, 200);
+        return () => {
+            cancelAnimationFrame(frame);
+            window.clearTimeout(timeoutId);
+        };
+    }, [translationUnits, isCorrectionEditorMode]);
 
     // Handle pending scroll to cell after page loads (for jumpToCell with pagination)
     // We track translationUnits changes because cached pages update translationUnits
@@ -4055,6 +4129,7 @@ const CodexCellEditor: React.FC = () => {
                     </div>
                 )}
                 <div
+                    ref={scrollableContentRef}
                     className="scrollable-content"
                     style={{ height: `calc(100vh - ${headerHeight}px)`, overflowY: "auto" }}
                 >

--- a/webviews/codex-webviews/src/CodexCellEditor/EmptyCellDisplay.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/EmptyCellDisplay.tsx
@@ -90,6 +90,7 @@ const EmptyCellDisplay: React.FC<EmptyCellDisplayProps> = ({
         <div
             ref={contentRef}
             className="empty-cell-display"
+            data-cell-id={cellMarkers[0]}
             onClick={() => openCellById(cellMarkers[0], "")}
             style={{
                 whiteSpace: "normal", // Allow text to wrap

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
@@ -9,6 +9,9 @@ import {
     rewrapWithSourceWrappers,
     tryDeterministicStructureFix,
     extractPlainTextFromHtml,
+    isEmptyOrPlaceholderHtml,
+    joinMergedCellHtml,
+    MERGE_CELL_SEPARATOR,
     type HtmlStructureDiff,
 } from "../../../../../sharedUtils/htmlStructureUtils";
 
@@ -141,6 +144,50 @@ describe("htmlStructureUtils", () => {
                 '<strong data-tag="bd">tučný text</strong> and <em data-tag="it">kurzíva</em>';
             const result = compareHtmlStructure(source, target);
             expect(result.isMatch).toBe(true);
+        });
+
+        it("does not flag untranslated or merge-spacer-only cells", () => {
+            const source =
+                '<p class="indesign-paragraph"><span class="idml-segment">MAT</span></p>';
+            expect(compareHtmlStructure(source, "").isMatch).toBe(true);
+            expect(compareHtmlStructure(source, "<span>&nbsp;</span>").isMatch).toBe(true);
+            expect(compareHtmlStructure(source, "<p>&nbsp;</p>").isMatch).toBe(true);
+        });
+
+        it("ignores the merge spacer between otherwise matching paragraphs", () => {
+            expect(
+                compareHtmlStructure(
+                    "<p>Hello</p><span>&nbsp;</span><p>world</p>",
+                    "<p>Hola</p><p>mundo</p>"
+                ).isMatch
+            ).toBe(true);
+        });
+    });
+
+    describe("joinMergedCellHtml", () => {
+        it("keeps two blank cells empty instead of inserting a spacer", () => {
+            expect(joinMergedCellHtml("", "")).toBe("");
+            expect(joinMergedCellHtml("<span>&nbsp;</span>", "")).toBe("");
+            expect(joinMergedCellHtml("", "<span>&nbsp;</span>")).toBe("");
+        });
+
+        it("joins two translated cells with the merge spacer", () => {
+            expect(joinMergedCellHtml("<p>Hello</p>", "<p>world</p>")).toBe(
+                `<p>Hello</p>${MERGE_CELL_SEPARATOR}<p>world</p>`
+            );
+        });
+
+        it("keeps the non-empty side when the other is blank", () => {
+            expect(joinMergedCellHtml("<p>Hello</p>", "")).toBe("<p>Hello</p>");
+            expect(joinMergedCellHtml("", "<p>world</p>")).toBe("<p>world</p>");
+        });
+    });
+
+    describe("isEmptyOrPlaceholderHtml", () => {
+        it("treats blank and nbsp-only markup as empty", () => {
+            expect(isEmptyOrPlaceholderHtml("")).toBe(true);
+            expect(isEmptyOrPlaceholderHtml("<span>&nbsp;</span>")).toBe(true);
+            expect(isEmptyOrPlaceholderHtml("<p>Hello</p>")).toBe(false);
         });
     });
 

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
@@ -152,7 +152,7 @@ describe("htmlStructureUtils", () => {
             expect(result.isMatch).toBe(true);
         });
 
-        it("does not flag InDesign segment/EOC markup a translator cannot type", () => {
+        it("flags missing InDesign segment/EOC markup in the translation", () => {
             const source =
                 '<p class="indesign-paragraph" data-segment-count="3">' +
                 '<span class="idml-segment" data-segment-index="0">Hello</span>' +
@@ -161,10 +161,13 @@ describe("htmlStructureUtils", () => {
                 '<br class="idml-eoc" data-eoc="1" />' +
                 '<span class="idml-segment" data-segment-index="2">world</span>' +
                 "</p>";
-            expect(compareHtmlStructure(source, "<p>hey</p>").isMatch).toBe(true);
+            const result = compareHtmlStructure(source, "<p>hey</p>");
+            expect(result.isMatch).toBe(false);
+            expect(result.errors[0]).toContain("Missing tags");
+            expect(result.errors[0]).toContain("<span>");
             expect(
                 compareHtmlStructure(source, "<p>line one</p><p>line two</p>").isMatch
-            ).toBe(true);
+            ).toBe(false);
         });
 
         it("does not flag untranslated or merge-spacer-only cells", () => {
@@ -553,10 +556,10 @@ describe("htmlStructureUtils", () => {
             ).toBe(true);
         });
 
-        it("tolerates InDesign EOC breaks like other line breaks", () => {
+        it("still enforces attributed InDesign EOC breaks", () => {
             expect(
                 compareHtmlStructure('a<br class="idml-eoc" data-eoc="1"/>b', "a b").isMatch
-            ).toBe(true);
+            ).toBe(false);
         });
 
         it("still enforces real structural differences alongside breaks", () => {

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureUtils.test.ts
@@ -85,15 +85,21 @@ describe("htmlStructureUtils", () => {
         });
 
         it("detects missing tags in target", () => {
-            // Attributed breaks (e.g. InDesign's EOC markers) are structure;
-            // only bare <br>s are tolerated as user content.
-            const source = 'text<br class="idml-eoc" data-eoc="1"/>more text';
+            const source = "text <em>more</em> text";
             const target = "text more text";
             const result = compareHtmlStructure(source, target);
             expect(result.isMatch).toBe(false);
             expect(result.errors).toHaveLength(1);
             expect(result.errors[0]).toContain("Missing tags");
-            expect(result.errors[0]).toContain("<br/>");
+            expect(result.errors[0]).toContain("<em>");
+        });
+
+        it("summarizes repeated missing tags instead of listing each one", () => {
+            const source = "<p><em>a</em><em>b</em><em>c</em></p>";
+            const target = "<p>abc</p>";
+            const result = compareHtmlStructure(source, target);
+            expect(result.isMatch).toBe(false);
+            expect(result.errors[0]).toBe("Missing tags: 3× <em>, 3× </em>");
         });
 
         it("detects extra tags in target", () => {
@@ -144,6 +150,21 @@ describe("htmlStructureUtils", () => {
                 '<strong data-tag="bd">tučný text</strong> and <em data-tag="it">kurzíva</em>';
             const result = compareHtmlStructure(source, target);
             expect(result.isMatch).toBe(true);
+        });
+
+        it("does not flag InDesign segment/EOC markup a translator cannot type", () => {
+            const source =
+                '<p class="indesign-paragraph" data-segment-count="3">' +
+                '<span class="idml-segment" data-segment-index="0">Hello</span>' +
+                '<span class="idml-eoc" data-eoc="1" aria-hidden="true"></span>' +
+                '<span class="idml-segment" data-segment-index="1">ʼ</span>' +
+                '<br class="idml-eoc" data-eoc="1" />' +
+                '<span class="idml-segment" data-segment-index="2">world</span>' +
+                "</p>";
+            expect(compareHtmlStructure(source, "<p>hey</p>").isMatch).toBe(true);
+            expect(
+                compareHtmlStructure(source, "<p>line one</p><p>line two</p>").isMatch
+            ).toBe(true);
         });
 
         it("does not flag untranslated or merge-spacer-only cells", () => {
@@ -532,10 +553,10 @@ describe("htmlStructureUtils", () => {
             ).toBe(true);
         });
 
-        it("still enforces attributed breaks (InDesign EOC markers)", () => {
+        it("tolerates InDesign EOC breaks like other line breaks", () => {
             expect(
                 compareHtmlStructure('a<br class="idml-eoc" data-eoc="1"/>b', "a b").isMatch
-            ).toBe(false);
+            ).toBe(true);
         });
 
         it("still enforces real structural differences alongside breaks", () => {

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/scrollAnchorUtils.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/scrollAnchorUtils.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { captureScrollAnchor, restoreScrollAnchor } from "./scrollAnchorUtils";
+
+const makeCell = (id: string, top: number, height: number): HTMLElement => {
+    const el = document.createElement("div");
+    el.setAttribute("data-cell-id", id);
+    Object.defineProperty(el, "getBoundingClientRect", {
+        value: () => ({
+            top,
+            bottom: top + height,
+            left: 0,
+            right: 100,
+            width: 100,
+            height,
+            x: 0,
+            y: top,
+            toJSON: () => ({}),
+        }),
+    });
+    return el;
+};
+
+describe("scrollAnchorUtils", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        container.className = "scrollable-content";
+        container.scrollTop = 200;
+        Object.defineProperty(container, "getBoundingClientRect", {
+            value: () => ({
+                top: 80,
+                bottom: 580,
+                left: 0,
+                right: 100,
+                width: 100,
+                height: 500,
+                x: 0,
+                y: 80,
+                toJSON: () => ({}),
+            }),
+        });
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("captures the first cell that intersects the viewport", () => {
+        const above = makeCell("above", 0, 40);
+        const firstVisible = makeCell("visible", 90, 40);
+        const below = makeCell("below", 200, 40);
+        container.append(above, firstVisible, below);
+
+        const anchor = captureScrollAnchor(container);
+        expect(anchor).toEqual({ cellId: "visible", viewportTop: 90, scrollTop: 200 });
+    });
+
+    it("falls back to scrollTop when the container has no cells", () => {
+        expect(captureScrollAnchor(container)).toEqual({
+            cellId: null,
+            viewportTop: 0,
+            scrollTop: 200,
+        });
+        expect(captureScrollAnchor(null)).toBeNull();
+    });
+
+    it("restores scrollTop so the anchored cell keeps its viewport Y", () => {
+        const cell = makeCell("visible", 140, 40);
+        container.appendChild(cell);
+        container.scrollTop = 200;
+
+        restoreScrollAnchor(container, { cellId: "visible", viewportTop: 90, scrollTop: 200 });
+
+        // cell is 50px lower than the captured viewport Y, so we scroll down by 50
+        expect(container.scrollTop).toBe(250);
+    });
+
+    it("does not change scrollTop when the cell is already at the captured Y", () => {
+        const cell = makeCell("visible", 90, 40);
+        container.appendChild(cell);
+        container.scrollTop = 200;
+
+        restoreScrollAnchor(container, { cellId: "visible", viewportTop: 90, scrollTop: 200 });
+        expect(container.scrollTop).toBe(200);
+    });
+
+    it("falls back to captured scrollTop when the anchored cell is gone", () => {
+        container.scrollTop = 40;
+        restoreScrollAnchor(container, { cellId: "missing", viewportTop: 90, scrollTop: 200 });
+        expect(container.scrollTop).toBe(200);
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/scrollAnchorUtils.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/scrollAnchorUtils.ts
@@ -1,0 +1,81 @@
+export type ScrollAnchor = {
+    cellId: string | null;
+    viewportTop: number;
+    scrollTop: number;
+};
+
+const cellSelector = "[data-cell-id], [data-cell-editor-id]";
+
+const cellIdOf = (el: Element): string | null =>
+    el.getAttribute("data-cell-id") || el.getAttribute("data-cell-editor-id");
+
+const queryCell = (root: ParentNode, cellId: string): HTMLElement | null => {
+    const escapedId = cellId.replace(/"/g, '\\"');
+    return (
+        (root.querySelector(`[data-cell-id="${escapedId}"]`) as HTMLElement | null) ||
+        (root.querySelector(`[data-cell-editor-id="${escapedId}"]`) as HTMLElement | null)
+    );
+};
+
+/**
+ * Capture the first cell that is at least partially visible in `scrollContainer`,
+ * along with its viewport Y and the raw scrollTop. Used to keep that cell in
+ * place across in-place content refreshes (merge, source-editing toggle) that
+ * insert/remove rows above. `scrollTop` is the fallback when the anchored
+ * cell is gone after the update (e.g. it was merged into a neighbor).
+ */
+export const captureScrollAnchor = (scrollContainer: HTMLElement | null): ScrollAnchor | null => {
+    if (!scrollContainer) {
+        return null;
+    }
+    const scrollTop = scrollContainer.scrollTop;
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const cells = scrollContainer.querySelectorAll(cellSelector);
+    for (const cell of Array.from(cells)) {
+        const rect = cell.getBoundingClientRect();
+        if (rect.bottom > containerRect.top + 1) {
+            const cellId = cellIdOf(cell);
+            if (cellId) {
+                return { cellId, viewportTop: rect.top, scrollTop };
+            }
+        }
+    }
+    return { cellId: null, viewportTop: 0, scrollTop };
+};
+
+/**
+ * Scroll `scrollContainer` so the anchored cell sits at the same viewport Y
+ * it had when `captureScrollAnchor` ran. Falls back to the captured
+ * `scrollTop` if that cell is no longer in the DOM.
+ */
+export const restoreScrollAnchor = (
+    scrollContainer: HTMLElement | null,
+    anchor: ScrollAnchor
+): void => {
+    if (!scrollContainer) {
+        return;
+    }
+    const previousOverflowAnchor = scrollContainer.style.getPropertyValue("overflow-anchor");
+    scrollContainer.style.setProperty("overflow-anchor", "none");
+    try {
+        if (anchor.cellId) {
+            const cellEl = queryCell(scrollContainer, anchor.cellId);
+            if (cellEl) {
+                const delta = cellEl.getBoundingClientRect().top - anchor.viewportTop;
+                if (Math.abs(delta) > 1) {
+                    scrollContainer.scrollTop += delta;
+                }
+                return;
+            }
+        }
+        if (Math.abs(scrollContainer.scrollTop - anchor.scrollTop) > 1) {
+            scrollContainer.scrollTop = anchor.scrollTop;
+        }
+    } finally {
+        if (previousOverflowAnchor) {
+            scrollContainer.style.setProperty("overflow-anchor", previousOverflowAnchor);
+        } else {
+            scrollContainer.style.removeProperty("overflow-anchor");
+        }
+    }
+};

--- a/webviews/codex-webviews/src/NewSourceUploader/components/UnifiedImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/components/UnifiedImporterForm.tsx
@@ -124,6 +124,7 @@ export const UnifiedImporterForm: React.FC<UnifiedImporterFormProps> = ({
     const [alignedCells, setAlignedCells] = useState<AlignedCell[] | null>(null);
     const [importedContent, setImportedContent] = useState<any[]>([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const importInFlightRef = useRef(false);
 
     const { wizardContext, onTranslationComplete, alignContent } = importerProps;
     const isTranslationImport =
@@ -145,6 +146,7 @@ export const UnifiedImporterForm: React.FC<UnifiedImporterFormProps> = ({
             setResult(null);
             setAlignedCells(null);
             setImportedContent([]);
+            importInFlightRef.current = false;
 
             // Read preview from first file (skip binary / zip — avoids loading huge archives)
             if (showPreview) {
@@ -215,7 +217,8 @@ export const UnifiedImporterForm: React.FC<UnifiedImporterFormProps> = ({
     );
 
     const handleImport = useCallback(async () => {
-        if (files.length === 0) return;
+        if (files.length === 0 || importInFlightRef.current) return;
+        importInFlightRef.current = true;
 
         notifyImportStarted();
         setIsProcessing(true);
@@ -256,35 +259,30 @@ export const UnifiedImporterForm: React.FC<UnifiedImporterFormProps> = ({
                 );
                 setAlignedCells(aligned);
                 setIsAligning(false);
+                importInFlightRef.current = false;
+                setIsProcessing(false);
 
                 onProgress({
                     stage: "Complete",
                     message: "Alignment complete - review and confirm",
                     progress: 100,
                 });
+                return;
+            }
+
+            // Source import: write notebooks immediately and let the wizard
+            // replace this form with the importing progress view. Do not
+            // re-enable Finish Import — a second click re-parsed the file
+            // and then hit "already imported" against the first write.
+            if (onSourceImportComplete) {
+                await onSourceImportComplete(notebookResult);
             } else {
-                setTimeout(async () => {
-                    try {
-                        if (onSourceImportComplete) {
-                            await onSourceImportComplete(notebookResult);
-                        } else {
-                            await handleImportCompletion(
-                                notebookResult,
-                                importerProps
-                            );
-                        }
-                    } catch (err) {
-                        setError(
-                            err instanceof Error ? err.message : "Failed to complete import"
-                        );
-                        notifyImportEnded();
-                    }
-                }, 1500);
+                await handleImportCompletion(notebookResult, importerProps);
             }
         } catch (err) {
             setError(err instanceof Error ? err.message : "Unknown error occurred");
             notifyImportEnded();
-        } finally {
+            importInFlightRef.current = false;
             setIsProcessing(false);
         }
     }, [

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/ebibleCorpus/EbibleDownloadImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/ebibleCorpus/EbibleDownloadImporterForm.tsx
@@ -281,6 +281,7 @@ export const EbibleDownloadImporterForm: React.FC<ImporterComponentProps> = (pro
     const [error, setError] = useState<string | null>(null);
     const [showDetails, setShowDetails] = useState(false);
     const [result, setResult] = useState<NotebookPair | null>(null);
+    const importInFlightRef = useRef(false);
     const [alignedCells, setAlignedCells] = useState<AlignedCell[] | null>(null);
     const [importedContent, setImportedContent] = useState<ImportedContent[]>([]);
     const [targetCells, setTargetCells] = useState<any[]>([]);
@@ -333,7 +334,9 @@ export const EbibleDownloadImporterForm: React.FC<ImporterComponentProps> = (pro
             setError("Please select a translation to download");
             return;
         }
+        if (importInFlightRef.current) return;
 
+        importInFlightRef.current = true;
         notifyImportStarted();
         setIsProcessing(true);
         setError(null);
@@ -434,17 +437,11 @@ export const EbibleDownloadImporterForm: React.FC<ImporterComponentProps> = (pro
                     if (allNotebooks) {
                         const notebookPairs: NotebookPair[] = Object.values(allNotebooks);
 
-                        setTimeout(async () => {
-                            try {
-                                // For multi-file imports, pass all notebook pairs for batch import
-                                await handleImportCompletion(notebookPairs, props);
-                            } catch (err) {
-                                setError(
-                                    err instanceof Error ? err.message : "Failed to complete import"
-                                );
-                                notifyImportEnded();
-                            }
-                        }, 2000);
+                        // Complete immediately. Leaving the download form
+                        // visible during this delay allowed a second click to
+                        // submit the same books and trigger duplicate-import
+                        // detection.
+                        await handleImportCompletion(notebookPairs, props);
                     } else {
                         // Single notebook - use the translation helper
                         try {

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/ebibleCorpus/EbibleDownloadImporterForm.tsx
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/ebibleCorpus/EbibleDownloadImporterForm.tsx
@@ -327,6 +327,7 @@ export const EbibleDownloadImporterForm: React.FC<ImporterComponentProps> = (pro
     const handleSelectTranslation = useCallback((translation: EbibleTranslation) => {
         setSelectedTranslation(translation);
         setError(null);
+        importInFlightRef.current = false;
     }, []);
 
     const handleDownload = useCallback(async () => {
@@ -463,6 +464,7 @@ export const EbibleDownloadImporterForm: React.FC<ImporterComponentProps> = (pro
         } catch (err) {
             setError(err instanceof Error ? err.message : "Download failed");
             setIsProcessing(false);
+            importInFlightRef.current = false;
             notifyImportEnded();
         }
     }, [selectedTranslation, props]);


### PR DESCRIPTION
## Fix ghost tags and fix warnings

## Summary
Related to #1107

**This PR does not change how IDML cells are merged, imported, or exported.** IDML round-trip still restores segment/EOC markup from cell metadata. The IDML-related change is only in **structure comparison**: editor-only InDesign markup is ignored when deciding whether a typed translation is a mismatch.

Structure enforcement was treating InDesign editor markup and merge spacers as tags the translator had to recreate. Merging two blank notebook cells wrote `<span>&nbsp;</span>`, which then showed a Resolve error. Typing a normal translation against an IDML *source* produced a wall of “Missing tags: `<span>`, `</span>`, `<br/>`…” that nobody could act on.

This change:
- Keeps blank **notebook** cell merges blank (the `<span>&nbsp;</span>` spacer is only used when both cells have real text). Same join helper for every `.source`/`.codex` merge; not an IDML merge path.
- Ignores IDML-internal markup (`idml-segment` runs, empty EOC spans, EOC `<br>`s) when **comparing** source vs target for structure warnings.
- Summarizes remaining mismatch lists (`3× <em>`) instead of dumping every tag.
- Adds **Continue anyway** on the export HTML-structure warning so it actually advances to the next wizard step.

Also on this branch (still in the tree):

- Sequential merges in source editing apply to the **live** target document. Reopening the `.codex` after each save used to create a detached instance, so only the first merge showed until a window reload.
- Merge, unmerge, and toggling source editing refresh the current page **in place** (no `refreshWebview()` HTML remount).
- After that in-place refresh, the editor pins the first visible verse so extra/hidden merged children do not shove the viewport back to the top of the chapter.

## Changes

### Ghost tags / structure warnings
- [ ] Merging two untranslated/empty **notebook** cells does not inject a spacer-only `<span>&nbsp;</span>` and does not show a structure-mismatch / Resolve banner.
- [ ] Merging two cells that both have text still joins them with `<span>&nbsp;</span>` for visual separation in the editor.
- [ ] Typing a normal paragraph against an IDML *source* (segment spans, EOC glue, EOC line breaks) does not warn. IDML cell merge / export is unchanged.
- [ ] User-typable structure is still enforced (e.g. missing `<em>`, extra wrappers).
- [ ] Empty / placeholder cells (`""`, `<span>&nbsp;</span>`, “Click to translate”) are not flagged as mismatches.
- [ ] Mismatch copy summarizes repeated tags instead of listing each one.
- [ ] Export “HTML Structure Mismatch” modal has a **Continue anyway** button that dismisses the warning and goes to the next step. The X / backdrop click only closes the modal.

### Live target merges (scripture source editing)
- [ ] Sequential source-side merges (e.g. Genesis 9–12 → `9-10-11-12`) update the open target editor after each merge, not only after a window reload.
- [ ] An already-open target webview is reused; the provider does not replace a document bound to a live editor by reloading from disk mid-merge.

### Scroll / source-editing toggle
- [ ] Merge and unmerge keep the current chapter; they do not remount the editor HTML.
- [ ] Toggling source editing updates merged/hidden cell visibility in both panes without jumping to the top of the file.
- [ ] After merge or toggle, the verse that was on screen stays on screen (not just “same chapter, top of the page”).

## Test Checklist

### Merge (blank notebook cells)
- [x] In source editing, merge two untranslated target cells. The surviving cell stays empty (“Click to translate”); no yellow Resolve banner.
- [x] Merge two cells that already have translations. They still join with a visible space between them.
- [x] Unmerge still restores the child cell.

### IDML / ghost tags (comparison only — do not merge IDML cells)
- [x] Open an IDML/NIrV-style project with `enforceHtmlStructure` on.
- [x] Type a short translation (e.g. “hey”) into a long source paragraph that used to dump dozens of `<span>` / `<br/>` tags. No structure warning.
- [x] Type a multi-line outline (Enter between lines) into a source cell with EOC breaks. No structure warning.
- [x] A simple one-span heading still saves cleanly (outer paragraph wrap is fine).
- [x] A cell that is actually missing user-visible formatting (e.g. source has `<em>`, target does not) still shows a mismatch, summarized (e.g. `Missing tags: <em>, </em>`), not a tag dump.

### Resolve / sparkle
- [x] Sparkle still produces a structured translation when used.
- [x] Resolve is not offered on blank cells or on IDML-only “ghost tag” differences.
- [x] Resolve still runs for a real mismatch (missing italic / extra wrapper).

### Export modal
- [x] Select round-trip export when a file still has a real structure mismatch. The modal appears with a **Continue anyway** button.
- [x] **Continue anyway** closes the modal and advances to the next wizard step (milestone step if shown, otherwise export location).
- [x] The X and clicking the backdrop close the modal without advancing; round-trip stays selected so you can click Next Step yourself.

### Sequential source merges (live target)
- [x] Open source + target for a book with several consecutive verses (e.g. Genesis 9–12).
- [x] In source editing, merge 9 into 8/9, then 10, then 11, then 12 without reloading.
- [x] Source shows the combined range and greyed children after each merge.
- [x] Target shows the same combined range after each merge — not only the first one — without a window reload.

### Scroll stays put
- [x] Scroll mid-chapter, merge the verse you are looking at. You stay on that verse, not the top of the chapter or the top of the file.
- [x] Unmerge that cell. Scroll still stays on it.
- [x] Scroll mid-chapter, toggle source editing on (merged children appear). The verse you were looking at stays in place.
- [x] Toggle source editing off. Same verse stays in place.
- [x] Chapter navigation still jumps to the selected chapter as before.