### PR TITLE
Wider edit history box

### DIFF
--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -1758,7 +1758,8 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                         zIndex: 1000,
                         maxHeight: "80vh",
                         overflowY: "auto",
-                        minWidth: "300px",
+                        width: "min(700px, calc(100vw - 40px))",
+                        boxSizing: "border-box",
                     }}
                 >
                     <div

--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -1776,7 +1776,7 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
                         zIndex: 1000,
                         maxHeight: "80vh",
                         overflowY: "auto",
-                        width: "min(700px, calc(100vw - 40px))",
+                        width: "calc(100vw - 40px)",
                         boxSizing: "border-box",
                     }}
                 >

--- a/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/Editor.tsx
@@ -490,6 +490,24 @@ const Editor = forwardRef<EditorHandles, EditorProps>((props, ref) => {
     }, [isEditingFootnoteInline]);
 
     useEffect(() => {
+        if (!showHistoryModal) return;
+
+        const handleHistoryModalKeyDown = (event: KeyboardEvent): void => {
+            if (event.key !== "Escape") return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            setShowHistoryModal(false);
+        };
+
+        document.addEventListener("keydown", handleHistoryModalKeyDown, true);
+
+        return () => {
+            document.removeEventListener("keydown", handleHistoryModalKeyDown, true);
+        };
+    }, [showHistoryModal]);
+
+    useEffect(() => {
         pasteAsPlainTextRef.current = props.pasteAsPlainText ?? false;
     }, [props.pasteAsPlainText]);
 


### PR DESCRIPTION
## Wider edit history box

## Summary
Closes #[insert issue number here]

Widen the edit history modal so it uses the available tab width while preserving a small gap around the modal.

## Changes
- Updated the edit history modal to expand to the available viewport width.
- Preserved a 20px gap on each side.
- Ensured consistent modal sizing with `box-sizing: border-box`.
- Escape closes only the edit history modal without closing the cell editor.

## Test Checklist
- [x] Confirmed the edit history modal expands to the available width.
- [x] Confirmed a small gap remains around the modal.
- [x] Confirmed Escape closes only the edit history modal.
- [x] Confirmed the cell editor remains open after pressing Escape.
- [x] Confirmed there are no linter errors.