### PR TITLE
1137-Regression Guard Fixes

### DIFF
--- a/src/exportHandler/usfmBodyBuilder.ts
+++ b/src/exportHandler/usfmBodyBuilder.ts
@@ -7,6 +7,16 @@ const VERSE_REF_REGEX = /\b[A-Z0-9]{2,4}\s+\d+:\d+\b/;
 /** Section-heading markers: \s, \s1, \s2, ... (excludes \sp etc.) */
 const HEADING_MARKER_REGEX = /^\\s\d*$/;
 
+/**
+ * Paragraph-level markers that may open a paratext line as-is: headings
+ * (\s, \s1…), paragraphs (\p, \pc, \pm, \m, \mi), poetry (\q, \q1…), lists
+ * (\li, \li1…), descriptive titles (\d), section references (\r), speaker
+ * lines (\sp), and blank lines (\b). Character markers (\bd, \em, \it, \ul,
+ * \sup, \sub) are inline formatting, not paragraph openers — content leading
+ * with one still needs a paragraph marker prefix.
+ */
+const PARAGRAPH_MARKER_REGEX = /^\\(?:s\d*|p|q\d*|m|mi|li\d*|pc|pm|d|r|sp|b)\b/;
+
 /** Minimal cell shape the USFM body builder needs. */
 export interface UsfmExportCell {
     metadata?: any;
@@ -104,19 +114,25 @@ export function convertHtmlToUsfm(html: string): string {
 
 /**
  * Formats one paratext cell as a USFM line. Marker precedence:
- * 1. Explicit heading tags in the content (already converted to \s markers by convertHtmlToUsfm)
+ * 1. A paragraph-level marker already leading the content (heading tags convert
+ *    to \s markers via convertHtmlToUsfm; literal USFM in the cell also counts)
  * 2. The original USFM marker preserved in metadata by importers (e.g. \s, \q1)
  * 3. \s1 when the user opted in to exporting paratext cells as headings, otherwise \p
+ *
+ * Content leading with a *character* marker (\bd from <strong>, \em from <em>, …)
+ * deliberately falls through to 2/3: a character marker with no paragraph context
+ * is invalid USFM, so the line still gets its paragraph marker prefix.
  */
 function formatParatextCell(
     convertedContent: string,
     metadata: any,
     paratextAsHeadings: boolean
 ): { line: string; isHeading: boolean; } {
-    if (convertedContent.startsWith("\\")) {
+    if (PARAGRAPH_MARKER_REGEX.test(convertedContent)) {
+        const leadingMarker = convertedContent.match(/^\\[a-z]+\d*/)?.[0] ?? "";
         return {
             line: convertedContent,
-            isHeading: convertedContent.startsWith("\\s"),
+            isHeading: HEADING_MARKER_REGEX.test(leadingMarker),
         };
     }
     const marker =

--- a/src/projectManager/utils/merge/conflictSynthesis.ts
+++ b/src/projectManager/utils/merge/conflictSynthesis.ts
@@ -1,0 +1,147 @@
+/**
+ * Last-resort self-heal for the remote-changed/conflict-list invariant
+ * (issue #991, enforced in merge/index.ts): every remote-changed file must
+ * appear in the conflict list, or the merge commit would silently drop it.
+ *
+ * A mismatch is first treated as transient — the sync retries with a fresh
+ * fetch. But if it persists on the final attempt (a path-classification bug
+ * upstream, version skew), failing forever would cut the user off from pushing
+ * AND pulling. Instead, the missing paths get ConflictFile entries built from
+ * local git state so they flow through the normal resolvers. That upholds the
+ * invariant's actual guarantee — the merged result includes those files —
+ * rather than abandoning the sync.
+ *
+ * The synthesis is deliberately conservative: a path whose remote content
+ * cannot be read is reported as unsynthesizable (the caller keeps failing
+ * loudly for it) — the fallback never invents deletions or guesses content.
+ */
+import * as vscode from "vscode";
+import * as dugiteGit from "../../../utils/dugiteGit";
+import { ConflictFile } from "./types";
+
+/** Git operations the synthesis needs; injectable for tests. */
+export interface ConflictSynthesisGitOps {
+    resolveRef: (dir: string, ref: string) => Promise<string>;
+    readBlobAtRef: (dir: string, ref: string, filepath: string) => Promise<Buffer>;
+}
+
+/**
+ * Canonical form for comparing paths from different producers (frontier's
+ * conflict list vs its remote-changed list): forward slashes, no leading
+ * "./" or "/", Unicode NFC.
+ */
+export function normalizeSyncPath(filepath: string): string {
+    let normalized = filepath.replace(/\\/g, "/");
+    while (normalized.startsWith("./")) {
+        normalized = normalized.slice(2);
+    }
+    normalized = normalized.replace(/^\/+/, "");
+    return normalized.normalize("NFC");
+}
+
+/**
+ * The ref holding the fetched remote state. syncChanges has already fetched by
+ * the time the invariant runs, so FETCH_HEAD is the primary candidate; the
+ * origin-tracking refs cover setups where FETCH_HEAD is unavailable.
+ */
+const REMOTE_REF_CANDIDATES = [
+    "FETCH_HEAD",
+    "refs/remotes/origin/HEAD",
+    "refs/remotes/origin/main",
+    "refs/remotes/origin/master",
+];
+
+async function findRemoteRef(
+    workspaceDir: string,
+    gitOps: ConflictSynthesisGitOps
+): Promise<string | null> {
+    for (const ref of REMOTE_REF_CANDIDATES) {
+        try {
+            await gitOps.resolveRef(workspaceDir, ref);
+            return ref;
+        } catch {
+            // try the next candidate
+        }
+    }
+    return null;
+}
+
+export interface ConflictSynthesisResult {
+    synthesized: ConflictFile[];
+    /** Paths whose remote content could not be read — the caller must keep failing loudly for these. */
+    unsynthesizable: string[];
+}
+
+/**
+ * Builds ConflictFile entries for remote-changed paths the conflict list
+ * missed. Content sources:
+ *  - theirs: the fetched remote ref (required — no remote blob, no synthesis);
+ *  - ours: the working tree, falling back to HEAD;
+ *  - base: HEAD (there is no merge-base helper; for a file only the remote
+ *    changed, ours == HEAD makes the 3-way resolve to theirs, and the `.codex`
+ *    custom merge is edit-history-driven and ignores base entirely).
+ */
+export async function synthesizeConflictsForPaths(
+    workspaceDir: string,
+    filepaths: string[],
+    gitOps: ConflictSynthesisGitOps = dugiteGit
+): Promise<ConflictSynthesisResult> {
+    const synthesized: ConflictFile[] = [];
+    const unsynthesizable: string[] = [];
+
+    const remoteRef = await findRemoteRef(workspaceDir, gitOps);
+    if (remoteRef === null) {
+        return { synthesized, unsynthesizable: [...filepaths] };
+    }
+
+    for (const filepath of filepaths) {
+        const normalized = normalizeSyncPath(filepath);
+
+        let theirs: string;
+        try {
+            const blob = await gitOps.readBlobAtRef(workspaceDir, remoteRef, normalized);
+            theirs = blob.toString("utf-8");
+        } catch (error) {
+            console.warn(
+                `[Sync] Could not read remote content for ${normalized} at ${remoteRef}:`,
+                error
+            );
+            unsynthesizable.push(filepath);
+            continue;
+        }
+
+        let headContent: string | null = null;
+        try {
+            const blob = await gitOps.readBlobAtRef(workspaceDir, "HEAD", normalized);
+            headContent = blob.toString("utf-8");
+        } catch {
+            // not in HEAD — the file is new from the remote's perspective
+        }
+
+        let workingContent: string | null = null;
+        try {
+            const target = vscode.Uri.joinPath(
+                vscode.Uri.file(workspaceDir),
+                ...normalized.split("/")
+            );
+            workingContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(target));
+        } catch {
+            // not in the working tree
+        }
+
+        synthesized.push({
+            filepath: normalized,
+            ours: workingContent ?? headContent ?? "",
+            theirs,
+            base: headContent ?? "",
+            isDeleted: false,
+            // Keyed off DISK presence, not HEAD: the resolvers' existing-file
+            // branch stats the working tree and fails for a missing file, so
+            // any file absent locally must take the isNew creation path (which
+            // still merges both sides when they differ).
+            isNew: workingContent === null,
+        });
+    }
+
+    return { synthesized, unsynthesizable };
+}

--- a/src/projectManager/utils/merge/conflictSynthesis.ts
+++ b/src/projectManager/utils/merge/conflictSynthesis.ts
@@ -18,6 +18,7 @@
 import * as vscode from "vscode";
 import * as dugiteGit from "../../../utils/dugiteGit";
 import { ConflictFile } from "./types";
+import { TransientSyncError } from "./transientSyncError";
 
 /** Git operations the synthesis needs; injectable for tests. */
 export interface ConflictSynthesisGitOps {
@@ -144,4 +145,84 @@ export async function synthesizeConflictsForPaths(
     }
 
     return { synthesized, unsynthesizable };
+}
+
+export interface ConflictListInvariantOptions {
+    /** The conflict list frontier produced. */
+    conflicts: Array<{ filepath?: string; }>;
+    /** conflictsResponse.remoteChangedFilePaths (or allChangedFilePaths fallback). */
+    changedPaths: unknown;
+    /** Current sync attempt (the outer retry layer caps at 2 retries). */
+    retryCount: number;
+    workspaceDir: string;
+    /**
+     * Sink for the self-heal log entry (defaults to console.warn). Injectable
+     * because the extension host defines console methods as non-writable, so
+     * tests cannot intercept the global.
+     */
+    log?: (message: string, ...args: unknown[]) => void;
+}
+
+/**
+ * Enforces the #991 invariant: every remote-changed file must appear in the
+ * conflict list, or the merge commit would silently drop it. Both sides are
+ * normalized before comparing so a formatting mismatch (separators, "./",
+ * Unicode form) can't fake a violation.
+ *
+ * Returns the ConflictFile entries to append to the conflict list — empty when
+ * the invariant holds. On early attempts a mismatch throws TransientSyncError
+ * so the retry layer refetches; on the final attempt the missing paths are
+ * synthesized from local git state instead (see synthesizeConflictsForPaths),
+ * so a persistent upstream mismatch degrades to a normal merge rather than a
+ * permanent sync outage. Paths that cannot be synthesized still throw.
+ */
+export async function enforceConflictListInvariant(
+    options: ConflictListInvariantOptions,
+    gitOps: ConflictSynthesisGitOps = dugiteGit
+): Promise<ConflictFile[]> {
+    const { conflicts, changedPaths, retryCount, workspaceDir } = options;
+    const log = options.log ?? console.warn;
+
+    if (!Array.isArray(changedPaths) || changedPaths.length === 0) return [];
+
+    const conflictPaths = new Set(
+        conflicts
+            .map((c) => c?.filepath)
+            .filter((p): p is string => typeof p === "string")
+            .map(normalizeSyncPath)
+    );
+    const missingFromConflicts = changedPaths
+        .filter((p): p is string => typeof p === "string" && p.length > 0)
+        .filter((p) => !conflictPaths.has(normalizeSyncPath(p)));
+    if (missingFromConflicts.length === 0) return [];
+
+    const describeMissing = (paths: string[]) => {
+        const sample = paths.slice(0, 5).join(", ");
+        const extra = paths.length > 5 ? ` (+${paths.length - 5} more)` : "";
+        return `${sample}${extra}`;
+    };
+
+    if (retryCount < 2) {
+        throw new TransientSyncError(
+            `${missingFromConflicts.length} remote-changed file(s) were not in the conflict list. Missing: ${describeMissing(missingFromConflicts)}`,
+            missingFromConflicts
+        );
+    }
+
+    const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+        workspaceDir,
+        missingFromConflicts,
+        gitOps
+    );
+    if (unsynthesizable.length > 0) {
+        throw new TransientSyncError(
+            `${unsynthesizable.length} remote-changed file(s) were not in the conflict list and could not be recovered from the fetched remote. Missing: ${describeMissing(unsynthesizable)}`,
+            unsynthesizable
+        );
+    }
+    log(
+        `[Sync] Conflict-list invariant self-heal: merging ${synthesized.length} remote-changed file(s) the conflict list missed:`,
+        synthesized.map((c) => c.filepath)
+    );
+    return synthesized;
 }

--- a/src/projectManager/utils/merge/fileDeletionGuard.ts
+++ b/src/projectManager/utils/merge/fileDeletionGuard.ts
@@ -7,8 +7,9 @@
  * records act as deletion tombstones:
  *
  * 1. Before sync commits local state, any tracked content file that is present
- *    in git HEAD but missing from the working tree WITHOUT a tombstone is
- *    restored from HEAD instead of being committed as a deletion.
+ *    in git HEAD but missing from the working tree WITHOUT a tombstone at
+ *    least as recent as the file's latest HEAD content activity is restored
+ *    from HEAD instead of being committed as a deletion.
  * 2. During conflict resolution, a delete-vs-modify conflict on a content file
  *    only resolves as "deleted" when a tombstone exists that is at least as
  *    recent as the surviving content's latest edit. Otherwise the surviving
@@ -101,10 +102,15 @@ export function collectDeletionTombstones(
  * path, or undefined when no tombstone matches (i.e. no intentional deletion
  * was ever recorded for it).
  *
- * Older builds recorded absolute machine-local paths, so matching falls back
- * from exact/suffix path comparison to basename comparison. A `.source` file
- * is matched via its paired `.codex` name — the delete flow removes the pair
- * together but only records the codex path.
+ * A `.source` file is matched via its paired `.codex` — the delete flow removes
+ * the pair together but only records the codex path.
+ *
+ * Bare-basename matching is a legacy accommodation only: older builds recorded
+ * just an absolute machine-local path (no relPath), which can't reliably
+ * suffix-match a workspace-relative path from another machine's layout.
+ * Tombstones written by current builds carry relPath and must match by
+ * exact/suffix path, so a file re-created under the same name after an old
+ * deletion can't inherit that deletion's tombstone.
  */
 export function findTombstoneTimestamp(
     tombstones: DeletionTombstone[],
@@ -115,6 +121,9 @@ export function findTombstoneTimestamp(
     const pairedCodexName = baseName.endsWith(".source")
         ? baseName.slice(0, -".source".length) + ".codex"
         : undefined;
+    // The pair lives at a fixed location, so modern (relPath-bearing)
+    // tombstones can match a .source path-aware via its codex twin.
+    const pairedCodexRelPath = pairedCodexName ? "files/target/" + pairedCodexName : undefined;
 
     let latest: number | undefined;
     for (const tombstone of tombstones) {
@@ -124,6 +133,13 @@ export function findTombstoneTimestamp(
         const matches = candidates.some((candidate) => {
             const recorded = normalizePath(candidate);
             if (recorded === normalized || recorded.endsWith("/" + normalized)) return true;
+            if (
+                pairedCodexRelPath &&
+                (recorded === pairedCodexRelPath || recorded.endsWith("/" + pairedCodexRelPath))
+            ) {
+                return true;
+            }
+            if (tombstone.relPath) return false; // modern tombstones never match by bare basename
             const recordedBase = path.posix.basename(recorded);
             return recordedBase === baseName || recordedBase === pairedCodexName;
         });
@@ -196,8 +212,12 @@ export interface DeletionGuardGitOps {
  * missing from the working tree without a deletion tombstone, and restores
  * them from HEAD so the upcoming stage-all commit cannot propagate the loss.
  *
- * Files covered by a tombstone are left deleted (intentional removals).
- * Returns the workspace-relative paths of the files it restored.
+ * A tombstone only covers a missing file when the deletion was recorded at or
+ * after the file's latest content activity at HEAD (the same rule the
+ * delete-vs-modify resolver applies). A file re-created under the same name
+ * after an old deletion carries newer edit timestamps, so a stale tombstone
+ * can't re-propagate the old deletion. Returns the workspace-relative paths
+ * of the files it restored.
  */
 export async function restoreContentFilesMissingWithoutTombstone(
     workspaceDir: string,
@@ -214,11 +234,15 @@ export async function restoreContentFilesMissingWithoutTombstone(
 
     const restored: string[] = [];
     for (const [filepath] of missingFiles) {
-        if (findTombstoneTimestamp(tombstones, filepath) !== undefined) {
-            continue; // Intentionally deleted through the app — let the deletion sync.
-        }
         try {
             const blob = await gitOps.readBlobAtRef(workspaceDir, "HEAD", filepath);
+            const tombstoneTimestamp = findTombstoneTimestamp(tombstones, filepath);
+            if (
+                tombstoneTimestamp !== undefined &&
+                tombstoneTimestamp >= getLatestContentTimestamp(blob.toString("utf-8"))
+            ) {
+                continue; // Intentionally deleted through the app — let the deletion sync.
+            }
             const target = vscode.Uri.joinPath(
                 vscode.Uri.file(workspaceDir),
                 ...normalizePath(filepath).split("/")

--- a/src/projectManager/utils/merge/index.ts
+++ b/src/projectManager/utils/merge/index.ts
@@ -32,7 +32,7 @@ import {
     notifyEmptiedCodexFilesRestored,
     notifyEmptiedCodexFilesBlockedSync,
 } from "../syncSafetyGuard";
-import { normalizeSyncPath, synthesizeConflictsForPaths } from "./conflictSynthesis";
+import { enforceConflictListInvariant } from "./conflictSynthesis";
 
 const DEBUG_MODE = false;
 function debug(...args: any[]): void {
@@ -199,75 +199,30 @@ export async function stageAndCommitAllAndSync(
         }
 
         // Invariant (issue #991): every remote-changed file MUST appear in the
-        // conflict list. If it doesn't, something dropped silently between
-        // Frontier's existence classification and the conflict list it produced
-        // — proceeding would create a merge commit missing those files. On
-        // early attempts, throw a TransientSyncError so the retry layer below
-        // can re-run sync (which refetches via fetchOrigin) before bothering
-        // the user. On the FINAL attempt, a persistent mismatch (upstream path
-        // classification bug, version skew) must not leave sync permanently
-        // failing — the user could neither push nor pull — so self-heal by
-        // synthesizing conflict entries for the missing paths from local git
-        // state and letting them flow through the normal resolvers. That still
-        // upholds the invariant's guarantee: the merged result includes the
-        // files. Paths that can't be synthesized keep failing loudly.
-        //
-        // Unlike the old diagnostic, this checks ALL paths, not just `.codex`,
-        // because the gan-ji-an regression involved .webm pointer files too.
-        // Both sides are normalized before comparing so a formatting mismatch
-        // (backslashes, leading "./", Unicode form) can't fake a violation.
+        // conflict list — proceeding otherwise would create a merge commit
+        // missing those files. Unlike the old diagnostic, this checks ALL
+        // paths, not just `.codex`, because the gan-ji-an regression involved
+        // .webm pointer files too. On early attempts a mismatch throws a
+        // TransientSyncError so the retry layer below refetches; on the FINAL
+        // attempt the missing paths are synthesized from local git state and
+        // merged normally, so a persistent upstream mismatch degrades to a
+        // normal merge instead of a permanent sync outage. See
+        // enforceConflictListInvariant for the full decision logic.
         const conflictsArr = Array.isArray(conflictsResponse?.conflicts)
             ? (conflictsResponse.conflicts as Array<{ filepath?: string; }>)
             : [];
-        const conflictPaths = new Set(
-            conflictsArr
-                .map((c) => c?.filepath)
-                .filter((p): p is string => typeof p === "string")
-                .map(normalizeSyncPath)
-        );
-
         const remoteChanged = conflictsResponse?.remoteChangedFilePaths;
         const allChanged = conflictsResponse?.allChangedFilePaths;
-        const changedList: unknown =
-            Array.isArray(remoteChanged) ? remoteChanged : Array.isArray(allChanged) ? allChanged : [];
-
-        const synthesizedConflicts: ConflictFile[] = [];
-        if (Array.isArray(changedList) && changedList.length > 0) {
-            const changedPaths = changedList.filter(
-                (p): p is string => typeof p === "string" && p.length > 0
-            );
-            const missingFromConflicts = changedPaths.filter(
-                (p) => !conflictPaths.has(normalizeSyncPath(p))
-            );
-            if (missingFromConflicts.length > 0) {
-                const describeMissing = (paths: string[]) => {
-                    const sample = paths.slice(0, 5).join(", ");
-                    const extra = paths.length > 5 ? ` (+${paths.length - 5} more)` : "";
-                    return `${sample}${extra}`;
-                };
-                if (retryCount < 2) {
-                    throw new TransientSyncError(
-                        `${missingFromConflicts.length} remote-changed file(s) were not in the conflict list. Missing: ${describeMissing(missingFromConflicts)}`,
-                        missingFromConflicts
-                    );
-                }
-                const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
-                    workspaceFolder,
-                    missingFromConflicts
-                );
-                if (unsynthesizable.length > 0) {
-                    throw new TransientSyncError(
-                        `${unsynthesizable.length} remote-changed file(s) were not in the conflict list and could not be recovered from the fetched remote. Missing: ${describeMissing(unsynthesizable)}`,
-                        unsynthesizable
-                    );
-                }
-                console.warn(
-                    `[Sync] Conflict-list invariant self-heal: merging ${synthesized.length} remote-changed file(s) the conflict list missed:`,
-                    synthesized.map((c) => c.filepath)
-                );
-                synthesizedConflicts.push(...synthesized);
-            }
-        }
+        const synthesizedConflicts: ConflictFile[] = await enforceConflictListInvariant({
+            conflicts: conflictsArr,
+            changedPaths: Array.isArray(remoteChanged)
+                ? remoteChanged
+                : Array.isArray(allChanged)
+                    ? allChanged
+                    : [],
+            retryCount,
+            workspaceDir: workspaceFolder,
+        });
 
         // Capture uploaded LFS files from the sync operation
         if (conflictsResponse?.uploadedLfsFiles) {

--- a/src/projectManager/utils/merge/index.ts
+++ b/src/projectManager/utils/merge/index.ts
@@ -32,6 +32,7 @@ import {
     notifyEmptiedCodexFilesRestored,
     notifyEmptiedCodexFilesBlockedSync,
 } from "../syncSafetyGuard";
+import { normalizeSyncPath, synthesizeConflictsForPaths } from "./conflictSynthesis";
 
 const DEBUG_MODE = false;
 function debug(...args: any[]): void {
@@ -197,20 +198,32 @@ export async function stageAndCommitAllAndSync(
             return syncResult;
         }
 
-        // Diagnostic: every remote-changed file MUST appear in the conflict list.
-        // If it doesn't, something dropped silently between Frontier's existence
-        // classification and the conflict list it produced — proceeding would
-        // create a merge commit missing those files. Throw a TransientSyncError
-        // so the retry layer below can re-run sync (which refetches via
-        // fetchOrigin) before bothering the user.
+        // Invariant (issue #991): every remote-changed file MUST appear in the
+        // conflict list. If it doesn't, something dropped silently between
+        // Frontier's existence classification and the conflict list it produced
+        // — proceeding would create a merge commit missing those files. On
+        // early attempts, throw a TransientSyncError so the retry layer below
+        // can re-run sync (which refetches via fetchOrigin) before bothering
+        // the user. On the FINAL attempt, a persistent mismatch (upstream path
+        // classification bug, version skew) must not leave sync permanently
+        // failing — the user could neither push nor pull — so self-heal by
+        // synthesizing conflict entries for the missing paths from local git
+        // state and letting them flow through the normal resolvers. That still
+        // upholds the invariant's guarantee: the merged result includes the
+        // files. Paths that can't be synthesized keep failing loudly.
         //
         // Unlike the old diagnostic, this checks ALL paths, not just `.codex`,
         // because the gan-ji-an regression involved .webm pointer files too.
+        // Both sides are normalized before comparing so a formatting mismatch
+        // (backslashes, leading "./", Unicode form) can't fake a violation.
         const conflictsArr = Array.isArray(conflictsResponse?.conflicts)
             ? (conflictsResponse.conflicts as Array<{ filepath?: string; }>)
             : [];
         const conflictPaths = new Set(
-            conflictsArr.map((c) => c?.filepath).filter((p): p is string => typeof p === "string")
+            conflictsArr
+                .map((c) => c?.filepath)
+                .filter((p): p is string => typeof p === "string")
+                .map(normalizeSyncPath)
         );
 
         const remoteChanged = conflictsResponse?.remoteChangedFilePaths;
@@ -218,20 +231,41 @@ export async function stageAndCommitAllAndSync(
         const changedList: unknown =
             Array.isArray(remoteChanged) ? remoteChanged : Array.isArray(allChanged) ? allChanged : [];
 
+        const synthesizedConflicts: ConflictFile[] = [];
         if (Array.isArray(changedList) && changedList.length > 0) {
             const changedPaths = changedList.filter(
                 (p): p is string => typeof p === "string" && p.length > 0
             );
-            const missingFromConflicts = changedPaths.filter((p) => !conflictPaths.has(p));
+            const missingFromConflicts = changedPaths.filter(
+                (p) => !conflictPaths.has(normalizeSyncPath(p))
+            );
             if (missingFromConflicts.length > 0) {
-                const sample = missingFromConflicts.slice(0, 5).join(", ");
-                const extra = missingFromConflicts.length > 5
-                    ? ` (+${missingFromConflicts.length - 5} more)`
-                    : "";
-                throw new TransientSyncError(
-                    `${missingFromConflicts.length} remote-changed file(s) were not in the conflict list. Missing: ${sample}${extra}`,
+                const describeMissing = (paths: string[]) => {
+                    const sample = paths.slice(0, 5).join(", ");
+                    const extra = paths.length > 5 ? ` (+${paths.length - 5} more)` : "";
+                    return `${sample}${extra}`;
+                };
+                if (retryCount < 2) {
+                    throw new TransientSyncError(
+                        `${missingFromConflicts.length} remote-changed file(s) were not in the conflict list. Missing: ${describeMissing(missingFromConflicts)}`,
+                        missingFromConflicts
+                    );
+                }
+                const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+                    workspaceFolder,
                     missingFromConflicts
                 );
+                if (unsynthesizable.length > 0) {
+                    throw new TransientSyncError(
+                        `${unsynthesizable.length} remote-changed file(s) were not in the conflict list and could not be recovered from the fetched remote. Missing: ${describeMissing(unsynthesizable)}`,
+                        unsynthesizable
+                    );
+                }
+                console.warn(
+                    `[Sync] Conflict-list invariant self-heal: merging ${synthesized.length} remote-changed file(s) the conflict list missed:`,
+                    synthesized.map((c) => c.filepath)
+                );
+                synthesizedConflicts.push(...synthesized);
             }
         }
 
@@ -240,8 +274,8 @@ export async function stageAndCommitAllAndSync(
             syncResult.uploadedLfsFiles = conflictsResponse.uploadedLfsFiles;
         }
 
-        if (conflictsResponse?.hasConflicts) {
-            const conflicts = conflictsResponse.conflicts || [];
+        if (conflictsResponse?.hasConflicts || synthesizedConflicts.length > 0) {
+            const conflicts = [...(conflictsResponse.conflicts || []), ...synthesizedConflicts];
             debug(`🔧 Processing ${conflicts.length} file conflicts from git sync...`);
 
             // Track which files are being modified

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -1241,6 +1241,9 @@ export async function resolveCodexCustomMerge(
             debugLog(`Mapped their cell with ID: ${cell.metadata.id}`);
         }
     });
+    // Same-id merges below remove entries from theirCellsMap, so capturing the
+    // initial size lets the re-import alignment measure id overlap afterwards.
+    const theirIdBearingCellCount = theirCellsMap.size;
 
     const resultCells: CustomNotebookCellData[] = [];
 
@@ -1276,7 +1279,14 @@ export async function resolveCodexCustomMerge(
     // "their-only" cells as new, align them to our cells by content identity:
     //   - a timed cell (subtitle cue) with the exact same (startTime, endTime) and
     //     cell type IS the same cue, re-imported under a fresh id;
-    //   - a milestone with the same chapter number IS the same section marker.
+    //   - a milestone with the same chapter number IS the same section marker —
+    //     but ONLY in a wholesale-re-import-shaped merge (zero id overlap between
+    //     the two sides, the #1079 signature). In a normal incremental sync most
+    //     ids match, and a their-only milestone there is a genuinely NEW milestone
+    //     from the milestone-editing feature (promote/add, issue #936) whose
+    //     user-chosen label ("Part 2") must not fold it into an existing chapter
+    //     milestone that happens to share its last number. Timed-cue alignment
+    //     stays unconditional: exact (startTime, endTime) keys are precise.
     // Aligned pairs merge into the our-side cell (our id is canonical; edit
     // histories union; the newest edit wins per field).
     //
@@ -1290,9 +1300,12 @@ export async function resolveCodexCustomMerge(
     // Anything ambiguous (several live our-cells share a key — e.g. an already-
     // damaged file) is also left to the insert path.
     if (theirCellsMap.size > 0) {
+        const sharedIdCount = theirIdBearingCellCount - theirCellsMap.size;
+        const isWholesaleReimportShape = sharedIdCount === 0;
         const contentKeyForCell = (cell: CustomNotebookCellData): string | null => {
             const md: any = cell.metadata || {};
             if (md.type === CodexCellTypes.MILESTONE) {
+                if (!isWholesaleReimportShape) return null;
                 const label = (cell.value || "").trim();
                 if (!label) return null;
                 // Milestone values come in two app-generated formats for the same
@@ -1301,9 +1314,11 @@ export async function resolveCodexCustomMerge(
                 // value — same rule as extractChapterNumberFromMilestoneValue in the
                 // webview) so a re-imported "1" aligns with an existing "<docName> 1"
                 // instead of inserting a duplicate section. Files with several
-                // same-numbered milestones fall into the ambiguity skip.
+                // same-numbered milestones fall into the ambiguity skip. Digitless
+                // labels never align: they carry no chapter identity, and two
+                // default-named user milestones ("New milestone") must not fold.
                 const chapterMatch = label.match(/(\d+)(?!.*\d)/);
-                return chapterMatch ? `milestone:${chapterMatch[1]}` : `milestone:${label}`;
+                return chapterMatch ? `milestone:${chapterMatch[1]}` : null;
             }
             const data = md.data || {};
             if (data.startTime != null && data.endTime != null) {

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -212,9 +212,23 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                             console.warn(`[Navigation] Could not read codex metadata for original file cleanup: ${err}`);
                         }
 
+                        // Record the deletion tombstone BEFORE deleting so a
+                        // concurrently starting sync can never observe the file
+                        // missing without a tombstone and restore it from HEAD
+                        // (issue #1116 guard race). Withdrawn below on failure.
+                        let tombstoneRecordedAt: number | undefined;
+                        if (message.type === "codexDocument") {
+                            tombstoneRecordedAt = await this.recordFileDeletionToEditHistory(
+                                normalizedPath,
+                                message.label
+                            );
+                        }
+
                         // Delete the codex file
+                        let codexDeleted = false;
                         try {
                             await vscode.workspace.fs.delete(codexUri);
+                            codexDeleted = true;
                             deletedFiles.push(`${message.label}.codex`);
                         } catch (error) {
                             console.error("Error deleting codex file:", error);
@@ -279,9 +293,14 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                             }
                         }
 
-                        // Record single file deletion to project edit history
-                        if (deletedFiles.length > 0 && message.type === "codexDocument") {
-                            await this.recordFileDeletionToEditHistory(normalizedPath, message.label);
+                        // The codex file is the tombstone's subject; if its
+                        // deletion failed the file still exists, so withdraw
+                        // the tombstone recorded above.
+                        if (tombstoneRecordedAt !== undefined && !codexDeleted) {
+                            await this.removeFileDeletionFromEditHistory(
+                                normalizedPath,
+                                tombstoneRecordedAt
+                            );
                         }
 
                         // Show appropriate message based on results
@@ -1566,13 +1585,25 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
             .replace(/\\/g, "/");
     }
 
-    private async recordFileDeletionToEditHistory(filePath: string, label: string): Promise<void> {
+    /**
+     * Records a deletion tombstone. Called BEFORE the file is deleted so a
+     * concurrently starting sync can never observe the file missing without a
+     * tombstone and restore it from HEAD (issue #1116 guard race). Returns a
+     * timestamp lower bound identifying the recorded edit so the caller can
+     * withdraw it if the deletion then fails; undefined when nothing was
+     * recorded.
+     */
+    private async recordFileDeletionToEditHistory(
+        filePath: string,
+        label: string
+    ): Promise<number | undefined> {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
-        if (!workspaceFolder) return;
+        if (!workspaceFolder) return undefined;
 
         try {
             const author = await this.getCurrentUser();
             const relPath = this.toWorkspaceRelativePath(workspaceFolder, filePath);
+            const recordedAtOrAfter = Date.now();
             await MetadataManager.safeUpdateMetadata(
                 workspaceFolder,
                 (metadata: { edits?: unknown[]; }) => {
@@ -1587,17 +1618,66 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 },
                 { author }
             );
+            return recordedAtOrAfter;
         } catch (err) {
             console.warn(`[Navigation] Could not record file deletion to edit history: ${err}`);
+            return undefined;
         }
     }
 
-    private async recordCorpusDeletionToEditHistory(
-        corpusMarker: string,
-        deletedFiles: Array<{ filePath: string; label: string; }>
+    /**
+     * Withdraws a deletion tombstone recorded by recordFileDeletionToEditHistory
+     * when the deletion itself failed — the file still exists, and a leftover
+     * tombstone would mark any future disappearance as intentional.
+     */
+    private async removeFileDeletionFromEditHistory(
+        filePath: string,
+        recordedAtOrAfter: number
     ): Promise<void> {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceFolder) return;
+
+        try {
+            const author = await this.getCurrentUser();
+            const relPath = this.toWorkspaceRelativePath(workspaceFolder, filePath);
+            await MetadataManager.safeUpdateMetadata(
+                workspaceFolder,
+                (metadata: { edits?: any[]; }) => {
+                    if (Array.isArray(metadata.edits)) {
+                        metadata.edits = metadata.edits.filter(
+                            (edit: any) =>
+                                !(
+                                    Array.isArray(edit?.editMap) &&
+                                    edit.editMap.length === 1 &&
+                                    edit.editMap[0] === EditMapUtils.deletedFile()[0] &&
+                                    edit?.value?.relPath === relPath &&
+                                    typeof edit?.timestamp === "number" &&
+                                    edit.timestamp >= recordedAtOrAfter
+                                )
+                        );
+                    }
+                    return metadata;
+                },
+                { author }
+            );
+        } catch (err) {
+            console.warn(`[Navigation] Could not withdraw file deletion tombstone: ${err}`);
+        }
+    }
+
+    /**
+     * Records a corpus deletion tombstone covering the given files. Called
+     * BEFORE any file is deleted (issue #1116 guard race — see
+     * recordFileDeletionToEditHistory). Returns a timestamp lower bound
+     * identifying the recorded edit for reconciliation; undefined when nothing
+     * was recorded.
+     */
+    private async recordCorpusDeletionToEditHistory(
+        corpusMarker: string,
+        deletedFiles: Array<{ filePath: string; label: string; }>
+    ): Promise<number | undefined> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!workspaceFolder) return undefined;
 
         try {
             const author = await this.getCurrentUser();
@@ -1605,6 +1685,7 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 ...file,
                 relPath: this.toWorkspaceRelativePath(workspaceFolder, file.filePath),
             }));
+            const recordedAtOrAfter = Date.now();
             await MetadataManager.safeUpdateMetadata(
                 workspaceFolder,
                 (metadata: { edits?: unknown[]; }) => {
@@ -1619,8 +1700,64 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 },
                 { author }
             );
+            return recordedAtOrAfter;
         } catch (err) {
             console.warn(`[Navigation] Could not record corpus deletion to edit history: ${err}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Narrows a pre-recorded corpus deletion tombstone to the files that were
+     * actually deleted, or withdraws it entirely when none were. Files whose
+     * deletion failed still exist, and leaving them tombstoned would mark any
+     * future disappearance as intentional.
+     */
+    private async reconcileCorpusDeletionInEditHistory(
+        corpusMarker: string,
+        recordedAtOrAfter: number,
+        actuallyDeletedFiles: Array<{ filePath: string; label: string; }>
+    ): Promise<void> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!workspaceFolder) return;
+
+        try {
+            const author = await this.getCurrentUser();
+            const survivingEntries = actuallyDeletedFiles.map((file) => ({
+                ...file,
+                relPath: this.toWorkspaceRelativePath(workspaceFolder, file.filePath),
+            }));
+            const isTargetEdit = (edit: any) =>
+                Array.isArray(edit?.editMap) &&
+                edit.editMap.length === 1 &&
+                edit.editMap[0] === EditMapUtils.deletedCorpusMarker()[0] &&
+                edit?.value?.corpusMarker === corpusMarker &&
+                typeof edit?.timestamp === "number" &&
+                edit.timestamp >= recordedAtOrAfter;
+
+            await MetadataManager.safeUpdateMetadata(
+                workspaceFolder,
+                (metadata: { edits?: any[]; }) => {
+                    if (Array.isArray(metadata.edits)) {
+                        if (survivingEntries.length === 0) {
+                            metadata.edits = metadata.edits.filter((edit: any) => !isTargetEdit(edit));
+                        } else {
+                            for (const edit of metadata.edits) {
+                                if (isTargetEdit(edit)) {
+                                    edit.value = {
+                                        ...edit.value,
+                                        deletedFiles: survivingEntries,
+                                    };
+                                }
+                            }
+                        }
+                    }
+                    return metadata;
+                },
+                { author }
+            );
+        } catch (err) {
+            console.warn(`[Navigation] Could not reconcile corpus deletion tombstone: ${err}`);
         }
     }
 
@@ -1664,6 +1801,18 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
 
         const allDeletedFiles: Array<{ filePath: string; label: string; }> = [];
         const errors: string[] = [];
+
+        // Record the corpus tombstone for every intended file BEFORE deleting
+        // anything, so a concurrently starting sync can never observe files
+        // missing without tombstones and restore them from HEAD (issue #1116
+        // guard race). Reconciled below to the files actually deleted.
+        const tombstoneRecordedAt = await this.recordCorpusDeletionToEditHistory(
+            corpusLabel,
+            children.map((child) => ({
+                filePath: (child.uri as string).replace(/\\/g, "/"),
+                label: child.label,
+            }))
+        );
 
         await vscode.window.withProgress(
             {
@@ -1751,9 +1900,14 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
             }
         );
 
-        // Record folder and all deleted files to edit history
-        if (allDeletedFiles.length > 0) {
-            await this.recordCorpusDeletionToEditHistory(corpusLabel, allDeletedFiles);
+        // Narrow the pre-recorded tombstone to the files actually deleted
+        // (files whose deletion failed still exist and must not stay covered).
+        if (tombstoneRecordedAt !== undefined && allDeletedFiles.length < children.length) {
+            await this.reconcileCorpusDeletionInEditHistory(
+                corpusLabel,
+                tombstoneRecordedAt,
+                allDeletedFiles
+            );
         }
 
         if (allDeletedFiles.length > 0 && errors.length === 0) {

--- a/src/test/suite/conflictSynthesis.test.ts
+++ b/src/test/suite/conflictSynthesis.test.ts
@@ -6,9 +6,11 @@ import * as os from "os";
 import {
     normalizeSyncPath,
     synthesizeConflictsForPaths,
+    enforceConflictListInvariant,
     ConflictSynthesisGitOps,
 } from "../../projectManager/utils/merge/conflictSynthesis";
 import { resolveConflictFiles } from "../../projectManager/utils/merge/resolvers";
+import { TransientSyncError } from "../../projectManager/utils/merge/transientSyncError";
 
 async function makeTempWorkspace(): Promise<string> {
     const dir = path.join(
@@ -246,5 +248,164 @@ suite("conflictSynthesis - synthesizeConflictsForPaths", () => {
         );
         const merged = JSON.parse(new TextDecoder().decode(mergedBytes));
         assert.strictEqual(merged.cells[0].value, "<span>newer remote</span>");
+    });
+});
+
+suite("conflictSynthesis - enforceConflictListInvariant", () => {
+    let workspaceDir: string;
+
+    setup(async () => {
+        workspaceDir = await makeTempWorkspace();
+    });
+
+    teardown(async () => {
+        await removeDir(workspaceDir);
+    });
+
+    // The extension host defines console methods as non-writable, so the log
+    // emission is verified through the injectable `log` option instead.
+
+    test("returns no entries when every remote-changed path is in the conflict list", async () => {
+        const result = await enforceConflictListInvariant(
+            {
+                conflicts: [{ filepath: "files/target/EP.codex" }],
+                changedPaths: ["files/target/EP.codex"],
+                retryCount: 0,
+                workspaceDir,
+            },
+            fakeGitOps([], {})
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    test("path formatting differences are not violations (separators, ./, Unicode form)", async () => {
+        const result = await enforceConflictListInvariant(
+            {
+                conflicts: [
+                    { filepath: "files/target/EP.codex" },
+                    { filepath: "files/target/Genèse.codex".normalize("NFC") },
+                ],
+                changedPaths: [
+                    ".\\files\\target\\EP.codex",
+                    "files/target/Genèse.codex".normalize("NFD"),
+                ],
+                retryCount: 0,
+                workspaceDir,
+            },
+            fakeGitOps([], {})
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    test("throws TransientSyncError on early attempts so the retry layer refetches", async () => {
+        for (const retryCount of [0, 1]) {
+            await assert.rejects(
+                enforceConflictListInvariant(
+                    {
+                        conflicts: [],
+                        changedPaths: ["files/target/MISSING.codex"],
+                        retryCount,
+                        workspaceDir,
+                    },
+                    fakeGitOps(["FETCH_HEAD"], {
+                        "FETCH_HEAD:files/target/MISSING.codex": "remote-content",
+                    })
+                ),
+                (error: unknown) =>
+                    error instanceof TransientSyncError &&
+                    error.message.includes("files/target/MISSING.codex")
+            );
+        }
+    });
+
+    test("self-heals on the final attempt: synthesizes the missing paths and logs the event", async () => {
+        const warns: any[][] = [];
+        const result = await enforceConflictListInvariant(
+            {
+                conflicts: [],
+                changedPaths: ["files/target/MISSING.codex"],
+                retryCount: 2,
+                workspaceDir,
+                log: (...args: unknown[]) => {
+                    warns.push(args);
+                },
+            },
+            fakeGitOps(["FETCH_HEAD"], {
+                "FETCH_HEAD:files/target/MISSING.codex": "remote-content",
+                "HEAD:files/target/MISSING.codex": "head-content",
+            })
+        );
+
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].filepath, "files/target/MISSING.codex");
+        assert.strictEqual(result[0].theirs, "remote-content");
+        assert.strictEqual(result[0].ours, "head-content");
+        assert.ok(
+            warns.some((args) => String(args[0]).includes("invariant self-heal")),
+            "the self-heal must emit a log entry"
+        );
+    });
+
+    test("keeps failing loudly on the final attempt for paths that cannot be synthesized", async () => {
+        await assert.rejects(
+            enforceConflictListInvariant(
+                {
+                    conflicts: [],
+                    changedPaths: ["files/target/UNREADABLE.codex"],
+                    retryCount: 2,
+                    workspaceDir,
+                },
+                fakeGitOps(["FETCH_HEAD"], {})
+            ),
+            (error: unknown) =>
+                error instanceof TransientSyncError &&
+                error.message.includes("could not be recovered") &&
+                error.message.includes("files/target/UNREADABLE.codex")
+        );
+    });
+
+    test("integration: a persistent mismatch self-heals end-to-end — the missing file lands merged on disk", async () => {
+        // Simulates the frontier response shape on the final attempt: a
+        // remote-changed .codex absent from the conflict list on every attempt.
+        // The invariant must synthesize it, and the normal resolvers must leave
+        // the merged content on disk — which is exactly what the subsequent
+        // sync commit stages.
+        const ourContent = notebookWithEdit("<span>older local</span>", 1000);
+        const theirContent = notebookWithEdit("<span>newer remote</span>", 2000);
+        await writeFileText(workspaceDir, "files/target/EP.codex", ourContent);
+
+        const warns: any[][] = [];
+        const synthesized = await enforceConflictListInvariant(
+            {
+                conflicts: [],
+                changedPaths: ["files/target/EP.codex"],
+                retryCount: 2,
+                workspaceDir,
+                log: (...args: unknown[]) => {
+                    warns.push(args);
+                },
+            },
+            fakeGitOps(["FETCH_HEAD"], {
+                "FETCH_HEAD:files/target/EP.codex": theirContent,
+                "HEAD:files/target/EP.codex": ourContent,
+            })
+        );
+
+        const { resolved, failed } = await resolveConflictFiles(synthesized, workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP.codex", resolution: "modified" },
+        ]);
+        const mergedBytes = await vscode.workspace.fs.readFile(
+            vscode.Uri.file(path.join(workspaceDir, "files/target/EP.codex"))
+        );
+        const merged = JSON.parse(new TextDecoder().decode(mergedBytes));
+        assert.strictEqual(
+            merged.cells[0].value,
+            "<span>newer remote</span>",
+            "the remote-changed file is merged, not dropped"
+        );
+        assert.ok(warns.some((args) => String(args[0]).includes("invariant self-heal")));
     });
 });

--- a/src/test/suite/conflictSynthesis.test.ts
+++ b/src/test/suite/conflictSynthesis.test.ts
@@ -1,0 +1,250 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os from "os";
+
+import {
+    normalizeSyncPath,
+    synthesizeConflictsForPaths,
+    ConflictSynthesisGitOps,
+} from "../../projectManager/utils/merge/conflictSynthesis";
+import { resolveConflictFiles } from "../../projectManager/utils/merge/resolvers";
+
+async function makeTempWorkspace(): Promise<string> {
+    const dir = path.join(
+        os.tmpdir(),
+        `conflict-synthesis-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+    return dir;
+}
+
+async function removeDir(dir: string): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(vscode.Uri.file(dir), { recursive: true });
+    } catch {
+        // best-effort cleanup
+    }
+}
+
+async function writeFileText(dir: string, relPath: string, content: string): Promise<void> {
+    const target = vscode.Uri.file(path.join(dir, relPath));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(target.fsPath)));
+    await vscode.workspace.fs.writeFile(target, Buffer.from(content));
+}
+
+/** blobs keyed by "<ref>:<filepath>"; refs listed in `refs` resolve. */
+function fakeGitOps(
+    refs: string[],
+    blobs: Record<string, string>
+): ConflictSynthesisGitOps {
+    return {
+        resolveRef: async (_dir: string, ref: string) => {
+            if (!refs.includes(ref)) throw new Error(`unknown ref ${ref}`);
+            return "0000000000000000000000000000000000000000";
+        },
+        readBlobAtRef: async (_dir: string, ref: string, filepath: string) => {
+            const key = `${ref}:${filepath}`;
+            if (!(key in blobs)) throw new Error(`no blob for ${key}`);
+            return Buffer.from(blobs[key]);
+        },
+    };
+}
+
+/** Minimal `.codex` notebook with one cell whose newest edit has the given value/timestamp. */
+function notebookWithEdit(value: string, timestamp: number): string {
+    return JSON.stringify({
+        cells: [
+            {
+                kind: 2,
+                languageId: "html",
+                value,
+                metadata: {
+                    id: "EP 1:1",
+                    type: "text",
+                    edits: [
+                        {
+                            editMap: ["value"],
+                            value,
+                            timestamp,
+                            type: "user-edit",
+                            author: "translator",
+                        },
+                    ],
+                    data: {},
+                },
+            },
+        ],
+        metadata: { id: "EP", edits: [] },
+    });
+}
+
+suite("conflictSynthesis - normalizeSyncPath", () => {
+    test("canonicalizes separators, leading ./ and /, and Unicode form", () => {
+        assert.strictEqual(normalizeSyncPath("files\\target\\EP.codex"), "files/target/EP.codex");
+        assert.strictEqual(normalizeSyncPath("./files/target/EP.codex"), "files/target/EP.codex");
+        assert.strictEqual(normalizeSyncPath("././files/target/EP.codex"), "files/target/EP.codex");
+        assert.strictEqual(normalizeSyncPath("/files/target/EP.codex"), "files/target/EP.codex");
+        // NFD (e + combining acute) normalizes to NFC (precomposed é)
+        assert.strictEqual(normalizeSyncPath("files/target/Genèse.codex".normalize("NFD")), "files/target/Genèse.codex".normalize("NFC"));
+        // already-canonical paths pass through unchanged
+        assert.strictEqual(normalizeSyncPath("files/target/EP.codex"), "files/target/EP.codex");
+    });
+});
+
+suite("conflictSynthesis - synthesizeConflictsForPaths", () => {
+    let workspaceDir: string;
+
+    setup(async () => {
+        workspaceDir = await makeTempWorkspace();
+    });
+
+    teardown(async () => {
+        await removeDir(workspaceDir);
+    });
+
+    test("builds ours from the working tree, theirs from the remote ref, base from HEAD", async () => {
+        await writeFileText(workspaceDir, "files/target/EP.codex", "working-content");
+        const gitOps = fakeGitOps(["FETCH_HEAD"], {
+            "FETCH_HEAD:files/target/EP.codex": "remote-content",
+            "HEAD:files/target/EP.codex": "head-content",
+        });
+
+        const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/EP.codex"],
+            gitOps
+        );
+
+        assert.deepStrictEqual(unsynthesizable, []);
+        assert.deepStrictEqual(synthesized, [
+            {
+                filepath: "files/target/EP.codex",
+                ours: "working-content",
+                theirs: "remote-content",
+                base: "head-content",
+                isDeleted: false,
+                isNew: false,
+            },
+        ]);
+    });
+
+    test("falls back to HEAD for ours when the working tree lacks the file, and flags remote-new files", async () => {
+        const gitOps = fakeGitOps(["FETCH_HEAD"], {
+            "FETCH_HEAD:files/target/EXISTING.codex": "remote-content",
+            "HEAD:files/target/EXISTING.codex": "head-content",
+            "FETCH_HEAD:files/target/NEW.codex": "brand-new-remote-content",
+        });
+
+        const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/EXISTING.codex", "files/target/NEW.codex"],
+            gitOps
+        );
+
+        assert.deepStrictEqual(unsynthesizable, []);
+        const existing = synthesized.find((c) => c.filepath === "files/target/EXISTING.codex");
+        assert.deepStrictEqual(existing, {
+            filepath: "files/target/EXISTING.codex",
+            ours: "head-content",
+            theirs: "remote-content",
+            base: "head-content",
+            isDeleted: false,
+            // isNew keys off disk presence: absent locally → the resolvers'
+            // creation path must handle it (their existing-file path would
+            // fail a disk stat).
+            isNew: true,
+        });
+        const brandNew = synthesized.find((c) => c.filepath === "files/target/NEW.codex");
+        assert.deepStrictEqual(brandNew, {
+            filepath: "files/target/NEW.codex",
+            ours: "",
+            theirs: "brand-new-remote-content",
+            base: "",
+            isDeleted: false,
+            isNew: true,
+        });
+    });
+
+    test("normalizes incoming paths before reading git state", async () => {
+        const gitOps = fakeGitOps(["FETCH_HEAD"], {
+            "FETCH_HEAD:files/target/EP.codex": "remote-content",
+        });
+
+        const { synthesized } = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["./files\\target\\EP.codex"],
+            gitOps
+        );
+
+        assert.strictEqual(synthesized.length, 1);
+        assert.strictEqual(synthesized[0].filepath, "files/target/EP.codex");
+    });
+
+    test("reports paths whose remote content cannot be read as unsynthesizable — never invents content", async () => {
+        const gitOps = fakeGitOps(["FETCH_HEAD"], {
+            "FETCH_HEAD:files/target/OK.codex": "remote-content",
+        });
+
+        const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/OK.codex", "files/target/UNREADABLE.codex"],
+            gitOps
+        );
+
+        assert.deepStrictEqual(
+            synthesized.map((c) => c.filepath),
+            ["files/target/OK.codex"]
+        );
+        assert.deepStrictEqual(unsynthesizable, ["files/target/UNREADABLE.codex"]);
+    });
+
+    test("falls back through remote ref candidates and gives up cleanly when none resolve", async () => {
+        const viaOriginMain = fakeGitOps(["refs/remotes/origin/main"], {
+            "refs/remotes/origin/main:files/target/EP.codex": "remote-content",
+        });
+        const ok = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/EP.codex"],
+            viaOriginMain
+        );
+        assert.strictEqual(ok.synthesized.length, 1);
+        assert.strictEqual(ok.synthesized[0].theirs, "remote-content");
+
+        const noRefs = fakeGitOps([], {});
+        const failed = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/EP.codex"],
+            noRefs
+        );
+        assert.deepStrictEqual(failed.synthesized, []);
+        assert.deepStrictEqual(failed.unsynthesizable, ["files/target/EP.codex"]);
+    });
+
+    test("synthesized .codex conflicts resolve through the normal resolvers (newest edit wins)", async () => {
+        const ourContent = notebookWithEdit("<span>older local</span>", 1000);
+        const theirContent = notebookWithEdit("<span>newer remote</span>", 2000);
+        await writeFileText(workspaceDir, "files/target/EP.codex", ourContent);
+        const gitOps = fakeGitOps(["FETCH_HEAD"], {
+            "FETCH_HEAD:files/target/EP.codex": theirContent,
+            "HEAD:files/target/EP.codex": ourContent,
+        });
+
+        const { synthesized } = await synthesizeConflictsForPaths(
+            workspaceDir,
+            ["files/target/EP.codex"],
+            gitOps
+        );
+        const { resolved, failed } = await resolveConflictFiles(synthesized, workspaceDir);
+
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/EP.codex", resolution: "modified" },
+        ]);
+        const mergedBytes = await vscode.workspace.fs.readFile(
+            vscode.Uri.file(path.join(workspaceDir, "files/target/EP.codex"))
+        );
+        const merged = JSON.parse(new TextDecoder().decode(mergedBytes));
+        assert.strictEqual(merged.cells[0].value, "<span>newer remote</span>");
+    });
+});

--- a/src/test/suite/export/usfmParatextHeadings.test.ts
+++ b/src/test/suite/export/usfmParatextHeadings.test.ts
@@ -106,6 +106,79 @@ suite("USFM export - paratext heading placement and markers", () => {
         );
     });
 
+    test("bold-formatted paratext keeps a paragraph marker with the option off (\\bd is not a paragraph opener)", () => {
+        const boldCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "parent:paratext-2-x" },
+            value: "<span><strong>Bold Heading</strong></span>",
+        };
+        const { body } = buildUsfmBody([
+            verseCell("MAT 1:1", "Alpha"),
+            boldCell,
+            verseCell("MAT 1:2", "Beta"),
+        ]);
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\p \\bd Bold Heading\\bd*\n\\v 2 Beta\n"
+        );
+    });
+
+    test("bold-formatted paratext exports as \\s1 with the option on, character markup nested inside", () => {
+        const boldCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "parent:paratext-3-x" },
+            value: "<span><strong>Bold Heading</strong></span>",
+        };
+        const { body } = buildUsfmBody(
+            [
+                verseCell("MAT 1:1", "Alpha"),
+                boldCell,
+                verseCell("MAT 1:2", "Beta"),
+            ],
+            { paratextAsHeadings: true }
+        );
+
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\s1 \\bd Bold Heading\\bd*\n\\p\n\\v 2 Beta\n"
+        );
+    });
+
+    test("\\sup-leading content is not a paragraph opener and is not classified as a heading", () => {
+        const supCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "parent:paratext-4-x" },
+            value: "<span><sup>2</sup> footnote text</span>",
+        };
+        const { body } = buildUsfmBody([
+            verseCell("MAT 1:1", "Alpha"),
+            supCell,
+            verseCell("MAT 1:2", "Beta"),
+        ]);
+
+        // \p prefix added, and no \p restart after (not a heading).
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\p \\sup 2\\sup* footnote text\n\\v 2 Beta\n"
+        );
+    });
+
+    test("literal paragraph-level markers in content pass through; \\sp is not a heading", () => {
+        const speakerCell: UsfmExportCell = {
+            metadata: { type: "paratext", id: "parent:paratext-5-x" },
+            value: "<span>\\sp Jesus</span>",
+        };
+        const { body } = buildUsfmBody([
+            verseCell("MAT 1:1", "Alpha"),
+            speakerCell,
+            verseCell("MAT 1:2", "Beta"),
+        ]);
+
+        // Passes through as-is, no \p restart (only \s markers are headings).
+        assert.strictEqual(
+            body,
+            "\\c 1\n\\p\n\\v 1 Alpha\n\\sp Jesus\n\\v 2 Beta\n"
+        );
+    });
+
     test("legacy 'Chapter N' paratext cells still open chapters without duplicate \\c markers", () => {
         const legacyChapterCell: UsfmExportCell = {
             metadata: { type: "paratext", id: "legacy-1" },

--- a/src/test/suite/fileDeletionGuard.test.ts
+++ b/src/test/suite/fileDeletionGuard.test.ts
@@ -177,6 +177,35 @@ suite("fileDeletionGuard - helpers", () => {
         assert.strictEqual(findTombstoneTimestamp(tombstones, "files/target/EP207.codex"), undefined);
     });
 
+    test("findTombstoneTimestamp: modern relPath tombstones never match by bare basename", () => {
+        // A tombstone recorded for one path must not cover a different file
+        // that merely shares its filename (delete-then-reimport-same-name).
+        const tombstones = collectDeletionTombstones(
+            makeMetadataContent([deletedFileEdit("files/target/old/EP206.codex", 5000)])
+        );
+        assert.strictEqual(
+            findTombstoneTimestamp(tombstones, "files/target/EP206.codex"),
+            undefined
+        );
+    });
+
+    test("findTombstoneTimestamp: legacy tombstones without relPath still match by basename", () => {
+        // Old builds recorded only an absolute machine-local path; when the
+        // layout differs so the suffix rule fails, basename is the fallback.
+        const legacy = collectDeletionTombstones(
+            makeMetadataContent([
+                {
+                    editMap: ["deletedFile"],
+                    value: { filePath: "D:\\stuff\\EP206.codex", label: "E" },
+                    timestamp: 6000,
+                    type: "user-edit",
+                    author: "reviewer",
+                },
+            ])
+        );
+        assert.strictEqual(findTombstoneTimestamp(legacy, "files/target/EP206.codex"), 6000);
+    });
+
     test("findTombstoneTimestamp matches a .source file via its paired .codex tombstone", () => {
         const tombstones = collectDeletionTombstones(
             makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
@@ -316,6 +345,45 @@ suite("fileDeletionGuard - pre-sync restore guard", () => {
             false
         );
         assert.strictEqual(await fileExists(workspaceDir, "files/target/EP207.codex"), true);
+    });
+
+    test("restores a re-created file whose HEAD edits are newer than a stale tombstone", async () => {
+        // Delete-then-reimport-same-name: the old tombstone (5000) predates the
+        // re-imported file's content activity at HEAD (9000), so the guard must
+        // treat the tombstone as stale and restore the file.
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 5000)])
+        );
+
+        const gitOps = fakeGitOps(
+            [["files/target/EP206.codex", 1, 0, 0]],
+            { "files/target/EP206.codex": makeNotebookContent(9000) }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+
+        assert.deepStrictEqual(restored, ["files/target/EP206.codex"]);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), true);
+    });
+
+    test("keeps a file deleted when the tombstone is newer than its HEAD content activity", async () => {
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/EP206.codex", 9999)])
+        );
+
+        const gitOps = fakeGitOps(
+            [["files/target/EP206.codex", 1, 0, 0]],
+            { "files/target/EP206.codex": makeNotebookContent(1000) }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+
+        assert.deepStrictEqual(restored, []);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), false);
     });
 
     test("does nothing when no tracked content files are missing", async () => {

--- a/src/test/suite/fileDeletionGuard.test.ts
+++ b/src/test/suite/fileDeletionGuard.test.ts
@@ -386,6 +386,102 @@ suite("fileDeletionGuard - pre-sync restore guard", () => {
         assert.strictEqual(await fileExists(workspaceDir, "files/target/EP206.codex"), false);
     });
 
+    test("integration: delete → re-import same filename → stale-worktree sync → file survives everywhere", async () => {
+        // The full #1116-reopened story. Machine A deleted MAT.codex through the
+        // app (tombstone at T1=5000), the book was later re-imported under the
+        // SAME filename, and the re-imported content was synced (HEAD carries
+        // edits at T2=9000 > T1).
+        const reimportedContent = makeNotebookContent(9000);
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([deletedFileEdit("files/target/MAT.codex", 5000)])
+        );
+
+        // Leg 1 — machine B has a stale/damaged worktree missing the re-imported
+        // file. The pre-sync guard must treat the old tombstone as stale and
+        // restore the file instead of committing a deletion.
+        const gitOps = fakeGitOps(
+            [["files/target/MAT.codex", 1, 0, 0]],
+            { "files/target/MAT.codex": reimportedContent }
+        );
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+        assert.deepStrictEqual(restored, ["files/target/MAT.codex"]);
+        assert.strictEqual(
+            await readFileText(workspaceDir, "files/target/MAT.codex"),
+            reimportedContent
+        );
+
+        // Leg 2 — a machine that somehow already committed the deletion syncs
+        // against a teammate's surviving re-imported copy: the delete-vs-modify
+        // resolver must restore the file (tombstone older than surviving edits),
+        // so the deletion cannot propagate.
+        await vscode.workspace.fs.delete(
+            vscode.Uri.file(path.join(workspaceDir, "files/target/MAT.codex"))
+        );
+        const conflict: ConflictFile = {
+            filepath: "files/target/MAT.codex",
+            ours: "",
+            theirs: reimportedContent,
+            base: makeNotebookContent(1000),
+            isDeleted: true,
+            isNew: false,
+        };
+        const { resolved, failed } = await resolveConflictFiles([conflict], workspaceDir);
+        assert.deepStrictEqual(failed, []);
+        assert.deepStrictEqual(resolved, [
+            { filepath: "files/target/MAT.codex", resolution: "created" },
+        ]);
+        assert.strictEqual(
+            await readFileText(workspaceDir, "files/target/MAT.codex"),
+            reimportedContent
+        );
+    });
+
+    test("race window: a sync landing mid-corpus-delete preserves the deletion (tombstone-first state)", async () => {
+        // With tombstone-first ordering, a sync that starts between the first
+        // file deletion and flow completion observes: corpus tombstone recorded
+        // for ALL intended files (timestamp now, newer than any HEAD content
+        // activity), some files already deleted, some still present. The guard
+        // must leave the deleted files deleted and not touch the rest.
+        const now = Date.now();
+        await writeFileText(
+            workspaceDir,
+            "metadata.json",
+            makeMetadataContent([
+                {
+                    editMap: ["deletedCorpusMarker"],
+                    value: {
+                        corpusMarker: "EP",
+                        deletedFiles: [
+                            { filePath: "/abs/files/target/EP1.codex", relPath: "files/target/EP1.codex", label: "EP1" },
+                            { filePath: "/abs/files/target/EP2.codex", relPath: "files/target/EP2.codex", label: "EP2" },
+                        ],
+                    },
+                    timestamp: now,
+                    type: "user-edit",
+                    author: "reviewer",
+                },
+            ])
+        );
+
+        // Mid-flow: EP1 already deleted, EP2 still present.
+        await writeFileText(workspaceDir, "files/target/EP2.codex", makeNotebookContent(1000));
+        const gitOps = fakeGitOps(
+            [
+                ["files/target/EP1.codex", 1, 0, 0],
+                ["files/target/EP2.codex", 1, 1, 1],
+            ],
+            { "files/target/EP1.codex": makeNotebookContent(1000) }
+        );
+
+        const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);
+
+        assert.deepStrictEqual(restored, [], "the in-progress deletion must not be undone");
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP1.codex"), false);
+        assert.strictEqual(await fileExists(workspaceDir, "files/target/EP2.codex"), true);
+    });
+
     test("does nothing when no tracked content files are missing", async () => {
         const gitOps = fakeGitOps([["files/target/EP205.codex", 1, 1, 1]], {});
         const restored = await restoreContentFilesMissingWithoutTombstone(workspaceDir, gitOps);

--- a/src/test/suite/navigationWebviewProvider.test.ts
+++ b/src/test/suite/navigationWebviewProvider.test.ts
@@ -775,3 +775,269 @@ suite("NavigationWebviewProvider Test Suite", () => {
     });
 });
 
