### PR TITLE
Export file name fixes

### DIFF
--- a/src/exportHandler/audioExporter.ts
+++ b/src/exportHandler/audioExporter.ts
@@ -15,6 +15,12 @@ import { formatCellDisplayLabel } from "./cellLabelUtils";
 import { parseVerseRef } from "../utils/verseRefUtils";
 import { CodexCellTypes } from "../../types/enums";
 import { buildMilestoneIndexModel } from "../../sharedUtils/milestoneIndexUtils";
+import {
+    sanitizeFileComponent,
+    toExportFileBaseName,
+} from "./exportFileNameUtils";
+
+export { sanitizeFileComponent, getTargetLanguageCode } from "./exportFileNameUtils";
 
 const execAsync = promisify(exec);
 
@@ -56,13 +62,6 @@ type AudioCellData = {
     audioStartTime?: number;
     audioEndTime?: number;
 };
-
-export function sanitizeFileComponent(input: string): string {
-    return input
-        .replace(/\s+/g, "_")
-        .replace(/[^a-zA-Z0-9._-]/g, "-")
-        .replace(/_+/g, "_");
-}
 
 function sanitizeFolderName(input: string): string {
     return input
@@ -161,13 +160,6 @@ export function formatChapterVerseSuffix(chapter?: number, verse?: number, verse
 // `formatCellDisplayLabel` and `extractCellTextSnippet` were extracted to
 // `./cellLabelUtils.ts` so the export wizard's pre-flight scan can reuse the
 // same identifiers — see that file for the rules and rationale.
-
-export function getTargetLanguageCode(): string {
-    const projectConfig = vscode.workspace.getConfiguration("codex-project-manager");
-    const lang = projectConfig.get<any>("targetLanguage") || {};
-    const code: string = lang.tag || lang.refName || "lang";
-    return sanitizeFileComponent(String(code).toLowerCase());
-}
 
 /**
  * Builds a mapping from cell ID to its milestone folder name.
@@ -936,6 +928,7 @@ export async function exportAudioAttachments(
         });
 
         const bookCode = basename(file.fsPath).split(".")[0] || "BOOK";
+        const exportBookCode = toExportFileBaseName(bookCode);
         // Targeted retry: when set, only the listed cells in this file are
         // processed (and merged into the existing export folder).
         const retryFilter = options?.retryCellFilter?.get(file.fsPath);
@@ -968,7 +961,7 @@ export async function exportAudioAttachments(
         const cellMilestoneFolder = buildCellMilestoneMap(notebook.cells);
         const milestoneModel = buildMilestoneIndexModel(notebook.cells);
 
-        const bookFolder = vscode.Uri.joinPath(exportDir, sanitizeFileComponent(bookCode));
+        const bookFolder = vscode.Uri.joinPath(exportDir, sanitizeFileComponent(exportBookCode));
 
         // Count audio cells for per-book progress. Paratext and
         // milestone cells (e.g. chapter headers, intros) are not
@@ -1162,7 +1155,7 @@ export async function exportAudioAttachments(
                 ? vscode.Uri.joinPath(bookFolder, sanitizeFolderName(milestoneFolderName))
                 : bookFolder;
 
-            const baseSegments = [sanitizeFileComponent(bookCode)];
+            const baseSegments = [sanitizeFileComponent(exportBookCode)];
             if (cvSuffix) {
                 baseSegments.push(cvSuffix);
             } else {

--- a/src/exportHandler/characterAudioExporter.ts
+++ b/src/exportHandler/characterAudioExporter.ts
@@ -10,7 +10,6 @@ import { getFFmpegPath } from "../utils/ffmpegManager";
 import { EditMapUtils } from "../utils/editMapUtils";
 import {
     sanitizeFileComponent,
-    getTargetLanguageCode,
     pickAudioAttachmentForCell,
     readNotebook,
     getAudioExporterContext,
@@ -22,6 +21,7 @@ import {
     type FrontierLfsApi,
 } from "./audioExporter";
 import { isExportableCell } from "./audioAttachmentUtils";
+import { toExportFileBaseName } from "./exportFileNameUtils";
 import { buildMilestoneIndexModel } from "../../sharedUtils/milestoneIndexUtils";
 import type { ExportProgressReporter } from "./exportProgress";
 import { createNoopReporter } from "./exportProgress";
@@ -507,11 +507,10 @@ export async function exportAudioByCharacter(
 
             if (token?.isCancellationRequested) break;
 
-            const bookFolder = vscode.Uri.joinPath(exportDir, sanitizeFileComponent(fileBase));
+            const exportFileBase = toExportFileBaseName(fileBase);
+            const safeFileBase = sanitizeFileComponent(exportFileBase);
+            const bookFolder = vscode.Uri.joinPath(exportDir, safeFileBase);
             await vscode.workspace.fs.createDirectory(bookFolder);
-
-            const langCode = getTargetLanguageCode();
-            const safeFileBase = sanitizeFileComponent(fileBase);
 
             const groupEntries = [...groups.entries()];
             for (let gi = 0; gi < groupEntries.length; gi++) {
@@ -543,7 +542,7 @@ export async function exportAudioByCharacter(
                 // don't bloat the file. Files still start at 0 so they DAW-align.
                 const trimSec = computeTrimDurationSec(verified, episodeDurationSec);
 
-                const destName = `${safeFileBase}_${langCode}_${charKey}${ext}`;
+                const destName = `${safeFileBase}_${charKey}${ext}`;
                 const destUri = vscode.Uri.joinPath(bookFolder, destName);
 
                 reporter.report({

--- a/src/exportHandler/exportFileNameUtils.ts
+++ b/src/exportHandler/exportFileNameUtils.ts
@@ -1,0 +1,236 @@
+import * as vscode from "vscode";
+import { basename, extname } from "path";
+
+/**
+ * ISO 639-3 tags → ISO 639-1, for languages that have a 2-letter code.
+ * Used to recognize source-file suffixes like `_en` when the project stores `eng`.
+ */
+const TAG_TO_ISO1: Record<string, string> = {
+    eng: "en",
+    spa: "es",
+    fra: "fr",
+    fre: "fr",
+    deu: "de",
+    ger: "de",
+    por: "pt",
+    ita: "it",
+    nld: "nl",
+    dut: "nl",
+    rus: "ru",
+    zho: "zh",
+    chi: "zh",
+    arb: "ar",
+    ara: "ar",
+    hin: "hi",
+    swa: "sw",
+    ind: "id",
+    tgl: "tl",
+    kor: "ko",
+    jpn: "ja",
+    vie: "vi",
+    tha: "th",
+    tur: "tr",
+    pol: "pl",
+    ukr: "uk",
+    ces: "cs",
+    cze: "cs",
+    ron: "ro",
+    rum: "ro",
+    hun: "hu",
+    swe: "sv",
+    dan: "da",
+    nor: "no",
+    nob: "nb",
+    nno: "nn",
+    fin: "fi",
+    ell: "el",
+    gre: "el",
+    heb: "he",
+    urd: "ur",
+    ben: "bn",
+    tam: "ta",
+    tel: "te",
+    mar: "mr",
+    mal: "ml",
+    kan: "kn",
+    pan: "pa",
+    guj: "gu",
+    amh: "am",
+    yor: "yo",
+    ibo: "ig",
+    hau: "ha",
+    zul: "zu",
+    afr: "af",
+    cat: "ca",
+    eus: "eu",
+    glg: "gl",
+    slk: "sk",
+    slo: "sk",
+    slv: "sl",
+    hrv: "hr",
+    srp: "sr",
+    bul: "bg",
+    lit: "lt",
+    lav: "lv",
+    est: "et",
+    isl: "is",
+    gle: "ga",
+    cym: "cy",
+    msa: "ms",
+    may: "ms",
+    fil: "tl",
+    lat: "la",
+};
+
+const ISO1_TO_TAG: Record<string, string> = Object.fromEntries(
+    Object.entries(TAG_TO_ISO1).map(([tag, iso1]) => [iso1, tag])
+);
+
+const WELL_KNOWN_LANG_TOKENS = new Set([
+    ...Object.keys(TAG_TO_ISO1),
+    ...Object.values(TAG_TO_ISO1),
+]);
+
+export type ProjectLanguageLike = {
+    tag?: string;
+    iso1?: string;
+    iso2t?: string;
+    iso2b?: string;
+    refName?: string;
+};
+
+export function sanitizeFileComponent(input: string): string {
+    return input
+        .replace(/\s+/g, "_")
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/_+/g, "_");
+}
+
+function addCodeAndParts(codes: Set<string>, raw?: string): void {
+    if (!raw) return;
+    const sanitized = sanitizeFileComponent(String(raw).toLowerCase());
+    if (!sanitized || sanitized === "custom" || sanitized === "lang") return;
+    codes.add(sanitized);
+    const primary = sanitized.split("-")[0];
+    if (primary && primary !== sanitized) {
+        codes.add(primary);
+    }
+}
+
+/** Filename-friendly language code: ISO 639-3 tag (e.g. `luo`), falling back to iso1 / name. */
+export function languageFileCode(lang: ProjectLanguageLike | undefined): string {
+    const raw = lang?.tag || lang?.iso1 || lang?.iso2t || lang?.refName || "lang";
+    return sanitizeFileComponent(String(raw).toLowerCase()) || "lang";
+}
+
+/** All codes that might appear as a `_lang` token for this language (`eng` and `en`, etc.). */
+export function languageCodeAliases(lang: ProjectLanguageLike | undefined): string[] {
+    const codes = new Set<string>();
+    addCodeAndParts(codes, lang?.tag);
+    addCodeAndParts(codes, lang?.iso1);
+    addCodeAndParts(codes, lang?.iso2t);
+    addCodeAndParts(codes, lang?.iso2b);
+
+    for (const code of [...codes]) {
+        const iso1 = TAG_TO_ISO1[code];
+        if (iso1) codes.add(iso1);
+        const tag = ISO1_TO_TAG[code];
+        if (tag) codes.add(tag);
+    }
+
+    return [...codes];
+}
+
+export function getProjectExportLanguageCodes(): {
+    targetCode: string;
+    sourceAliases: string[];
+} {
+    const projectConfig = vscode.workspace.getConfiguration("codex-project-manager");
+    const target = projectConfig.get<ProjectLanguageLike>("targetLanguage") || {};
+    const source = projectConfig.get<ProjectLanguageLike>("sourceLanguage") || {};
+    return {
+        targetCode: languageFileCode(target),
+        sourceAliases: languageCodeAliases(source),
+    };
+}
+
+export function getTargetLanguageCode(): string {
+    return getProjectExportLanguageCodes().targetCode;
+}
+
+/**
+ * Rewrites an export basename to use the project's target language instead of
+ * the source language (typically `_en` from English source files). Does not
+ * append a timestamp.
+ *
+ * `Some_project_120_en` + target `luo` → `Some_project_120_luo`
+ */
+export function rewriteExportBaseName(
+    baseName: string,
+    targetCode: string,
+    sourceAliases: string[] = []
+): string {
+    const sanitizedTarget = sanitizeFileComponent(targetCode.toLowerCase()) || "lang";
+    const aliasSet = new Set(
+        sourceAliases
+            .map((alias) => sanitizeFileComponent(alias.toLowerCase()))
+            .filter((alias) => alias && alias !== sanitizedTarget)
+    );
+
+    const sanitizedBase = sanitizeFileComponent(baseName);
+    const tokens = sanitizedBase.split("_").filter((token) => token.length > 0);
+    if (tokens.length === 0) {
+        return sanitizedTarget;
+    }
+
+    const isReplaceableLangToken = (token: string): boolean => {
+        const lower = token.toLowerCase();
+        if (lower === sanitizedTarget) return false;
+        if (aliasSet.has(lower)) return true;
+        // Fallback: original assets are often named `*_en` even when source
+        // language metadata is missing. Never replace a lone token (e.g. `MAT`).
+        return tokens.length > 1 && WELL_KNOWN_LANG_TOKENS.has(lower);
+    };
+
+    for (let i = tokens.length - 1; i >= 0; i--) {
+        if (isReplaceableLangToken(tokens[i]!)) {
+            tokens[i] = sanitizedTarget;
+            return tokens.join("_");
+        }
+    }
+
+    if (tokens[tokens.length - 1]?.toLowerCase() !== sanitizedTarget) {
+        tokens.push(sanitizedTarget);
+    }
+    return tokens.join("_");
+}
+
+export function toExportFileBaseName(
+    originalName: string,
+    targetCode?: string,
+    sourceAliases?: string[]
+): string {
+    const codes =
+        targetCode !== undefined
+            ? { targetCode, sourceAliases: sourceAliases ?? [] }
+            : getProjectExportLanguageCodes();
+    const fileName = basename(originalName);
+    const originalExt = extname(fileName);
+    const base = originalExt ? fileName.slice(0, -originalExt.length) : fileName;
+    return rewriteExportBaseName(base, codes.targetCode, codes.sourceAliases);
+}
+
+/**
+ * Builds an export filename from an original/notebook name: swap the source
+ * language token for the project target language, keep the project/asset
+ * prefix, and do not add a timestamp.
+ */
+export function toExportFileName(
+    originalName: string,
+    outputExtension: string,
+    targetCode?: string,
+    sourceAliases?: string[]
+): string {
+    const ext = outputExtension.startsWith(".") ? outputExtension : `.${outputExtension}`;
+    return `${toExportFileBaseName(originalName, targetCode, sourceAliases)}${ext}`;
+}

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -26,6 +26,7 @@ const execAsync = promisify(exec);
 
 import { CodexNotebookAsJSONData } from "../../types";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { toExportFileName, toExportFileBaseName } from "./exportFileNameUtils";
 import { resolveOriginalFileUri, findOriginalFileByPossibleNames } from "../providers/NewSourceUploader/originalFileUtils";
 import { isLfsPointerContent, resolveLfsPointerFile } from "../utils/lfsHelpers";
 import { exportCodexContentAsPlaintext } from "./plaintextExporter";
@@ -384,9 +385,7 @@ async function exportCodexContentAsIdmlRoundtrip(
                 updatedIdmlData = await exportIdmlRoundtrip(idmlData, codexNotebook.cells);
             }
 
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const suffix = isBiblicaFile ? '_biblica_translated' : '_translated';
-            const injectedName = originalFileName.replace(/\.idml$/i, `_${timestamp}${suffix}.idml`);
+            const injectedName = toExportFileName(originalFileName, ".idml");
             const injectedUri = vscode.Uri.joinPath(exportFolder, injectedName);
             await vscode.workspace.fs.writeFile(injectedUri, updatedIdmlData);
 
@@ -491,8 +490,7 @@ async function exportCodexContentAsDocxRoundtrip(
             );
 
             // Save translated DOCX into the chosen export folder
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const exportedName = originalFileName.replace(/\.docx$/i, `_${timestamp}_translated.docx`);
+            const exportedName = toExportFileName(originalFileName, ".docx");
             const exportedUri = vscode.Uri.joinPath(exportFolder, exportedName);
             await vscode.workspace.fs.writeFile(exportedUri, new Uint8Array(updatedDocxData));
 
@@ -670,8 +668,7 @@ async function exportCodexContentAsPdfRoundtrip(
             const pdfData = await convertDocxToPdfViaExtension(translatedDocxUri.fsPath);
 
             // Step 4: Save translated PDF to user's selected destination
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const translatedPdfName = originalFileName.replace(/\.pdf$/i, `_${timestamp}_translated.pdf`);
+            const translatedPdfName = toExportFileName(originalFileName, ".pdf");
             const translatedPdfUri = vscode.Uri.joinPath(exportFolder, translatedPdfName);
 
             await vscode.workspace.fs.writeFile(translatedPdfUri, new Uint8Array(pdfData));
@@ -910,11 +907,8 @@ async function exportCodexContentAsObsRoundtrip(
             const originalFileName = (codexNotebook.metadata as any)?.originalFileName ||
                 (codexNotebook.metadata as any)?.originalName ||
                 `${fileName.split('.')[0]}.md`;
-            const baseFileName = originalFileName.replace(/\.md$/i, '');
 
-            // Create timestamped filename
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-").split('T')[0]; // YYYY-MM-DD format
-            const exportedName = `${baseFileName}_${timestamp}_translated.md`;
+            const exportedName = toExportFileName(originalFileName, ".md");
             const exportedUri = vscode.Uri.joinPath(exportFolder, exportedName);
 
             // Write markdown content
@@ -996,9 +990,7 @@ async function exportCodexContentAsMarkdownRoundtrip(
 
             const updated = exportMarkdownWithTranslations(canonicalSource, codexNotebook.cells as never);
 
-            const baseFileName = originalFileName.replace(/\.(md|markdown)$/i, "");
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-").split("T")[0];
-            const exportedName = `${baseFileName}_${timestamp}_translated.md`;
+            const exportedName = toExportFileName(originalFileName, ".md");
             const exportedUri = vscode.Uri.joinPath(exportFolder, exportedName);
             await vscode.workspace.fs.writeFile(exportedUri, new TextEncoder().encode(updated));
 
@@ -1198,8 +1190,8 @@ async function exportCodexContentAsUsfmRoundtrip(
             }
 
             // Save to export folder
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const exportedName = originalFileName.replace(/\.(usfm|sfm|USFM|SFM)$/i, `_${timestamp}_translated.$1`);
+            const usfmExt = originalFileName.match(/\.(usfm|sfm)$/i)?.[0] ?? ".usfm";
+            const exportedName = toExportFileName(originalFileName, usfmExt);
             const exportedUri = vscode.Uri.joinPath(exportFolder, exportedName);
 
             const encoder = new TextEncoder();
@@ -1338,11 +1330,10 @@ async function exportCodexContentAsSpreadsheetRoundtrip(
             );
 
             // Generate output filename
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const baseName = originalFileName
-                ? originalFileName.replace(/\.(csv|tsv)$/i, '')
-                : fileName.replace(/\.codex$/i, '');
-            const outputFileName = `${baseName}_translated_${timestamp}.${extension}`;
+            const outputFileName = toExportFileName(
+                originalFileName || fileName,
+                `.${extension}`
+            );
             const outputUri = vscode.Uri.joinPath(exportFolder, outputFileName);
 
             // Write the file
@@ -1469,12 +1460,7 @@ async function exportCodexContentAsTmsRoundtrip(
 
             console.log(`[TMS Export] Generated ${determinedFileType.toUpperCase()} with translations, length:`, updatedTmsContent.length);
 
-            // Determine output filename
-            const baseFileName = finalOriginalFileName.replace(/\.(tmx|xliff|xlf)$/i, '');
-
-            // Create timestamped filename
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-").split('T')[0]; // YYYY-MM-DD format
-            const exportedName = `${baseFileName}_${timestamp}_translated${fileExtension}`;
+            const exportedName = toExportFileName(finalOriginalFileName, fileExtension);
             const exportedUri = vscode.Uri.joinPath(exportFolder, exportedName);
 
             // Write TMS content
@@ -1975,9 +1961,8 @@ export const exportCodexContentAsSubtitlesSrt = async (
 
             const srtContent = generateSrtData(cells, false);
 
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
             const fileName = basename(file.fsPath).replace(".codex", "") || "unknown";
-            const exportFileName = `${fileName}_${timestamp}.srt`;
+            const exportFileName = toExportFileName(fileName, ".srt");
             const exportFile = vscode.Uri.joinPath(exportFolder, exportFileName);
 
             await vscode.workspace.fs.writeFile(exportFile, Buffer.from(srtContent));
@@ -2054,9 +2039,8 @@ export const exportCodexContentAsSubtitlesVtt = async (
                     );
                     debug({ vttContent, cells, includeStyles });
 
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
             const fileName = basename(file.fsPath).replace(".codex", "") || "unknown";
-            const exportFileName = `${fileName}_${timestamp}.vtt`;
+            const exportFileName = toExportFileName(fileName, ".vtt");
             const exportFile = vscode.Uri.joinPath(exportFolder, exportFileName);
 
             await vscode.workspace.fs.writeFile(exportFile, Buffer.from(vttContent));
@@ -2387,8 +2371,7 @@ async function exportCodexContentAsDelimited(
                 }
 
                 // Write file
-                const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-                const exportFileName = `${currentBookCode}_${timestamp}.${fileExtension}`;
+                const exportFileName = toExportFileName(currentBookCode, `.${fileExtension}`);
                 const exportFile = vscode.Uri.joinPath(exportFolder, exportFileName);
                 await vscode.workspace.fs.writeFile(exportFile, Buffer.from(content));
 
@@ -2458,7 +2441,6 @@ async function exportCodexContentAsBacktranslations(
         const exportFolder = vscode.Uri.file(userSelectedPath);
         await vscode.workspace.fs.createDirectory(exportFolder);
 
-        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
         const fileGroups = new Map<string, Array<{ cellId: string; bt: any; }>>();
         let skipped = 0;
 
@@ -2525,7 +2507,10 @@ async function exportCodexContentAsBacktranslations(
                 }
 
                 const fileName = basename(targetPath, ".codex");
-                const exportFile = vscode.Uri.joinPath(exportFolder, `${fileName}_backtranslations_${timestamp}.csv`);
+                const exportFile = vscode.Uri.joinPath(
+                    exportFolder,
+                    `${toExportFileBaseName(fileName)}_backtranslations.csv`
+                );
                 await vscode.workspace.fs.writeFile(exportFile, Buffer.from(content));
                 filesWritten++;
             } catch (error) {

--- a/src/exportHandler/htmlExporter.ts
+++ b/src/exportHandler/htmlExporter.ts
@@ -4,6 +4,7 @@ import { CodexCellTypes } from "../../types/enums";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType, getVerseMarkerForCell } from "./exportHandlerUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
+import { toExportFileBaseName } from "./exportFileNameUtils";
 
 /** Verse ref regex: "1TH 1:1", "GEN 1:1", etc. */
 const VERSE_REF_REGEX = /\b[A-Z0-9]{2,4}\s+\d+:\d+\b/;
@@ -185,7 +186,9 @@ export async function exportCodexContentAsHtml(
             debug(`Processing file: ${file.fsPath}`);
 
                     const bookCode =
-                        basename(file.fsPath).split(".")[0] || "export";
+                        toExportFileBaseName(
+                            basename(file.fsPath).split(".")[0] || "export"
+                        );
 
                     // Create a subfolder per book for cleaner output
                     const exportFolder = vscode.Uri.joinPath(

--- a/src/exportHandler/plaintextExporter.ts
+++ b/src/exportHandler/plaintextExporter.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { basename } from "path";
 import { extractVerseRefFromLine } from "../utils/verseRefUtils";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { toExportFileName } from "./exportFileNameUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -123,12 +124,9 @@ export async function exportCodexContentAsPlaintext(
                 exportContent += chapterContent + "\n\n";
             }
 
-            const timestamp = new Date()
-                .toISOString()
-                .replace(/[:.]/g, "-");
             const fileName =
                 basename(file.fsPath).replace(".codex", "") || "unknown";
-            const exportFileName = `${fileName}_${timestamp}.txt`;
+            const exportFileName = toExportFileName(fileName, ".txt");
             const exportFile = vscode.Uri.joinPath(
                 exportFolder,
                 exportFileName

--- a/src/exportHandler/usfmExporter.ts
+++ b/src/exportHandler/usfmExporter.ts
@@ -4,6 +4,7 @@ import * as grammar from "usfm-grammar";
 import { CodexCellTypes } from "../../types/enums";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
 import { buildUsfmBody } from "./usfmBodyBuilder";
+import { toExportFileName } from "./exportFileNameUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -294,10 +295,7 @@ export async function exportCodexContentAsUsfm(
                     }
                 }
 
-                const timestamp = new Date()
-                    .toISOString()
-                    .replace(/[:.]/g, "-");
-                const exportFileName = `${bookCode}_${timestamp}.usfm`;
+                const exportFileName = toExportFileName(bookCode, ".usfm");
                 const exportFile = vscode.Uri.joinPath(
                     exportFolder,
                     exportFileName

--- a/src/exportHandler/xliffExporter.ts
+++ b/src/exportHandler/xliffExporter.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { basename } from "path";
 import { CodexNotebookAsJSONData } from "../../types";
 import { readCodexNotebookFromUri, getActiveCells, isContentCellType } from "./exportHandlerUtils";
+import { toExportFileName } from "./exportFileNameUtils";
 import type { ExportOptions } from "./exportHandler";
 import type { ExportProgressReporter } from "./exportProgress";
 
@@ -187,10 +188,7 @@ export async function exportCodexContentAsXliff(
     </file>
 </xliff>`;
 
-            const timestamp = new Date()
-                .toISOString()
-                .replace(/[:.]/g, "-");
-            const exportFileName = `${fileBaseName}_${timestamp}.xliff`;
+            const exportFileName = toExportFileName(fileBaseName, ".xliff");
             const exportFile = vscode.Uri.joinPath(
                 exportFolder,
                 exportFileName

--- a/src/test/suite/exportFileNameUtils.test.ts
+++ b/src/test/suite/exportFileNameUtils.test.ts
@@ -1,0 +1,71 @@
+import * as assert from "assert";
+import {
+    languageCodeAliases,
+    languageFileCode,
+    rewriteExportBaseName,
+    toExportFileBaseName,
+    toExportFileName,
+} from "../../exportHandler/exportFileNameUtils";
+
+suite("Export filename language rewrite", () => {
+    test("replaces source _en with the project language and drops any timestamp", () => {
+        const base = rewriteExportBaseName(
+            "Some_project_120_en",
+            "luo",
+            ["eng", "en"]
+        );
+        assert.strictEqual(base, "Some_project_120_luo");
+        assert.ok(!base.includes("2026"), "must not include a timestamp");
+        assert.strictEqual(
+            toExportFileName("Some_project_120_en.srt", ".srt", "luo", ["en"]),
+            "Some_project_120_luo.srt"
+        );
+    });
+
+    test("replaces _en even when source-language aliases are not provided", () => {
+        assert.strictEqual(
+            rewriteExportBaseName("Some_project_120_en", "luo", []),
+            "Some_project_120_luo"
+        );
+    });
+
+    test("keeps a trailing suffix after the language token", () => {
+        assert.strictEqual(
+            rewriteExportBaseName("TheChosen_306_en_SingleSpeaker", "luo", ["en"]),
+            "TheChosen_306_luo_SingleSpeaker"
+        );
+    });
+
+    test("appends the target language when the source name has no language token", () => {
+        assert.strictEqual(rewriteExportBaseName("GEN", "luo", ["en"]), "GEN_luo");
+        assert.strictEqual(
+            rewriteExportBaseName("Some_project_120", "luo", ["en"]),
+            "Some_project_120_luo"
+        );
+    });
+
+    test("does not double-append when the name already ends with the target language", () => {
+        assert.strictEqual(
+            rewriteExportBaseName("Some_project_120_luo", "luo", ["en"]),
+            "Some_project_120_luo"
+        );
+    });
+
+    test("maps English tag eng to the _en token used in source filenames", () => {
+        const aliases = languageCodeAliases({ tag: "eng" });
+        assert.ok(aliases.includes("eng"));
+        assert.ok(aliases.includes("en"));
+        assert.strictEqual(languageFileCode({ tag: "luo" }), "luo");
+    });
+
+    test("toExportFileBaseName strips the original extension before rewriting", () => {
+        assert.strictEqual(
+            toExportFileBaseName("Some_project_120_en.idml", "luo", ["en"]),
+            "Some_project_120_luo"
+        );
+        assert.strictEqual(
+            toExportFileName("Some_project_120_en.codex", ".vtt", "luo", ["eng"]),
+            "Some_project_120_luo.vtt"
+        );
+    });
+});


### PR DESCRIPTION
The timestamp that was clustering the name of the file was removed completely.

The language code that was previously hardcoded to english is now taking the actual target language code, e.g. "slk" for "Slovak" etc.

## PR Title
Format:
1070-export-file-names

## Summary
Closes #1070

Describe the change.

## Changes
The file names after exporting dont include the obscure timestamp anymore. They now include only the language code, that is taken from actual target language.

## Test Checklist
- [x] Export files across different languages/projects
- [x] All of them should not include timestamp, and only the correct language code