+
+/**
+ * Tombstone-first ordering (issue #1116 guard race): the delete flows must
+ * record deletion tombstones BEFORE deleting files, so a sync starting inside
+ * the delete window can never observe missing-without-tombstone and resurrect
+ * the files — and must withdraw/narrow the tombstone when a deletion fails,
+ * so files that still exist never stay covered.
+ */
+suite("NavigationWebviewProvider - deletion tombstone ordering", () => {
+    let context: vscode.ExtensionContext;
+    let provider: NavigationWebviewProvider;
+    let workspaceFolder: vscode.WorkspaceFolder | undefined;
+    let metadataUri: vscode.Uri | undefined;
+    let originalMetadataBytes: Uint8Array | undefined;
+
+    const readMetadataText = async (): Promise<string> => {
+        const bytes = await vscode.workspace.fs.readFile(metadataUri!);
+        return new TextDecoder().decode(bytes);
+    };
+
+    suiteSetup(async () => {
+        workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) return;
+        metadataUri = vscode.Uri.joinPath(workspaceFolder.uri, "metadata.json");
+        try {
+            originalMetadataBytes = await vscode.workspace.fs.readFile(metadataUri);
+        } catch {
+            originalMetadataBytes = undefined;
+        }
+        await vscode.workspace.fs.createDirectory(
+            vscode.Uri.joinPath(workspaceFolder.uri, "files", "target")
+        );
+    });
+
+    setup(async () => {
+        if (!workspaceFolder || !metadataUri) return;
+        context = createMockExtensionContext();
+        provider = new NavigationWebviewProvider(context);
+        // Seed a minimal metadata.json so safeUpdateMetadata can read-modify-write.
+        await vscode.workspace.fs.writeFile(
+            metadataUri,
+            Buffer.from(JSON.stringify({ projectName: "TombstoneOrderTest", edits: [], meta: {} }))
+        );
+    });
+
+    suiteTeardown(async () => {
+        if (!metadataUri) return;
+        if (originalMetadataBytes) {
+            await vscode.workspace.fs.writeFile(metadataUri, originalMetadataBytes);
+        } else {
+            try {
+                await vscode.workspace.fs.delete(metadataUri);
+            } catch {
+                // nothing to restore
+            }
+        }
+    });
+
+    async function writeCodexFile(name: string): Promise<vscode.Uri> {
+        const uri = vscode.Uri.joinPath(workspaceFolder!.uri, "files", "target", `${name}.codex`);
+        await vscode.workspace.fs.writeFile(
+            uri,
+            Buffer.from(
+                JSON.stringify({
+                    cells: [{ kind: 2, languageId: "html", value: "x", metadata: { id: "c1", edits: [] } }],
+                    metadata: { id: name, edits: [] },
+                })
+            )
+        );
+        return uri;
+    }
+
+    test("deleteFile records the tombstone BEFORE the file is deleted", async function () {
+        if (!workspaceFolder) return;
+        const codexUri = await writeCodexFile("RACE1");
+        const normalizedPath = codexUri.fsPath.replace(/\\/g, "/");
+
+        const realDelete = vscode.workspace.fs.delete.bind(vscode.workspace.fs);
+        let tombstonePresentAtCodexDelete: boolean | undefined;
+        let deleteStub: sinon.SinonStub;
+        try {
+            deleteStub = sinon
+                .stub(vscode.workspace.fs, "delete")
+                .callsFake(async (uri: vscode.Uri, options?: any) => {
+                    if (uri.fsPath.replace(/\\/g, "/").endsWith("files/target/RACE1.codex")) {
+                        tombstonePresentAtCodexDelete = (await readMetadataText()).includes(
+                            "files/target/RACE1.codex"
+                        );
+                    }
+                    return realDelete(uri, options);
+                });
+        } catch {
+            // vscode.workspace.fs not stubbable in this host — cannot observe ordering
+            this.skip();
+            return;
+        }
+
+        const showInformationMessageStub = sinon.stub(vscode.window, "showInformationMessage");
+        const showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
+        const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+        const buildInitialDataStub = sinon.stub(provider as any, "buildInitialData").resolves();
+
+        try {
+            await (provider as any).handleMessage({
+                command: "deleteFile",
+                uri: normalizedPath,
+                label: "RACE1",
+                type: "codexDocument",
+            });
+
+            assert.strictEqual(
+                tombstonePresentAtCodexDelete,
+                true,
+                "the tombstone must already be in metadata.json when the file deletion starts"
+            );
+            let stillExists = true;
+            try {
+                await vscode.workspace.fs.stat(codexUri);
+            } catch {
+                stillExists = false;
+            }
+            assert.strictEqual(stillExists, false, "the codex file is deleted");
+            assert.ok(
+                (await readMetadataText()).includes("files/target/RACE1.codex"),
+                "the tombstone survives a successful deletion"
+            );
+        } finally {
+            deleteStub.restore();
+            showInformationMessageStub.restore();
+            showWarningMessageStub.restore();
+            showErrorMessageStub.restore();
+            buildInitialDataStub.restore();
+        }
+    });
+
+    test("deleteFile withdraws the tombstone when the deletion fails", async function () {
+        if (!workspaceFolder) return;
+        const codexUri = await writeCodexFile("RACE2");
+        const normalizedPath = codexUri.fsPath.replace(/\\/g, "/");
+
+        const realDelete = vscode.workspace.fs.delete.bind(vscode.workspace.fs);
+        let deleteStub: sinon.SinonStub;
+        try {
+            deleteStub = sinon
+                .stub(vscode.workspace.fs, "delete")
+                .callsFake(async (uri: vscode.Uri, options?: any) => {
+                    if (uri.fsPath.replace(/\\/g, "/").endsWith("files/target/RACE2.codex")) {
+                        throw new Error("simulated: file locked by another process");
+                    }
+                    return realDelete(uri, options);
+                });
+        } catch {
+            this.skip();
+            return;
+        }
+
+        const showInformationMessageStub = sinon.stub(vscode.window, "showInformationMessage");
+        const showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
+        const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+        const buildInitialDataStub = sinon.stub(provider as any, "buildInitialData").resolves();
+        const consoleErrorStub = sinon.stub(console, "error");
+
+        try {
+            await (provider as any).handleMessage({
+                command: "deleteFile",
+                uri: normalizedPath,
+                label: "RACE2",
+                type: "codexDocument",
+            });
+
+            assert.ok(
+                !(await readMetadataText()).includes("files/target/RACE2.codex"),
+                "a failed deletion must not leave its tombstone behind"
+            );
+        } finally {
+            deleteStub.restore();
+            showInformationMessageStub.restore();
+            showWarningMessageStub.restore();
+            showErrorMessageStub.restore();
+            buildInitialDataStub.restore();
+            consoleErrorStub.restore();
+            try {
+                await vscode.workspace.fs.delete(codexUri);
+            } catch {
+                // already gone
+            }
+        }
+    });
+
+    test("deleteCorpusMarker records all tombstones before the loop and narrows to actual deletions", async function () {
+        if (!workspaceFolder) return;
+        const corp1 = await writeCodexFile("CORP1");
+        const corp2 = await writeCodexFile("CORP2");
+
+        const realDelete = vscode.workspace.fs.delete.bind(vscode.workspace.fs);
+        let tombstonesPresentAtFirstDelete: { corp1: boolean; corp2: boolean } | undefined;
+        let deleteStub: sinon.SinonStub;
+        try {
+            deleteStub = sinon
+                .stub(vscode.workspace.fs, "delete")
+                .callsFake(async (uri: vscode.Uri, options?: any) => {
+                    const p = uri.fsPath.replace(/\\/g, "/");
+                    if (p.endsWith("files/target/CORP1.codex")) {
+                        const metaText = await readMetadataText();
+                        tombstonesPresentAtFirstDelete = {
+                            corp1: metaText.includes("files/target/CORP1.codex"),
+                            corp2: metaText.includes("files/target/CORP2.codex"),
+                        };
+                    }
+                    if (p.endsWith("files/target/CORP2.codex")) {
+                        throw new Error("simulated: file locked by another process");
+                    }
+                    return realDelete(uri, options);
+                });
+        } catch {
+            this.skip();
+            return;
+        }
+
+        const showInformationMessageStub = sinon.stub(vscode.window, "showInformationMessage");
+        const showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
+        const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+        const buildInitialDataStub = sinon.stub(provider as any, "buildInitialData").resolves();
+        const consoleErrorStub = sinon.stub(console, "error");
+
+        try {
+            await (provider as any).deleteCorpusMarker("EPCORP", "EP Corp", [
+                { uri: corp1.fsPath, label: "CORP1", type: "codexDocument" },
+                { uri: corp2.fsPath, label: "CORP2", type: "codexDocument" },
+            ]);
+
+            assert.deepStrictEqual(
+                tombstonesPresentAtFirstDelete,
+                { corp1: true, corp2: true },
+                "every intended file must be tombstoned before the first deletion starts"
+            );
+
+            const metadata = JSON.parse(await readMetadataText());
+            const corpusEdits = (metadata.edits || []).filter(
+                (e: any) =>
+                    Array.isArray(e?.editMap) &&
+                    e.editMap[0] === "deletedCorpusMarker" &&
+                    e?.value?.corpusMarker === "EPCORP"
+            );
+            assert.strictEqual(corpusEdits.length, 1, "one corpus tombstone edit remains");
+            const relPaths = corpusEdits[0].value.deletedFiles.map((f: any) => f.relPath);
+            assert.deepStrictEqual(
+                relPaths,
+                ["files/target/CORP1.codex"],
+                "the tombstone is narrowed to the files actually deleted"
+            );
+        } finally {
+            deleteStub.restore();
+            showInformationMessageStub.restore();
+            showWarningMessageStub.restore();
+            showErrorMessageStub.restore();
+            buildInitialDataStub.restore();
+            consoleErrorStub.restore();
+            try {
+                await vscode.workspace.fs.delete(corp2);
+            } catch {
+                // already gone
+            }
+        }
+    });
+});

--- a/src/test/suite/resolveMergeReimportAlignment.test.ts
+++ b/src/test/suite/resolveMergeReimportAlignment.test.ts
@@ -261,6 +261,69 @@ suite("resolveCodexCustomMerge — re-import content alignment (#1079)", () => {
         );
     });
 
+    test("promote-subdivision-then-sync: both milestones keep their own labels and subdivisions", async () => {
+        // Full #936 regression scenario: promoting a subdivision creates a new
+        // milestone carrying its own subdivision placements. After the merge,
+        // the original chapter milestone and the promoted milestone must both
+        // exist, each with its own label and metadata.data.subdivisions.
+        const chapterMilestone = (subdivisions: string[]) => ({
+            kind: 2,
+            languageId: "html",
+            value: "Matthew 2",
+            metadata: {
+                type: "milestone",
+                id: "ms-chapter-2",
+                data: { subdivisions, subdivisionNames: { [subdivisions[0]]: "First half" } },
+                edits: [],
+            },
+        });
+        const promotedMilestone = {
+            kind: 2,
+            languageId: "html",
+            value: "Part 2",
+            metadata: {
+                type: "milestone",
+                id: freshId(),
+                data: { subdivisions: ["cue-x"], subdivisionNames: { "cue-x": "Promoted section" } },
+                edits: [],
+            },
+        };
+        const ours = [
+            chapterMilestone(["cue-a", "cue-b"]),
+            cueCell({ id: "shared-cue", start: 10, end: 12, value: "<span>translated</span>", edits: [valueEdit("<span>translated</span>", 1000)] }),
+        ];
+        const theirs = [
+            chapterMilestone(["cue-a", "cue-b"]),
+            cueCell({ id: "shared-cue", start: 10, end: 12, value: "<span>translated</span>", edits: [valueEdit("<span>translated</span>", 1000)] }),
+            promotedMilestone,
+        ];
+
+        const merged = JSON.parse(await resolveCodexCustomMerge(notebook(ours), notebook(theirs)));
+        const milestones = merged.cells.filter((c: any) => c.metadata?.type === "milestone");
+        assert.strictEqual(milestones.length, 2, "both milestones exist post-merge");
+
+        const chapter = milestones.find((c: any) => c.metadata.id === "ms-chapter-2");
+        assert.strictEqual(chapter.value, "Matthew 2", "chapter milestone keeps its label");
+        assert.deepStrictEqual(
+            chapter.metadata.data.subdivisions,
+            ["cue-a", "cue-b"],
+            "chapter milestone keeps its own subdivisions"
+        );
+
+        const promoted = milestones.find((c: any) => c.value === "Part 2");
+        assert.ok(promoted, "promoted milestone survives with its label");
+        assert.deepStrictEqual(
+            promoted.metadata.data.subdivisions,
+            ["cue-x"],
+            "promoted milestone keeps its own subdivisions"
+        );
+        assert.deepStrictEqual(
+            promoted.metadata.data.subdivisionNames,
+            { "cue-x": "Promoted section" },
+            "promoted milestone keeps its own subdivision names"
+        );
+    });
+
     test("digitless milestone labels never align, even in a re-import-shaped merge", async () => {
         // Two users independently adding default-named milestones must not have
         // them merged into one; a digitless label carries no chapter identity.

--- a/src/test/suite/resolveMergeReimportAlignment.test.ts
+++ b/src/test/suite/resolveMergeReimportAlignment.test.ts
@@ -235,6 +235,43 @@ suite("resolveCodexCustomMerge — re-import content alignment (#1079)", () => {
         assert.strictEqual(milestones.length, 2, "a genuinely new chapter milestone is added");
     });
 
+    test("a user-created milestone in an incremental sync (shared ids) is inserted, never folded", async () => {
+        // Issue #936 interaction: a subdivision promoted to a milestone named
+        // "Part 2" arrives as a their-only cell whose label ends in "2". In a
+        // normal sync (both sides share cell ids) it must NOT be folded into
+        // the existing "Matthew 2" chapter milestone by the #1079 alignment.
+        const ours = [
+            milestoneCell("Matthew 2", "ms-chapter-2"),
+            cueCell({ id: "shared-cue", start: 10, end: 12, value: "<span>translated</span>", edits: [valueEdit("<span>translated</span>", 1000)] }),
+        ];
+        const theirs = [
+            milestoneCell("Matthew 2", "ms-chapter-2"), // same id — normal merge
+            cueCell({ id: "shared-cue", start: 10, end: 12, value: "<span>translated</span>", edits: [valueEdit("<span>translated</span>", 1000)] }),
+            milestoneCell("Part 2"), // promoted subdivision, fresh id
+        ];
+
+        const merged = JSON.parse(await resolveCodexCustomMerge(notebook(ours), notebook(theirs)));
+        const milestones = merged.cells.filter((c: any) => c.metadata?.type === "milestone");
+        assert.strictEqual(milestones.length, 2, "the promoted milestone is a distinct new cell");
+        const chapter = milestones.find((c: any) => c.metadata.id === "ms-chapter-2");
+        assert.strictEqual(chapter.value, "Matthew 2", "the chapter milestone keeps its label");
+        assert.ok(
+            milestones.some((c: any) => c.value === "Part 2"),
+            "the promoted milestone survives with its own label"
+        );
+    });
+
+    test("digitless milestone labels never align, even in a re-import-shaped merge", async () => {
+        // Two users independently adding default-named milestones must not have
+        // them merged into one; a digitless label carries no chapter identity.
+        const ours = [milestoneCell("New milestone", "our-nm")];
+        const theirs = [milestoneCell("New milestone")];
+
+        const merged = JSON.parse(await resolveCodexCustomMerge(notebook(ours), notebook(theirs)));
+        const milestones = merged.cells.filter((c: any) => c.metadata?.type === "milestone");
+        assert.strictEqual(milestones.length, 2, "same default label must not cross-match");
+    });
+
     test("a re-imported bare-'1' milestone aligns with the long-form '<docName> 1' milestone", async () => {
         // the importer names milestones "1"; the milestone migration names them
         // "<docName> <chapter>" — the same chapter must align across formats


### PR DESCRIPTION
## Summary
Closes #1137

Fixes four regression risks found while auditing the recent merges into main, verified against the introducing commits, PR descriptions, and real project data before implementation:

1. **USFM export emitted invalid markup for bolded paratext headings** (from the #1130 heading fix): content converted to a character marker (`<strong>` → `\bd …\bd*`) was mistaken for a paragraph-level marker and passed through raw — losing the `\p` prefix and bypassing the new `\s1` option. 313 of 314 live heading cells in the Burmese Bible project hit this.
2. **The #1116 deletion guard could re-propagate deletions for re-created files**: basename tombstone matching applied to every tombstone and never expired, so a book deleted and later re-imported under the same filename could be re-deleted team-wide by a stale worktree. The delete flows also recorded tombstones *after* deleting, leaving a race window where an auto-sync resurrected just-deleted files.
3. **The #1079 milestone alignment folded user-created milestones into chapter milestones**: keying by the label's last number predates milestone editing (#936), so a promoted subdivision named "Part 2" was silently merged into "Matthew 2" on teammates' first sync.
4. **The #991 conflict-list invariant could fail sync permanently**: a persistent remote-changed/conflict-list mismatch threw on every attempt, leaving users unable to push or pull.

## Changes
- `formatParatextCell` passes through only content leading with a **paragraph-level** marker (`\s#`, `\p`, `\q#`, `\m`, `\mi`, `\li#`, `\pc`, `\pm`, `\d`, `\r`, `\sp`, `\b`); character-marker-leading content falls through to the existing precedence chain (metadata marker → `\s1` opt-in → `\p`), nesting the character markup under the paragraph marker. `isHeading` is computed from the extracted leading marker via `HEADING_MARKER_REGEX`, so `\sup`/`\sub` no longer misclassify as headings.
- The pre-sync deletion guard honors a tombstone only when it is **at least as recent as the missing file's latest content activity at HEAD** — the same rule the delete-vs-modify resolver already applies — so a re-imported incarnation (newer edit timestamps) can never be covered by a stale tombstone.
- Bare-basename tombstone matching is restricted to **legacy tombstones without `relPath`**; modern tombstones match by exact/suffix path only, with the `.source` ↔ `.codex` pairing preserved path-aware via the pair's fixed location.
- The nav-panel delete flows record tombstones **before** deleting (for every intended file up front on corpus deletes), withdraw the tombstone when a single-file deletion fails, and narrow the corpus tombstone to the files actually deleted.
- Milestone alignment in the merge resolver runs **only in wholesale-re-import-shaped merges** (zero cell-id overlap, the #1079 signature); in a normal incremental sync a their-only milestone inserts as a genuinely new milestone. Digitless labels never align. Timed-cue alignment is unchanged.
- The #991 invariant normalizes both path lists (separators, leading `./`, Unicode NFC) before comparing; early attempts keep the throw-and-retry behavior; on the **final attempt** the missing paths get `ConflictFile` entries synthesized from local git state (theirs from the fetched remote ref, ours from the working tree falling back to HEAD, base from HEAD) and flow through the normal resolvers — upholding the invariant's guarantee instead of abandoning the sync. Paths whose remote content can't be read still fail loudly, the fallback never invents deletions, and each self-heal emits a log entry. The decision logic lives in a new testable `enforceConflictListInvariant` helper (`conflictSynthesis.ts`).

## Test Checklist
Full extension suite: **1518 passing, 0 failing** (compile + lint clean).

### USFM heading export
- [x] Bold-formatted paratext (`<span><strong>…</strong></span>`) exports as `\p \bd …\bd*` with the option off and `\s1 \bd …\bd*` (plus `\p` restart) with the option on — never a bare `\bd` line
- [x] Content already leading with a paragraph-level marker (`\s`, `\q1`, `\sp`, …) still passes through unchanged
- [x] `\sup`-leading content is not classified as a heading (no spurious `\p` restart)
- [x] All 7 pre-existing heading-placement tests pass unchanged

### Deletion guard
- [x] `findTombstoneTimestamp`: a modern (relPath) tombstone does not match a different path sharing its basename; a legacy tombstone without relPath still matches by basename; existing relPath/suffix/paired-`.source` tests stay green
- [x] `restoreContentFilesMissingWithoutTombstone`: a missing file with an old tombstone but newer HEAD edit timestamps is restored; a tombstone newer than HEAD activity keeps the file deleted
- [x] Integration: delete → re-import same filename → simulated stale-worktree sync → the file survives (pre-sync guard leg) and a machine that already committed the deletion restores it via the delete-vs-modify resolver (propagation leg)
- [x] Race: a sync landing mid-corpus-delete preserves the deletion (tombstone-first state)
- [x] Provider ordering: the tombstone is already in `metadata.json` when the file deletion starts; it is withdrawn when the deletion fails; corpus deletes tombstone every intended child before the loop and narrow to actual successes
- [x] Intentional deletions still propagate — the full pre-existing #1116 guard suite passes

### Milestone merge
- [x] Milestone alignment is skipped when the two sides share cell ids (incremental sync) and applied when id overlap is zero (re-import)
- [x] A promoted "Part 2" milestone is inserted as a distinct cell, never folded into "Matthew 2"
- [x] Two default-labeled ("New milestone") cells never cross-match
- [x] Promote-subdivision-then-sync: both milestones exist post-merge with their own labels, `subdivisions`, and `subdivisionNames`
- [x] All 7 pre-existing #1079 alignment tests pass unchanged (including bare-"1" ↔ "<docName> 1" dedup)

### Conflict-list invariant
- [x] No mismatch → no synthesized entries; formatting-only differences (backslashes, `./`, Unicode NFD/NFC) are not violations
- [x] Attempts 0–1 throw `TransientSyncError` naming the missing paths (retry-with-refetch preserved)
- [x] Final attempt self-heals: synthesized `ConflictFile` carries correct ours/theirs/base, resolves through the real `resolveConflictFiles`, and the merged file lands on disk (what the sync commit stages); a log entry is emitted
- [x] Paths whose remote content cannot be read still fail loudly; the fallback never invents deletions
- [x] Live verification against a real Frontier server that `completeMerge` accepts the synthesized resolved files (not coverable by local tests)

### Regression sweep
- [x] Existing suites pass unchanged: `usfmParatextHeadings.test.ts`, `fileDeletionGuard.test.ts`, `resolveMergeReimportAlignment.test.ts`, `resolveMergeSubdivisions.test.ts`, `reimportMerge.test.ts` / `mergeReimportedNotebookPair`