### PR TITLE
Tools alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "activationEvents": [
         "onCustomEditor:newSourceUploaderProvider-scheme",
         "onCustomEditor:startupFlowProvider-scheme",
-        "*"
+        "onStartupFinished"
     ],
     "main": "./out/extension.js",
     "permissions": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "activationEvents": [
         "onCustomEditor:newSourceUploaderProvider-scheme",
         "onCustomEditor:startupFlowProvider-scheme",
-        "onStartupFinished"
+        "*"
     ],
     "main": "./out/extension.js",
     "permissions": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,7 +235,7 @@ let authApi: FrontierAPI | undefined;
 let savedTabLayout: any[] = [];
 const TAB_LAYOUT_KEY = "codexEditor.tabLayout";
 const FALLBACK_NOTICE_STATE_KEY = "codex.fallbackToolsNotice";
-const FALLBACK_NOTICE_DISMISSALS = 5;
+const FALLBACK_NOTICE_DISMISSALS = 10;
 
 interface FallbackNoticeState {
     fallbackSignature: string;
@@ -1646,18 +1646,18 @@ async function executeCommandsAfter(
                 ? vscode.window.showWarningMessage(
                     fallbackToolsNotice,
                     "Use Optimized Tools",
-                    "Don't show for 5 restarts",
+                    "Don't show for 10 restarts",
                     "Dismiss",
                 )
                 : vscode.window.showWarningMessage(
                     fallbackToolsNotice,
-                    "Don't show for 5 restarts",
+                    "Don't show for 10 restarts",
                     "Dismiss",
                 );
             void Promise.resolve(warningMessage).then(async (choice) => {
                 if (choice === "Use Optimized Tools") {
                     await applyOptimizedTools(context, optimizedToolKeys);
-                } else if (choice === "Don't show for 5 restarts") {
+                } else if (choice === "Don't show for 10 restarts") {
                     await snoozeFallbackNotice(context, fallbackToolsNotice);
                 }
             }).catch((error: unknown) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,6 +471,62 @@ async function restoreTabLayout(context: vscode.ExtensionContext) {
     await context.globalState.update(TAB_LAYOUT_KEY, undefined);
 }
 
+/**
+ * Begin preparing the optimized local tools as soon as the extension activates.
+ * This runs before project metadata, indexing, or synchronization is
+ * initialized. The individual tool setups are independent and can proceed in
+ * parallel, while each tool still falls back safely if its optimized asset
+ * cannot be used.
+ */
+async function prepareToolsBeforeWorkspace(context: vscode.ExtensionContext): Promise<void> {
+    const networkAvailable = await isOnline();
+    if (!networkAvailable) {
+        console.log("[Extension] Offline — will skip tool downloads and use cached binaries if available");
+    }
+
+    const prepareSqlite = async (): Promise<void> => {
+        const sqliteMode = getSqliteToolMode();
+        let nativeLoaded = false;
+        try {
+            const binaryPath = await ensureSqliteNativeBinary(context);
+            if (binaryPath) {
+                initNativeSqlite(binaryPath);
+                console.log("[SQLite] Native module initialized successfully");
+                nativeLoaded = true;
+            }
+        } catch (nativeError: unknown) {
+            const message = nativeError instanceof Error ? nativeError.message : String(nativeError);
+            console.warn("[SQLite] Failed to set up native binary:", message);
+        }
+
+        if (sqliteMode === "builtin" || !nativeLoaded) {
+            try {
+                await initFts5Sqlite(context);
+                const reason = sqliteMode === "builtin" ? "user preference" : "native unavailable";
+                console.log(`[SQLite] fts5-sql-bundle (WASM) initialized (${reason})`);
+            } catch (fallbackError: unknown) {
+                const message = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+                console.error("[SQLite] Failed to initialize fts5 fallback:", message);
+            }
+        }
+    };
+
+    const prepareAudio = async (): Promise<void> => {
+        try {
+            updateSplashScreenSync(0, "Setting up audio tools...");
+            await downloadFFmpeg(context);
+        } catch (error: unknown) {
+            if (!networkAvailable) {
+                console.log("[Extension] Offline — audio tools not cached locally, audio features unavailable until online");
+            } else {
+                console.error("[Extension] Error downloading audio tools:", error);
+            }
+        }
+    };
+
+    await Promise.all([prepareSqlite(), prepareAudio()]);
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     const activationStart = globalThis.performance.now();
 
@@ -590,6 +646,10 @@ export async function activate(context: vscode.ExtensionContext) {
         console.error("Error showing splash screen:", error);
         // Continue with activation even if splash screen fails
     }
+
+    // Start optimized tool preparation immediately. It runs while the
+    // remaining activation work loads metadata and registers startup flow.
+    const toolsPreparedBeforeWorkspace = prepareToolsBeforeWorkspace(context);
 
     // Check for metadata.json early — this determines if we're in a Codex project
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -736,61 +796,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
         stepStart = trackTiming("Configuring Startup Workflow", startupStart);
 
-        // Check connectivity once so we can skip network-dependent downloads when offline.
-        const networkAvailable = await isOnline();
-        if (!networkAvailable) {
-            console.log("[Extension] Offline — will skip tool downloads and use cached binaries if available");
-        }
-
-        // Set up the SQLite backend.
-        // Always try to load the native binary (so it's available if the user
-        // toggles back to "auto").  Then, if the preference is "builtin" OR if
-        // native failed, also initialize fts5-sql-bundle so the active backend
-        // is ready to go.
-        const sqliteBinaryStart = globalThis.performance.now();
-        const sqliteMode = getSqliteToolMode();
-        let nativeLoaded = false;
-        try {
-            const binaryPath = await ensureSqliteNativeBinary(context);
-            if (binaryPath) {
-                initNativeSqlite(binaryPath);
-                console.log("[SQLite] Native module initialized successfully");
-                nativeLoaded = true;
-            }
-        } catch (nativeError: any) {
-            console.warn("[SQLite] Failed to set up native binary:", nativeError?.message || nativeError);
-        }
-
-        if (sqliteMode === "builtin" || !nativeLoaded) {
-            try {
-                await initFts5Sqlite(context);
-                const reason = sqliteMode === "builtin" ? "user preference" : "native unavailable";
-                console.log(`[SQLite] fts5-sql-bundle (WASM) initialized (${reason})`);
-            } catch (fallbackError: any) {
-                if (!nativeLoaded) {
-                    console.error("[SQLite] Both native and fts5 fallback failed:", fallbackError?.message || fallbackError);
-                } else {
-                    console.warn("[SQLite] fts5-sql-bundle init failed (native available as fallback):", fallbackError?.message || fallbackError);
-                }
-            }
-        }
-        stepStart = trackTiming("Setting up search tools", sqliteBinaryStart);
-
-        // Download FFmpeg if not already present.
-        // downloadFFmpeg checks local cache first, only
-        // hitting the network if the binary isn't present on disk.
-        const audioToolsStart = globalThis.performance.now();
-        try {
-            updateSplashScreenSync(0, "Setting up audio tools...");
-            await downloadFFmpeg(context);
-        } catch (error) {
-            if (!networkAvailable) {
-                console.log("[Extension] Offline — audio tools not cached locally, audio features unavailable until online");
-            } else {
-                console.error("[Extension] Error downloading audio tools:", error);
-            }
-        }
-        stepStart = trackTiming("Setting up audio tools", audioToolsStart);
+        // Do not initialize the workspace until optimized tool preparation
+        // has completed, so project sync and indexing use the selected backend.
+        const toolsStart = globalThis.performance.now();
+        await toolsPreparedBeforeWorkspace;
+        stepStart = trackTiming("Preparing optimized tools", toolsStart);
 
         // Run a fresh tool availability check after all download attempts
         const toolCheckStart = globalThis.performance.now();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,7 @@ import {
     getAudioToolMode,
 } from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
+import { updateNativeToolStatus } from "./utils/nativeToolStatus";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
 import { cleanupOrphanedProjectFiles } from "./utils/fileUtils";
 // markUserAsUpdatedInRemoteList is now called in performProjectUpdate before window reload
@@ -813,6 +814,18 @@ export async function activate(context: vscode.ExtensionContext) {
             unavailableTools = getUnavailableTools(toolCheckResult);
         }
         stepStart = trackTiming("Checking tool availability", toolCheckStart);
+
+        if (metadataExists && workspaceFolders?.[0]) {
+            try {
+                await updateNativeToolStatus(
+                    workspaceFolders[0].uri,
+                    toolCheckResult,
+                    authApi,
+                );
+            } catch (error) {
+                console.warn("[Extension] Could not update native tool status in metadata:", error);
+            }
+        }
 
         const toolState = (nativeAvailable: boolean, mode: string): string => {
             const forced = mode === "force-builtin";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,13 @@ import { initializeAudioProcessor } from "./utils/audioProcessor";
 import { initializeAudioMerger } from "./utils/audioMerger";
 import { initializeAudioExtractor } from "./utils/audioExtractor";
 import { initializeAudioExporter } from "./exportHandler/audioExporter";
-import { checkTools, getFallbackToolsNotice, getUnavailableTools } from "./utils/toolsManager";
+import {
+    checkTools,
+    getFallbackToolsNotice,
+    getToolsEligibleForOptimization,
+    getUnavailableTools,
+    type OptimizedToolKey,
+} from "./utils/toolsManager";
 import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode, getAudioToolMode } from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
@@ -296,6 +302,45 @@ async function snoozeFallbackNotice(
     console.info(
         `[FallbackToolsNotice] Snoozed for ${FALLBACK_NOTICE_DISMISSALS} restarts; stored ${FALLBACK_NOTICE_STATE_KEY} ` +
         `(global storage: ${context.globalStorageUri.fsPath}): ${JSON.stringify(state)}`,
+    );
+}
+
+async function applyOptimizedTools(
+    context: vscode.ExtensionContext,
+    tools: OptimizedToolKey[],
+): Promise<void> {
+    if (tools.length === 0) {
+        return;
+    }
+
+    const { enableOptimizedTools } = await import("./utils/optimizedToolsManager");
+    const result = await enableOptimizedTools(context, getAuthApi(), tools);
+    const getToolLabel = (tool: OptimizedToolKey): string => ({
+        sqlite: "Search",
+        git: "Sync",
+        ffmpeg: "Audio",
+    }[tool]);
+    const enabled = result.enabled.map(getToolLabel).join(", ");
+    const failed = result.failed
+        .map(({ tool, reason }) => `${getToolLabel(tool)} (${reason})`)
+        .join(", ");
+
+    if (result.failed.length === 0 && result.enabled.length > 0) {
+        vscode.window.showInformationMessage(
+            `Optimized tools enabled for ${enabled}.`,
+        );
+        return;
+    }
+
+    if (result.enabled.length > 0) {
+        vscode.window.showWarningMessage(
+            `Optimized tools enabled for ${enabled}; could not enable ${failed}.`,
+        );
+        return;
+    }
+
+    vscode.window.showErrorMessage(
+        `Could not enable optimized tools: ${failed}.`,
     );
 }
 
@@ -755,6 +800,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 nativeSqliteAvailable: false,
                 ffmpeg: false,
                 platformUnsupported: { git: false, sqlite: false, ffmpeg: false },
+                nativePlatformSupported: { git: false, sqlite: false, ffmpeg: false },
             };
             unavailableTools = getUnavailableTools(toolCheckResult);
         }
@@ -1154,8 +1200,10 @@ export async function activate(context: vscode.ExtensionContext) {
             toolCheckResult,
             projectLoadedSuccessfully,
         );
+        const optimizedToolKeys = getToolsEligibleForOptimization(toolCheckResult)
+            .filter((tool) => tool !== "git" || !!getAuthApi()?.retryGitBinaryDownload);
         const postActivationStart = globalThis.performance.now();
-        await executeCommandsAfter(context, fallbackToolsNotice);
+        await executeCommandsAfter(context, fallbackToolsNotice, optimizedToolKeys);
         trackTiming("Running Post-activation Tasks", postActivationStart);
 
         // Register update commands and check for updates (non-blocking)
@@ -1551,6 +1599,7 @@ async function executeCommandsBefore(context: vscode.ExtensionContext) {
 async function executeCommandsAfter(
     context: vscode.ExtensionContext,
     fallbackToolsNotice: string | null,
+    optimizedToolKeys: OptimizedToolKey[],
 ) {
     try {
         // Update splash screen for post-activation tasks
@@ -1588,16 +1637,26 @@ async function executeCommandsAfter(
 
         if (fallbackToolsNotice) {
             console.info("[Extension] Showing fallback tools startup notice:", fallbackToolsNotice);
-            void Promise.resolve(vscode.window.showWarningMessage(
-                fallbackToolsNotice,
-                "Don't show for 5 restarts",
-                "Dismiss",
-            )).then(async (choice) => {
-                if (choice === "Don't show for 5 restarts") {
+            const warningMessage = optimizedToolKeys.length > 0
+                ? vscode.window.showWarningMessage(
+                    fallbackToolsNotice,
+                    "Use Optimized Tools",
+                    "Don't show for 5 restarts",
+                    "Dismiss",
+                )
+                : vscode.window.showWarningMessage(
+                    fallbackToolsNotice,
+                    "Don't show for 5 restarts",
+                    "Dismiss",
+                );
+            void Promise.resolve(warningMessage).then(async (choice) => {
+                if (choice === "Use Optimized Tools") {
+                    await applyOptimizedTools(context, optimizedToolKeys);
+                } else if (choice === "Don't show for 5 restarts") {
                     await snoozeFallbackNotice(context, fallbackToolsNotice);
                 }
             }).catch((error: unknown) => {
-                console.warn("[FallbackToolsNotice] Could not save dismissal state:", error);
+                console.warn("[FallbackToolsNotice] Could not process notification action:", error);
             });
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ import { initializeAudioProcessor } from "./utils/audioProcessor";
 import { initializeAudioMerger } from "./utils/audioMerger";
 import { initializeAudioExtractor } from "./utils/audioExtractor";
 import { initializeAudioExporter } from "./exportHandler/audioExporter";
-import { checkTools, getUnavailableTools } from "./utils/toolsManager";
+import { checkTools, getFallbackToolsNotice, getUnavailableTools } from "./utils/toolsManager";
 import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode, getAudioToolMode } from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
@@ -968,7 +968,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // Execute post-activation tasks
         const postActivationStart = globalThis.performance.now();
 
-        await executeCommandsAfter(context);
+        await executeCommandsAfter(context, getFallbackToolsNotice(toolCheckResult));
 
         // Only run migrations in actual Codex projects — they write completion flags
         // to .vscode/settings.json even when no project files exist
@@ -1468,7 +1468,8 @@ async function executeCommandsBefore(context: vscode.ExtensionContext) {
 }
 
 async function executeCommandsAfter(
-    context: vscode.ExtensionContext
+    context: vscode.ExtensionContext,
+    fallbackToolsNotice: string | null,
 ) {
     try {
         // Update splash screen for post-activation tasks
@@ -1503,6 +1504,19 @@ async function executeCommandsAfter(
             .update("workbench.editor.showTabs", "multiple", true);
         // Restore tab layout after splash screen closes
         await restoreTabLayout(context);
+
+        if (fallbackToolsNotice) {
+            console.info("[Extension] Showing fallback tools startup notice:", fallbackToolsNotice);
+            void vscode.window.showWarningMessage(
+                fallbackToolsNotice,
+                "View Tools Status",
+            ).then((choice) => {
+                if (choice === "View Tools Status") {
+                    return vscode.commands.executeCommand("codex-editor.openToolsStatus");
+                }
+                return undefined;
+            });
+        }
 
         // Check if we need to show the welcome view after initialization
         await showWelcomeViewIfNeeded();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,6 +221,83 @@ let notebookMetadataManager: NotebookMetadataManager;
 let authApi: FrontierAPI | undefined;
 let savedTabLayout: any[] = [];
 const TAB_LAYOUT_KEY = "codexEditor.tabLayout";
+const FALLBACK_NOTICE_STATE_KEY = "codex.fallbackToolsNotice";
+const FALLBACK_NOTICE_DISMISSALS = 5;
+
+interface FallbackNoticeState {
+    fallbackSignature: string;
+    dismissalsRemaining: number;
+}
+
+async function prepareFallbackToolsNotice(
+    context: vscode.ExtensionContext,
+    toolCheckResult: Awaited<ReturnType<typeof checkTools>>,
+    projectLoadedSuccessfully: boolean,
+): Promise<string | null> {
+    if (!projectLoadedSuccessfully) {
+        return null;
+    }
+
+    const notice = getFallbackToolsNotice(toolCheckResult);
+    const storageLocation = context.globalStorageUri.fsPath;
+    const previousState = context.globalState.get<FallbackNoticeState>(FALLBACK_NOTICE_STATE_KEY);
+
+    if (!notice) {
+        await context.globalState.update(FALLBACK_NOTICE_STATE_KEY, undefined);
+        console.info(
+            `[FallbackToolsNotice] Cleared ${FALLBACK_NOTICE_STATE_KEY} in globalState ` +
+            `(global storage: ${storageLocation})`,
+        );
+        return null;
+    }
+
+    if (previousState?.fallbackSignature !== notice) {
+        const resetState: FallbackNoticeState = {
+            fallbackSignature: notice,
+            dismissalsRemaining: 0,
+        };
+        await context.globalState.update(FALLBACK_NOTICE_STATE_KEY, resetState);
+        console.info(
+            `[FallbackToolsNotice] Stored ${FALLBACK_NOTICE_STATE_KEY} in globalState ` +
+            `(global storage: ${storageLocation}): ${JSON.stringify(resetState)}`,
+        );
+        return notice;
+    }
+
+    if (previousState.dismissalsRemaining > 0) {
+        const nextState: FallbackNoticeState = {
+            ...previousState,
+            dismissalsRemaining: previousState.dismissalsRemaining - 1,
+        };
+        await context.globalState.update(FALLBACK_NOTICE_STATE_KEY, nextState);
+        console.info(
+            `[FallbackToolsNotice] Suppressed notice; stored ${FALLBACK_NOTICE_STATE_KEY} ` +
+            `(global storage: ${storageLocation}): ${JSON.stringify(nextState)}`,
+        );
+        return null;
+    }
+
+    console.info(
+        `[FallbackToolsNotice] Showing notice; stored ${FALLBACK_NOTICE_STATE_KEY} ` +
+        `(global storage: ${storageLocation}): ${JSON.stringify(previousState)}`,
+    );
+    return notice;
+}
+
+async function snoozeFallbackNotice(
+    context: vscode.ExtensionContext,
+    notice: string,
+): Promise<void> {
+    const state: FallbackNoticeState = {
+        fallbackSignature: notice,
+        dismissalsRemaining: FALLBACK_NOTICE_DISMISSALS,
+    };
+    await context.globalState.update(FALLBACK_NOTICE_STATE_KEY, state);
+    console.info(
+        `[FallbackToolsNotice] Snoozed for ${FALLBACK_NOTICE_DISMISSALS} restarts; stored ${FALLBACK_NOTICE_STATE_KEY} ` +
+        `(global storage: ${context.globalStorageUri.fsPath}): ${JSON.stringify(state)}`,
+    );
+}
 
 // Helper to save tab layout and persist to globalState
 async function saveTabLayout(context: vscode.ExtensionContext) {
@@ -965,11 +1042,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         console.info(summaryMessage);
 
-        // Execute post-activation tasks
-        const postActivationStart = globalThis.performance.now();
-
-        await executeCommandsAfter(context, getFallbackToolsNotice(toolCheckResult));
-
         // Only run migrations in actual Codex projects — they write completion flags
         // to .vscode/settings.json even when no project files exist
         if (metadataExists) {
@@ -1009,6 +1081,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // After migrations complete, trigger sync directly
         // (All migrations have finished executing since they're awaited sequentially)
+        let projectLoadedSuccessfully = false;
         try {
             const hasCodexProject = await checkIfProjectIsInitialized();
             if (hasCodexProject) {
@@ -1070,11 +1143,19 @@ export async function activate(context: vscode.ExtensionContext) {
                         }
                     }
                 }
+                projectLoadedSuccessfully = true;
             }
         } catch (error) {
             console.error("❌ [POST-MIGRATIONS] Error triggering sync after migrations:", error);
         }
 
+        const fallbackToolsNotice = await prepareFallbackToolsNotice(
+            context,
+            toolCheckResult,
+            projectLoadedSuccessfully,
+        );
+        const postActivationStart = globalThis.performance.now();
+        await executeCommandsAfter(context, fallbackToolsNotice);
         trackTiming("Running Post-activation Tasks", postActivationStart);
 
         // Register update commands and check for updates (non-blocking)
@@ -1507,14 +1588,16 @@ async function executeCommandsAfter(
 
         if (fallbackToolsNotice) {
             console.info("[Extension] Showing fallback tools startup notice:", fallbackToolsNotice);
-            void vscode.window.showWarningMessage(
+            void Promise.resolve(vscode.window.showWarningMessage(
                 fallbackToolsNotice,
-                "View Tools Status",
-            ).then((choice) => {
-                if (choice === "View Tools Status") {
-                    return vscode.commands.executeCommand("codex-editor.openToolsStatus");
+                "Don't show for 5 restarts",
+                "Dismiss",
+            )).then(async (choice) => {
+                if (choice === "Don't show for 5 restarts") {
+                    await snoozeFallbackNotice(context, fallbackToolsNotice);
                 }
-                return undefined;
+            }).catch((error: unknown) => {
+                console.warn("[FallbackToolsNotice] Could not save dismissal state:", error);
             });
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,62 +471,6 @@ async function restoreTabLayout(context: vscode.ExtensionContext) {
     await context.globalState.update(TAB_LAYOUT_KEY, undefined);
 }
 
-/**
- * Begin preparing the optimized local tools as soon as the extension activates.
- * This runs before project metadata, indexing, or synchronization is
- * initialized. The individual tool setups are independent and can proceed in
- * parallel, while each tool still falls back safely if its optimized asset
- * cannot be used.
- */
-async function prepareToolsBeforeWorkspace(context: vscode.ExtensionContext): Promise<void> {
-    const networkAvailable = await isOnline();
-    if (!networkAvailable) {
-        console.log("[Extension] Offline — will skip tool downloads and use cached binaries if available");
-    }
-
-    const prepareSqlite = async (): Promise<void> => {
-        const sqliteMode = getSqliteToolMode();
-        let nativeLoaded = false;
-        try {
-            const binaryPath = await ensureSqliteNativeBinary(context);
-            if (binaryPath) {
-                initNativeSqlite(binaryPath);
-                console.log("[SQLite] Native module initialized successfully");
-                nativeLoaded = true;
-            }
-        } catch (nativeError: unknown) {
-            const message = nativeError instanceof Error ? nativeError.message : String(nativeError);
-            console.warn("[SQLite] Failed to set up native binary:", message);
-        }
-
-        if (sqliteMode === "builtin" || !nativeLoaded) {
-            try {
-                await initFts5Sqlite(context);
-                const reason = sqliteMode === "builtin" ? "user preference" : "native unavailable";
-                console.log(`[SQLite] fts5-sql-bundle (WASM) initialized (${reason})`);
-            } catch (fallbackError: unknown) {
-                const message = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
-                console.error("[SQLite] Failed to initialize fts5 fallback:", message);
-            }
-        }
-    };
-
-    const prepareAudio = async (): Promise<void> => {
-        try {
-            updateSplashScreenSync(0, "Setting up audio tools...");
-            await downloadFFmpeg(context);
-        } catch (error: unknown) {
-            if (!networkAvailable) {
-                console.log("[Extension] Offline — audio tools not cached locally, audio features unavailable until online");
-            } else {
-                console.error("[Extension] Error downloading audio tools:", error);
-            }
-        }
-    };
-
-    await Promise.all([prepareSqlite(), prepareAudio()]);
-}
-
 export async function activate(context: vscode.ExtensionContext) {
     const activationStart = globalThis.performance.now();
 
@@ -646,10 +590,6 @@ export async function activate(context: vscode.ExtensionContext) {
         console.error("Error showing splash screen:", error);
         // Continue with activation even if splash screen fails
     }
-
-    // Start optimized tool preparation immediately. It runs while the
-    // remaining activation work loads metadata and registers startup flow.
-    const toolsPreparedBeforeWorkspace = prepareToolsBeforeWorkspace(context);
 
     // Check for metadata.json early — this determines if we're in a Codex project
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -796,11 +736,61 @@ export async function activate(context: vscode.ExtensionContext) {
 
         stepStart = trackTiming("Configuring Startup Workflow", startupStart);
 
-        // Do not initialize the workspace until optimized tool preparation
-        // has completed, so project sync and indexing use the selected backend.
-        const toolsStart = globalThis.performance.now();
-        await toolsPreparedBeforeWorkspace;
-        stepStart = trackTiming("Preparing optimized tools", toolsStart);
+        // Check connectivity once so we can skip network-dependent downloads when offline.
+        const networkAvailable = await isOnline();
+        if (!networkAvailable) {
+            console.log("[Extension] Offline — will skip tool downloads and use cached binaries if available");
+        }
+
+        // Set up the SQLite backend.
+        // Always try to load the native binary (so it's available if the user
+        // toggles back to "auto"). Then, if the preference is "builtin" OR if
+        // native failed, also initialize fts5-sql-bundle so the active backend
+        // is ready to go.
+        const sqliteBinaryStart = globalThis.performance.now();
+        const sqliteMode = getSqliteToolMode();
+        let nativeLoaded = false;
+        try {
+            const binaryPath = await ensureSqliteNativeBinary(context);
+            if (binaryPath) {
+                initNativeSqlite(binaryPath);
+                console.log("[SQLite] Native module initialized successfully");
+                nativeLoaded = true;
+            }
+        } catch (nativeError: any) {
+            console.warn("[SQLite] Failed to set up native binary:", nativeError?.message || nativeError);
+        }
+
+        if (sqliteMode === "builtin" || !nativeLoaded) {
+            try {
+                await initFts5Sqlite(context);
+                const reason = sqliteMode === "builtin" ? "user preference" : "native unavailable";
+                console.log(`[SQLite] fts5-sql-bundle (WASM) initialized (${reason})`);
+            } catch (fallbackError: any) {
+                if (!nativeLoaded) {
+                    console.error("[SQLite] Both native and fts5 fallback failed:", fallbackError?.message || fallbackError);
+                } else {
+                    console.warn("[SQLite] fts5-sql-bundle init failed (native available as fallback):", fallbackError?.message || fallbackError);
+                }
+            }
+        }
+        stepStart = trackTiming("Setting up search tools", sqliteBinaryStart);
+
+        // Download FFmpeg if not already present.
+        // downloadFFmpeg checks local cache first, only
+        // hitting the network if the binary isn't present on disk.
+        const audioToolsStart = globalThis.performance.now();
+        try {
+            updateSplashScreenSync(0, "Setting up audio tools...");
+            await downloadFFmpeg(context);
+        } catch (error) {
+            if (!networkAvailable) {
+                console.log("[Extension] Offline — audio tools not cached locally, audio features unavailable until online");
+            } else {
+                console.error("[Extension] Error downloading audio tools:", error);
+            }
+        }
+        stepStart = trackTiming("Setting up audio tools", audioToolsStart);
 
         // Run a fresh tool availability check after all download attempts
         const toolCheckStart = globalThis.performance.now();
@@ -1266,9 +1256,6 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand("codex-editor.advancedToolSettings", async () => {
             if (!toolsStatusProvider) {
-                vscode.window.showInformationMessage(
-                    "Open the Status panel first (Codex Editor: Status), then run this command."
-                );
                 return;
             }
             toolsStatusProvider.enableReinstallMode();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,14 @@ import {
     getUnavailableTools,
     type OptimizedToolKey,
 } from "./utils/toolsManager";
-import { initToolPreferences, setNativeGitAvailable, getGitToolMode, getSqliteToolMode, getAudioToolMode } from "./utils/toolPreferences";
+import {
+    initToolPreferences,
+    resetTemporaryBuiltinModesOnStartup,
+    setNativeGitAvailable,
+    getGitToolMode,
+    getSqliteToolMode,
+    getAudioToolMode,
+} from "./utils/toolPreferences";
 import { downloadFFmpeg } from "./utils/ffmpegManager";
 import { MissingToolsWarningProvider } from "./providers/MissingToolsWarning/MissingToolsWarningProvider";
 import { cleanupOrphanedProjectFiles } from "./utils/fileUtils";
@@ -477,6 +484,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     initToolPreferences(context);
+    await resetTemporaryBuiltinModesOnStartup();
 
     // Clear the stream-only video session cache (stored outside the project) so
     // "Loaded" videos re-stream after a reload, like the in-memory audio cache.

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -15,7 +15,7 @@ import { CodexCell } from "@/utils/codexNotebookUtils";
 import { CodexCellTypes, EditType } from "../../../../types/enums";
 import { EditHistory, ValidationEntry, FileEditHistory, ProjectEditHistory, ProjectUserVersionEntry } from "../../../../types/index.d";
 import { EditMapUtils, deduplicateFileMetadataEdits } from "../../../utils/editMapUtils";
-import { normalizeNativeToolStatusEntries } from "../../../utils/nativeToolStatus";
+import { mergeNativeToolStatusEntries } from "../../../utils/nativeToolStatus";
 import { normalizeAttachmentUrl } from "@/utils/pathUtils";
 import { formatJsonForNotebookFile } from "../../../utils/notebookFileFormattingUtils";
 import { ORPHANED_PROJECT_FILES } from "../../../utils/fileUtils";
@@ -1955,25 +1955,6 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
                         // Top-level field (e.g., ["projectName"], ["languages"])
                         const field = path[0];
                         metadata[field] = value;
-                    } else if (
-                        path.length === 3
-                        && path[0] === "meta"
-                        && path[1] === "nativeToolStatus"
-                    ) {
-                        const username = path[2];
-                        const currentEntries = normalizeNativeToolStatusEntries(
-                            metadata.meta?.nativeToolStatus,
-                        );
-                        if (value && typeof value === "object") {
-                            const nextEntries = normalizeNativeToolStatusEntries([
-                                ...currentEntries.filter((entry) => entry.username !== username),
-                                { ...(value as Record<string, unknown>), username },
-                            ]);
-                            metadata.meta = {
-                                ...(metadata.meta || {}),
-                                nativeToolStatus: nextEntries,
-                            };
-                        }
                     } else if (path.length === 2 && path[0] === "meta") {
                         // Meta field edit (e.g., ["meta", "validationCount"], ["meta", "generator"])
                         if (!metadata.meta) {
@@ -2026,6 +2007,17 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
             // Fallback to starting with ours if no edit history
             resolvedMetadata = JSON.parse(JSON.stringify(ours));
         }
+
+        // nativeToolStatus is a timestamped per-user snapshot, not an edit
+        // history field. Merge it independently so concurrent users are
+        // preserved and the newest snapshot wins for the same username.
+        resolvedMetadata.meta = {
+            ...(resolvedMetadata.meta || {}),
+            nativeToolStatus: mergeNativeToolStatusEntries(
+                ours.meta?.nativeToolStatus,
+                theirs.meta?.nativeToolStatus,
+            ),
+        };
 
         // 1. Resolve initiateRemoteUpdatingFor (Complex Merge Logic)
         // Helper to extract and normalize updating list

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -15,7 +15,10 @@ import { CodexCell } from "@/utils/codexNotebookUtils";
 import { CodexCellTypes, EditType } from "../../../../types/enums";
 import { EditHistory, ValidationEntry, FileEditHistory, ProjectEditHistory, ProjectUserVersionEntry } from "../../../../types/index.d";
 import { EditMapUtils, deduplicateFileMetadataEdits } from "../../../utils/editMapUtils";
-import { mergeNativeToolStatusEntries } from "../../../utils/nativeToolStatus";
+import {
+    mergeNativeToolStatusEntries,
+    mergeNativeToolStatusHistory,
+} from "../../../utils/nativeToolStatus";
 import { normalizeAttachmentUrl } from "@/utils/pathUtils";
 import { formatJsonForNotebookFile } from "../../../utils/notebookFileFormattingUtils";
 import { ORPHANED_PROJECT_FILES } from "../../../utils/fileUtils";
@@ -2016,6 +2019,10 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
             nativeToolStatus: mergeNativeToolStatusEntries(
                 ours.meta?.nativeToolStatus,
                 theirs.meta?.nativeToolStatus,
+            ),
+            nativeToolStatusHistory: mergeNativeToolStatusHistory(
+                ours.meta?.nativeToolStatusHistory,
+                theirs.meta?.nativeToolStatusHistory,
             ),
         };
 

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -15,6 +15,7 @@ import { CodexCell } from "@/utils/codexNotebookUtils";
 import { CodexCellTypes, EditType } from "../../../../types/enums";
 import { EditHistory, ValidationEntry, FileEditHistory, ProjectEditHistory, ProjectUserVersionEntry } from "../../../../types/index.d";
 import { EditMapUtils, deduplicateFileMetadataEdits } from "../../../utils/editMapUtils";
+import { normalizeNativeToolStatusEntries } from "../../../utils/nativeToolStatus";
 import { normalizeAttachmentUrl } from "@/utils/pathUtils";
 import { formatJsonForNotebookFile } from "../../../utils/notebookFileFormattingUtils";
 import { ORPHANED_PROJECT_FILES } from "../../../utils/fileUtils";
@@ -1954,6 +1955,25 @@ async function resolveMetadataJsonConflict(conflict: ConflictFile): Promise<stri
                         // Top-level field (e.g., ["projectName"], ["languages"])
                         const field = path[0];
                         metadata[field] = value;
+                    } else if (
+                        path.length === 3
+                        && path[0] === "meta"
+                        && path[1] === "nativeToolStatus"
+                    ) {
+                        const username = path[2];
+                        const currentEntries = normalizeNativeToolStatusEntries(
+                            metadata.meta?.nativeToolStatus,
+                        );
+                        if (value && typeof value === "object") {
+                            const nextEntries = normalizeNativeToolStatusEntries([
+                                ...currentEntries.filter((entry) => entry.username !== username),
+                                { ...(value as Record<string, unknown>), username },
+                            ]);
+                            metadata.meta = {
+                                ...(metadata.meta || {}),
+                                nativeToolStatus: nextEntries,
+                            };
+                        }
                     } else if (path.length === 2 && path[0] === "meta") {
                         // Meta field edit (e.g., ["meta", "validationCount"], ["meta", "generator"])
                         if (!metadata.meta) {

--- a/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
+++ b/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
@@ -273,6 +273,11 @@ export class MissingToolsWarningProvider {
         const { setAudioToolMode } = await import("../../utils/toolPreferences");
         const current = getAudioToolMode();
         const next = current === "auto" ? "builtin" : "auto";
+        if (next === "auto" && current !== "auto") {
+            await setAudioToolMode(next);
+            await this._handleDownloadTool("ffmpeg");
+            return;
+        }
         await setAudioToolMode(next);
 
         const { checkTools } = await import("../../utils/toolsManager");
@@ -291,6 +296,11 @@ export class MissingToolsWarningProvider {
         const { setGitToolMode } = await import("../../utils/toolPreferences");
         const current = getGitToolMode();
         const next = current === "auto" ? "builtin" : "auto";
+        if (next === "auto" && current !== "auto") {
+            await setGitToolMode(next);
+            await this._handleDownloadTool("git");
+            return;
+        }
         await setGitToolMode(next);
 
         const { checkTools } = await import("../../utils/toolsManager");
@@ -323,6 +333,12 @@ export class MissingToolsWarningProvider {
         const { setSqliteToolMode } = await import("../../utils/toolPreferences");
         const current = getSqliteToolMode();
         const next = current === "auto" ? "builtin" : "auto";
+
+        if (next === "auto" && current !== "auto") {
+            await setSqliteToolMode(next);
+            await this._handleDownloadTool("sqlite");
+            return;
+        }
 
         // If switching to the WASM fallback, ensure it's initialized
         if (next === "builtin") {

--- a/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
+++ b/src/providers/MissingToolsWarning/MissingToolsWarningProvider.ts
@@ -504,6 +504,7 @@ export class MissingToolsWarningProvider {
             gitToolMode: getGitToolMode(),
             sqliteToolMode: getSqliteToolMode(),
             platformUnsupported: updated.platformUnsupported,
+            nativePlatformSupported: updated.nativePlatformSupported,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
     }
@@ -651,6 +652,7 @@ export class MissingToolsWarningProvider {
             nativeSqliteAvailable: result.nativeSqliteAvailable,
             ffmpeg: result.ffmpeg,
             platformUnsupported: result.platformUnsupported,
+            nativePlatformSupported: result.nativePlatformSupported,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
     }
@@ -668,6 +670,7 @@ export class MissingToolsWarningProvider {
             gitToolMode: getGitToolMode(),
             sqliteToolMode: getSqliteToolMode(),
             platformUnsupported: result.platformUnsupported,
+            nativePlatformSupported: result.nativePlatformSupported,
             ...flags,
         };
         safePostMessageToPanel(this._panel, message, "MissingToolsWarning");
@@ -693,6 +696,7 @@ export class MissingToolsWarningProvider {
             nativeSqliteAvailable: result.nativeSqliteAvailable,
             ffmpeg: result.ffmpeg,
             platformUnsupported: result.platformUnsupported,
+            nativePlatformSupported: result.nativePlatformSupported,
             mode,
         };
 

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -30,7 +30,6 @@ import { performProjectSwap } from "./performProjectSwap";
 import { getCodexProjectsDirectory } from "../../utils/projectLocationUtils";
 import archiver from "archiver";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
-import { openFolderWithToolModeHandoff } from "../../utils/toolPreferences";
 
 import { safePostMessageToPanel, safeIsVisible, safeSetHtml, safeSetOptions } from "../../utils/webviewUtils";
 import * as path from "path";
@@ -1184,7 +1183,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     title: "Select Project Folder",
                 });
                 if (result && result[0]) {
-                    await openFolderWithToolModeHandoff(result[0]);
+                    await vscode.commands.executeCommand("vscode.openFolder", result[0]);
                 }
                 break;
             }
@@ -1206,7 +1205,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     if (folderName) {
                         const projectPath = vscode.Uri.joinPath(result[0], folderName);
                         await vscode.workspace.fs.createDirectory(projectPath);
-                        await openFolderWithToolModeHandoff(projectPath);
+                        await vscode.commands.executeCommand("vscode.openFolder", projectPath);
                     }
                 }
                 break;
@@ -1481,211 +1480,211 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                             debugLog("Skipping update check (offline open requested)");
                         }
                         if (!skipUpdateCheck) {
-                        debugLog("Checking remote update requirement for project:", projectPath);
-                        const { checkRemoteProjectRequirements } = await import("../../utils/remoteUpdatingManager");
-                        // Pass true for bypassCache to ensure we verify connectivity before deciding to update
-                        const remoteResult = await checkRemoteProjectRequirements(projectPath, undefined, true);
-                        remoteProjectRequirements = remoteResult;
-                        // Capture the remote metadata for version checks (available since remote was fetched)
-                        fetchedRemoteMetadata = (remoteResult as { remoteMetadata?: typeof fetchedRemoteMetadata; }).remoteMetadata;
+                            debugLog("Checking remote update requirement for project:", projectPath);
+                            const { checkRemoteProjectRequirements } = await import("../../utils/remoteUpdatingManager");
+                            // Pass true for bypassCache to ensure we verify connectivity before deciding to update
+                            const remoteResult = await checkRemoteProjectRequirements(projectPath, undefined, true);
+                            remoteProjectRequirements = remoteResult;
+                            // Capture the remote metadata for version checks (available since remote was fetched)
+                            fetchedRemoteMetadata = (remoteResult as { remoteMetadata?: typeof fetchedRemoteMetadata; }).remoteMetadata;
 
-                        if (remoteProjectRequirements.updateRequired) {
-                            debugLog("Remote update required for user:", remoteProjectRequirements.currentUsername);
-                            try {
-                                await markPendingUpdateRequired(vscode.Uri.file(projectPath), "Remote requirement");
-                            } catch (e) {
-                                debugLog("Failed to persist pending update flag", e);
-                            }
-                            shouldUpdate = true;
-                            updatingReason = "Remote requirement";
-                        } else {
-                            debugLog("No remote update required:", remoteProjectRequirements?.updateReason);
-                            const projectUri = vscode.Uri.file(projectPath);
-
-                            // 1. Check for an in-progress update (backup/clone state)
-                            const hasLocalPending = await this.hasPendingLocalUpdate(projectPath);
-                            if (hasLocalPending) {
-                                debugLog("Local update state present; continuing update even though remote no longer requires it");
+                            if (remoteProjectRequirements.updateRequired) {
+                                debugLog("Remote update required for user:", remoteProjectRequirements.currentUsername);
                                 try {
-                                    await markPendingUpdateRequired(projectUri, "Local pending update");
+                                    await markPendingUpdateRequired(vscode.Uri.file(projectPath), "Remote requirement");
                                 } catch (e) {
-                                    debugLog("Failed to persist pending update flag for local pending state", e);
+                                    debugLog("Failed to persist pending update flag", e);
                                 }
                                 shouldUpdate = true;
-                                updatingReason = "Local pending update";
-                            }
+                                updatingReason = "Remote requirement";
+                            } else {
+                                debugLog("No remote update required:", remoteProjectRequirements?.updateReason);
+                                const projectUri = vscode.Uri.file(projectPath);
 
-                            // 2. Check pendingUpdate sticky flag – does NOT need a username
-                            if (!shouldUpdate) {
-                                try {
-                                    const localSettings = await readLocalProjectSettings(projectUri);
-                                    if (localSettings.pendingUpdate?.required) {
-                                        debugLog("pendingUpdate sticky flag set in localProjectSettings, triggering update");
-                                        shouldUpdate = true;
-                                        updatingReason = "Pending update (local flag)";
-                                    }
-                                } catch (e) {
-                                    debugLog("Error reading localProjectSettings for pendingUpdate check", e);
-                                }
-                            }
-
-                            // 3. Check local metadata.json entries (requires username)
-                            if (!shouldUpdate) {
-                                let currentUsername = remoteProjectRequirements?.currentUsername;
-                                if (!currentUsername) {
+                                // 1. Check for an in-progress update (backup/clone state)
+                                const hasLocalPending = await this.hasPendingLocalUpdate(projectPath);
+                                if (hasLocalPending) {
+                                    debugLog("Local update state present; continuing update even though remote no longer requires it");
                                     try {
-                                        const { getCurrentUsername } = await import("../../utils/remoteUpdatingManager");
-                                        currentUsername = (await getCurrentUsername()) ?? undefined;
-                                    } catch {
-                                        // non-fatal
+                                        await markPendingUpdateRequired(projectUri, "Local pending update");
+                                    } catch (e) {
+                                        debugLog("Failed to persist pending update flag for local pending state", e);
                                     }
+                                    shouldUpdate = true;
+                                    updatingReason = "Local pending update";
                                 }
 
-                                if (currentUsername) {
+                                // 2. Check pendingUpdate sticky flag – does NOT need a username
+                                if (!shouldUpdate) {
                                     try {
-                                        const metaResult = await MetadataManager.safeReadMetadata<ProjectMetadata>(projectUri);
-                                        if (metaResult.success && metaResult.metadata) {
-                                            const { normalizeUpdateEntry, isEffectivelyCancelled } = await import("../../utils/remoteUpdatingManager");
-                                            const entries = (metaResult.metadata.meta?.initiateRemoteUpdatingFor ?? [])
-                                                .map((e: any) => normalizeUpdateEntry(e));
-                                            const hasActiveEntry = entries.some(
-                                                (e) => e.userToUpdate === currentUsername && !e.executed && !isEffectivelyCancelled(e)
-                                            );
-                                            if (hasActiveEntry) {
-                                                debugLog("Active update entry found in local metadata.json for user:", currentUsername);
-                                                try {
-                                                    await markPendingUpdateRequired(projectUri, "Detected from local metadata on open");
-                                                } catch (e) {
-                                                    debugLog("Failed to persist pending update flag from local metadata", e);
-                                                }
-                                                shouldUpdate = true;
-                                                updatingReason = "Local metadata requirement";
-                                            }
+                                        const localSettings = await readLocalProjectSettings(projectUri);
+                                        if (localSettings.pendingUpdate?.required) {
+                                            debugLog("pendingUpdate sticky flag set in localProjectSettings, triggering update");
+                                            shouldUpdate = true;
+                                            updatingReason = "Pending update (local flag)";
                                         }
                                     } catch (e) {
-                                        debugLog("Error checking local metadata entries", e);
+                                        debugLog("Error reading localProjectSettings for pendingUpdate check", e);
+                                    }
+                                }
+
+                                // 3. Check local metadata.json entries (requires username)
+                                if (!shouldUpdate) {
+                                    let currentUsername = remoteProjectRequirements?.currentUsername;
+                                    if (!currentUsername) {
+                                        try {
+                                            const { getCurrentUsername } = await import("../../utils/remoteUpdatingManager");
+                                            currentUsername = (await getCurrentUsername()) ?? undefined;
+                                        } catch {
+                                            // non-fatal
+                                        }
+                                    }
+
+                                    if (currentUsername) {
+                                        try {
+                                            const metaResult = await MetadataManager.safeReadMetadata<ProjectMetadata>(projectUri);
+                                            if (metaResult.success && metaResult.metadata) {
+                                                const { normalizeUpdateEntry, isEffectivelyCancelled } = await import("../../utils/remoteUpdatingManager");
+                                                const entries = (metaResult.metadata.meta?.initiateRemoteUpdatingFor ?? [])
+                                                    .map((e: any) => normalizeUpdateEntry(e));
+                                                const hasActiveEntry = entries.some(
+                                                    (e) => e.userToUpdate === currentUsername && !e.executed && !isEffectivelyCancelled(e)
+                                                );
+                                                if (hasActiveEntry) {
+                                                    debugLog("Active update entry found in local metadata.json for user:", currentUsername);
+                                                    try {
+                                                        await markPendingUpdateRequired(projectUri, "Detected from local metadata on open");
+                                                    } catch (e) {
+                                                        debugLog("Failed to persist pending update flag from local metadata", e);
+                                                    }
+                                                    shouldUpdate = true;
+                                                    updatingReason = "Local metadata requirement";
+                                                }
+                                            }
+                                        } catch (e) {
+                                            debugLog("Error checking local metadata entries", e);
+                                        }
                                     }
                                 }
                             }
-                        }
-                        if (shouldUpdate) {
-                            // ── Version gate: block update if extensions are outdated ──
-                            // Checks both local and remote metadata requiredExtensions + REQUIRED_FRONTIER_VERSION
-                            try {
-                                const { ensureExtensionVersionsForSwapOrUpdate } = await import("../../utils/versionGate");
-                                const versionCheck = await ensureExtensionVersionsForSwapOrUpdate(projectPath, {
-                                    remoteMetadata: fetchedRemoteMetadata,
-                                    operationLabel: "To update the project",
-                                });
-                                if (!versionCheck.allowed) {
-                                    // Modal was already shown – abort the update (and opening)
+                            if (shouldUpdate) {
+                                // ── Version gate: block update if extensions are outdated ──
+                                // Checks both local and remote metadata requiredExtensions + REQUIRED_FRONTIER_VERSION
+                                try {
+                                    const { ensureExtensionVersionsForSwapOrUpdate } = await import("../../utils/versionGate");
+                                    const versionCheck = await ensureExtensionVersionsForSwapOrUpdate(projectPath, {
+                                        remoteMetadata: fetchedRemoteMetadata,
+                                        operationLabel: "To update the project",
+                                    });
+                                    if (!versionCheck.allowed) {
+                                        // Modal was already shown – abort the update (and opening)
+                                        return;
+                                    }
+                                } catch (versionErr) {
+                                    debugLog("Version check for update failed (non-fatal, allowing update):", versionErr);
+                                }
+
+                                const updateConfirmation = await vscode.window.showWarningMessage(
+                                    "Project Update Required\n\n" +
+                                    "An administrator has made changes that require updating your project. " +
+                                    "The project will be re-downloaded to apply the latest changes.\n\n" +
+                                    "Your local changes will be preserved and backed up.",
+                                    { modal: true },
+                                    "Update Project"
+                                );
+
+                                if (updateConfirmation !== "Update Project") {
+                                    debugLog("User declined project update from projects list");
+                                    this.safeSendMessage({
+                                        command: "project.openingInProgress",
+                                        projectPath,
+                                        opening: false,
+                                    } as any);
                                     return;
                                 }
-                            } catch (versionErr) {
-                                debugLog("Version check for update failed (non-fatal, allowing update):", versionErr);
-                            }
 
-                            const updateConfirmation = await vscode.window.showWarningMessage(
-                                "Project Update Required\n\n" +
-                                "An administrator has made changes that require updating your project. " +
-                                "The project will be re-downloaded to apply the latest changes.\n\n" +
-                                "Your local changes will be preserved and backed up.",
-                                { modal: true },
-                                "Update Project"
-                            );
+                                remoteUpdateWasPerformed = true;
 
-                            if (updateConfirmation !== "Update Project") {
-                                debugLog("User declined project update from projects list");
-                                this.safeSendMessage({
-                                    command: "project.openingInProgress",
-                                    projectPath,
-                                    opening: false,
-                                } as any);
-                                return;
-                            }
-
-                            remoteUpdateWasPerformed = true;
-
-                            // Inform webview that updating is starting (not opening)
-                            try {
-                                this.safeSendMessage({
-                                    command: "project.updatingInProgress",
-                                    projectPath,
-                                    updating: true,
-                                } as any);
-                            } catch (e) {
-                                // non-fatal
-                            }
-
-                            // Show notification and perform update
-                            await vscode.window.withProgress(
-                                {
-                                    location: vscode.ProgressLocation.Notification,
-                                    title: updatingReason === "Remote requirement"
-                                        ? "Project administrator requires update"
-                                        : "Continuing update",
-                                    cancellable: false,
-                                },
-                                async (progress) => {
-                                    progress.report({ message: "Updating project..." });
-
-                                    // Get project name for the update process
-                                    const projectName = projectPath.split(/[\\/]/).pop() || "project";
-
-                                    // Get git origin URL
-                                    const dugiteGitModule = await import("../../utils/dugiteGit");
-                                    const remotes = await dugiteGitModule.listRemotes(projectPath);
-                                    const origin = remotes.find((r) => r.remote === "origin");
-
-                                    if (!origin) {
-                                        throw new Error("No git origin found for project");
-                                    }
-
-                                    // Perform the update operation (suppress success message, we'll show it after opening)
-                                    // Username is passed so local flag can be set BEFORE window reload
-                                    await this.performProjectUpdate(
-                                        progress,
-                                        projectName,
+                                // Inform webview that updating is starting (not opening)
+                                try {
+                                    this.safeSendMessage({
+                                        command: "project.updatingInProgress",
                                         projectPath,
-                                        origin.url,
-                                        false, // Don't show success message yet
-                                        remoteProjectRequirements?.currentUsername || undefined // Pass username for local flag
-                                    );
-
-                                    // Update flags are now set INSIDE performProjectUpdate (before window reload)
-                                    // This ensures metadata.json has executed:true before sync runs on restart
-
-                                    // Clear pending update flag
-                                    try {
-                                        await clearPendingUpdate(vscode.Uri.file(projectPath));
-                                    } catch {
-                                        // Non-fatal error
-                                    }
-
-                                    progress.report({ message: "Opening project..." });
+                                        updating: true,
+                                    } as any);
+                                } catch (e) {
+                                    // non-fatal
                                 }
-                            );
 
-                            // Clear local pending flag after successful update run (even if remote no longer required it)
-                            try {
-                                await clearPendingUpdate(vscode.Uri.file(projectPath));
-                            } catch {
-                                // Non-fatal error
-                            }
+                                // Show notification and perform update
+                                await vscode.window.withProgress(
+                                    {
+                                        location: vscode.ProgressLocation.Notification,
+                                        title: updatingReason === "Remote requirement"
+                                            ? "Project administrator requires update"
+                                            : "Continuing update",
+                                        cancellable: false,
+                                    },
+                                    async (progress) => {
+                                        progress.report({ message: "Updating project..." });
 
-                            // Inform webview that update is complete
-                            try {
-                                this.safeSendMessage({
-                                    command: "project.updatingInProgress",
-                                    projectPath,
-                                    updating: false,
-                                } as any);
-                            } catch (e) {
-                                // non-fatal
+                                        // Get project name for the update process
+                                        const projectName = projectPath.split(/[\\/]/).pop() || "project";
+
+                                        // Get git origin URL
+                                        const dugiteGitModule = await import("../../utils/dugiteGit");
+                                        const remotes = await dugiteGitModule.listRemotes(projectPath);
+                                        const origin = remotes.find((r) => r.remote === "origin");
+
+                                        if (!origin) {
+                                            throw new Error("No git origin found for project");
+                                        }
+
+                                        // Perform the update operation (suppress success message, we'll show it after opening)
+                                        // Username is passed so local flag can be set BEFORE window reload
+                                        await this.performProjectUpdate(
+                                            progress,
+                                            projectName,
+                                            projectPath,
+                                            origin.url,
+                                            false, // Don't show success message yet
+                                            remoteProjectRequirements?.currentUsername || undefined // Pass username for local flag
+                                        );
+
+                                        // Update flags are now set INSIDE performProjectUpdate (before window reload)
+                                        // This ensures metadata.json has executed:true before sync runs on restart
+
+                                        // Clear pending update flag
+                                        try {
+                                            await clearPendingUpdate(vscode.Uri.file(projectPath));
+                                        } catch {
+                                            // Non-fatal error
+                                        }
+
+                                        progress.report({ message: "Opening project..." });
+                                    }
+                                );
+
+                                // Clear local pending flag after successful update run (even if remote no longer required it)
+                                try {
+                                    await clearPendingUpdate(vscode.Uri.file(projectPath));
+                                } catch {
+                                    // Non-fatal error
+                                }
+
+                                // Inform webview that update is complete
+                                try {
+                                    this.safeSendMessage({
+                                        command: "project.updatingInProgress",
+                                        projectPath,
+                                        updating: false,
+                                    } as any);
+                                } catch (e) {
+                                    // non-fatal
+                                }
+                            } else {
+                                debugLog("No remote updating required:", remoteProjectRequirements?.updateReason);
                             }
-                        } else {
-                            debugLog("No remote updating required:", remoteProjectRequirements?.updateReason);
-                        }
                         } // end if (!skipUpdateCheck)
                     } catch (updatingCheckErr) {
                         debugLog("Remote updating check failed:", updatingCheckErr);
@@ -2136,7 +2135,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
 
                     // Open the project directly
                     const projectUri = vscode.Uri.file(projectPath);
-                    await openFolderWithToolModeHandoff(projectUri);
+                    await vscode.commands.executeCommand("vscode.openFolder", projectUri);
 
                 } catch (error) {
                     console.error("Error opening project:", error);
@@ -3705,7 +3704,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     debugLog(`Successfully changed media strategy to "${mediaStrategy}"`);
                     // Open the project after applying strategy
                     try {
-                        await openFolderWithToolModeHandoff(projectUri);
+                        await vscode.commands.executeCommand("vscode.openFolder", projectUri);
                     } catch (openErr) {
                         debugLog("Failed to open project after strategy change", openErr);
                     }
@@ -4038,7 +4037,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
 
                         // 8. Open the project
                         progress.report({ message: "Opening project..." });
-                        await openFolderWithToolModeHandoff(newProjectUri);
+                        await vscode.commands.executeCommand("vscode.openFolder", newProjectUri);
                     });
 
                 } catch (error) {
@@ -5244,7 +5243,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                 console.error("Failed to set update flags:", flagErr);
             }
         }
-        await openFolderWithToolModeHandoff(updatedUri, false);
+        await vscode.commands.executeCommand("vscode.openFolder", updatedUri, false);
         return;
     }
 

--- a/src/providers/StartupFlow/StartupFlowProvider.ts
+++ b/src/providers/StartupFlow/StartupFlowProvider.ts
@@ -30,6 +30,7 @@ import { performProjectSwap } from "./performProjectSwap";
 import { getCodexProjectsDirectory } from "../../utils/projectLocationUtils";
 import archiver from "archiver";
 import { getWebviewHtml } from "../../utils/webviewTemplate";
+import { openFolderWithToolModeHandoff } from "../../utils/toolPreferences";
 
 import { safePostMessageToPanel, safeIsVisible, safeSetHtml, safeSetOptions } from "../../utils/webviewUtils";
 import * as path from "path";
@@ -1183,7 +1184,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     title: "Select Project Folder",
                 });
                 if (result && result[0]) {
-                    await vscode.commands.executeCommand("vscode.openFolder", result[0]);
+                    await openFolderWithToolModeHandoff(result[0]);
                 }
                 break;
             }
@@ -1205,7 +1206,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     if (folderName) {
                         const projectPath = vscode.Uri.joinPath(result[0], folderName);
                         await vscode.workspace.fs.createDirectory(projectPath);
-                        await vscode.commands.executeCommand("vscode.openFolder", projectPath);
+                        await openFolderWithToolModeHandoff(projectPath);
                     }
                 }
                 break;
@@ -2135,7 +2136,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
 
                     // Open the project directly
                     const projectUri = vscode.Uri.file(projectPath);
-                    await vscode.commands.executeCommand("vscode.openFolder", projectUri);
+                    await openFolderWithToolModeHandoff(projectUri);
 
                 } catch (error) {
                     console.error("Error opening project:", error);
@@ -3704,7 +3705,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                     debugLog(`Successfully changed media strategy to "${mediaStrategy}"`);
                     // Open the project after applying strategy
                     try {
-                        await vscode.commands.executeCommand("vscode.openFolder", projectUri);
+                        await openFolderWithToolModeHandoff(projectUri);
                     } catch (openErr) {
                         debugLog("Failed to open project after strategy change", openErr);
                     }
@@ -4037,7 +4038,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
 
                         // 8. Open the project
                         progress.report({ message: "Opening project..." });
-                        await vscode.commands.executeCommand("vscode.openFolder", newProjectUri);
+                        await openFolderWithToolModeHandoff(newProjectUri);
                     });
 
                 } catch (error) {
@@ -5243,7 +5244,7 @@ export class StartupFlowProvider implements vscode.CustomTextEditorProvider {
                 console.error("Failed to set update flags:", flagErr);
             }
         }
-        await vscode.commands.executeCommand("vscode.openFolder", updatedUri, false);
+        await openFolderWithToolModeHandoff(updatedUri, false);
         return;
     }
 

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -2611,8 +2611,13 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
             const sourceCell = await vscode.commands.executeCommand(
                 "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells",
                 cellId
-            ) as { cellId: string; content: string; } | null;
-            contentIsEmpty = !sourceCell || !sourceCell.content || (sourceCell.content.replace(/<[^>]*>/g, "").trim() === "");
+            ) as { cellId: string; content: string; } | null | undefined;
+            // An undefined result means the source lookup command is not
+            // registered (common in isolated tests), not that the source is
+            // empty. Only a registered command returning null indicates that
+            // transcription preflight may be needed.
+            contentIsEmpty = sourceCell !== undefined
+                && (!sourceCell || !sourceCell.content || (sourceCell.content.replace(/<[^>]*>/g, "").trim() === ""));
         } catch (e) {
             console.warn("getSourceCellByCellIdFromAllSourceCells unavailable; skipping transcription preflight");
             contentIsEmpty = false;

--- a/src/utils/editMapUtils.ts
+++ b/src/utils/editMapUtils.ts
@@ -29,6 +29,7 @@ type ProjectNameEditMap = ["projectName"];
 type MetaGeneratorEditMap = ["meta", "generator"];
 type MetaEditMap = ["meta"];
 type MetaFieldEditMap = ["meta", string];
+type NativeToolStatusEditMap = ["meta", "nativeToolStatus", string];
 type LanguagesEditMap = ["languages"];
 type DeletedCorpusMarkerEditMap = ["deletedCorpusMarker"];
 type DeletedFileEditMap = ["deletedFile"];
@@ -160,6 +161,10 @@ export const EditMapUtils = {
 
     metaField(field: string): readonly ["meta", string] {
         return ["meta", field];
+    },
+
+    nativeToolStatus(username: string): NativeToolStatusEditMap {
+        return ["meta", "nativeToolStatus", username];
     },
 
     languages(): LanguagesEditMap {
@@ -335,20 +340,19 @@ export function addProjectMetadataEdit(
     metadata: { edits?: any[]; },
     editMap: readonly string[],
     value: any,
-    author: string
+    author: string,
+    timestamp: number = Date.now(),
 ): void {
     // Initialize edits array if it doesn't exist
     if (!metadata.edits) {
         metadata.edits = [];
     }
 
-    const currentTimestamp = Date.now();
-
     // Create the new edit entry
     const newEdit = {
         editMap,
         value,
-        timestamp: currentTimestamp,
+        timestamp,
         type: EditType.USER_EDIT,
         author,
     };

--- a/src/utils/editMapUtils.ts
+++ b/src/utils/editMapUtils.ts
@@ -29,7 +29,6 @@ type ProjectNameEditMap = ["projectName"];
 type MetaGeneratorEditMap = ["meta", "generator"];
 type MetaEditMap = ["meta"];
 type MetaFieldEditMap = ["meta", string];
-type NativeToolStatusEditMap = ["meta", "nativeToolStatus", string];
 type LanguagesEditMap = ["languages"];
 type DeletedCorpusMarkerEditMap = ["deletedCorpusMarker"];
 type DeletedFileEditMap = ["deletedFile"];
@@ -161,10 +160,6 @@ export const EditMapUtils = {
 
     metaField(field: string): readonly ["meta", string] {
         return ["meta", field];
-    },
-
-    nativeToolStatus(username: string): NativeToolStatusEditMap {
-        return ["meta", "nativeToolStatus", username];
     },
 
     languages(): LanguagesEditMap {
@@ -340,8 +335,7 @@ export function addProjectMetadataEdit(
     metadata: { edits?: any[]; },
     editMap: readonly string[],
     value: any,
-    author: string,
-    timestamp: number = Date.now(),
+    author: string
 ): void {
     // Initialize edits array if it doesn't exist
     if (!metadata.edits) {
@@ -352,7 +346,7 @@ export function addProjectMetadataEdit(
     const newEdit = {
         editMap,
         value,
-        timestamp,
+        timestamp: Date.now(),
         type: EditType.USER_EDIT,
         author,
     };

--- a/src/utils/ffmpegManager.ts
+++ b/src/utils/ffmpegManager.ts
@@ -127,6 +127,15 @@ export function isFfmpegNativelySupported(): boolean {
 }
 
 /**
+ * Returns true only when the current OS/architecture has a directly matching
+ * FFmpeg asset. A compatibility fallback, such as Windows ARM64 using the
+ * Windows x64 binary, does not count as native.
+ */
+export function isFfmpegNativeAssetSupported(): boolean {
+    return PLATFORM_MAP[`${process.platform}-${process.arch}`] !== undefined;
+}
+
+/**
  * Options for `downloadFFmpeg`.
  */
 export interface DownloadFFmpegOptions {

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { ProjectUserVersionEntry } from "@types";
 import { addProjectMetadataEdit } from "./editMapUtils";
+import { openFolderWithToolModeHandoff } from "./toolPreferences";
 
 /**
  * Simple metadata manager for reading and writing metadata.json.
@@ -307,7 +308,7 @@ export class MetadataManager {
             await this.waitForPendingWrites(undefined, 10000);
         }
 
-        await vscode.commands.executeCommand("vscode.openFolder", targetUri, newWindow);
+        await openFolderWithToolModeHandoff(targetUri, newWindow);
     }
 
     /**

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import * as path from "path";
 import { ProjectUserVersionEntry } from "@types";
 import { addProjectMetadataEdit } from "./editMapUtils";
-import { openFolderWithToolModeHandoff } from "./toolPreferences";
 
 /**
  * Simple metadata manager for reading and writing metadata.json.
@@ -21,7 +20,7 @@ interface ProjectMetadata {
             codexEditor?: string;
             frontierAuthentication?: string;
         };
-        pinnedExtensions?: Record<string, { version: string; url: string }>;
+        pinnedExtensions?: Record<string, { version: string; url: string; }>;
         [key: string]: unknown;
     };
     edits?: any[];
@@ -151,7 +150,7 @@ export class MetadataManager {
         workspaceUri: vscode.Uri,
         updateFunction: (metadata: T) => T | Promise<T>,
         options: MetadataUpdateOptions = {}
-    ): Promise<{ success: boolean; metadata?: T; error?: string }> {
+    ): Promise<{ success: boolean; metadata?: T; error?: string; }> {
         const key = workspaceUri.fsPath;
         const previousWrite = this.writeQueue.get(key) ?? Promise.resolve();
 
@@ -180,7 +179,7 @@ export class MetadataManager {
         workspaceUri: vscode.Uri,
         updateFunction: (metadata: T) => T | Promise<T>,
         options: MetadataUpdateOptions = {}
-    ): Promise<{ success: boolean; metadata?: T; error?: string }> {
+    ): Promise<{ success: boolean; metadata?: T; error?: string; }> {
         const metadataPath = vscode.Uri.joinPath(workspaceUri, "metadata.json");
 
         try {
@@ -232,7 +231,7 @@ export class MetadataManager {
      */
     static async safeReadMetadata<T = ProjectMetadata>(
         workspaceUri: vscode.Uri
-    ): Promise<{ success: boolean; metadata?: T; error?: string }> {
+    ): Promise<{ success: boolean; metadata?: T; error?: string; }> {
         const pendingWrite = this.writeQueue.get(workspaceUri.fsPath);
         if (pendingWrite) {
             try {
@@ -251,7 +250,7 @@ export class MetadataManager {
      */
     private static async readMetadataFromDisk<T = ProjectMetadata>(
         workspaceUri: vscode.Uri
-    ): Promise<{ success: boolean; metadata?: T; error?: string }> {
+    ): Promise<{ success: boolean; metadata?: T; error?: string; }> {
         const metadataPath = vscode.Uri.joinPath(workspaceUri, "metadata.json");
 
         try {
@@ -308,7 +307,7 @@ export class MetadataManager {
             await this.waitForPendingWrites(undefined, 10000);
         }
 
-        await openFolderWithToolModeHandoff(targetUri, newWindow);
+        await vscode.commands.executeCommand("vscode.openFolder", targetUri, newWindow);
     }
 
     /**
@@ -353,7 +352,7 @@ export class MetadataManager {
             codexEditor?: string;
             frontierAuthentication?: string;
         }
-    ): Promise<{ success: boolean; error?: string }> {
+    ): Promise<{ success: boolean; error?: string; }> {
         const result = await this.safeUpdateMetadata<ProjectMetadata>(
             workspaceUri,
             async (metadata) => {
@@ -409,7 +408,7 @@ export class MetadataManager {
         workspaceUri: vscode.Uri
     ): Promise<{
         success: boolean;
-        versions?: { codexEditor?: string; frontierAuthentication?: string };
+        versions?: { codexEditor?: string; frontierAuthentication?: string; };
         error?: string;
     }> {
         const result = await this.safeReadMetadata<ProjectMetadata>(workspaceUri);
@@ -456,7 +455,7 @@ export class MetadataManager {
             }
 
             const existingVersions = result.metadata?.meta?.requiredExtensions || {};
-            const versionsToUpdate: { codexEditor?: string; frontierAuthentication?: string } = {};
+            const versionsToUpdate: { codexEditor?: string; frontierAuthentication?: string; } = {};
 
             // Suppress ratchet if a pin exists (the Conductor is in charge). Query the
             // Conductor for the authoritative pin set so we correctly suppress during
@@ -592,8 +591,8 @@ export class MetadataManager {
         }
 
         // Try to generate chatSystemMessage if it doesn't exist
-        let sourceLanguage: { refName: string } | undefined;
-        let targetLanguage: { refName: string } | undefined;
+        let sourceLanguage: { refName: string; } | undefined;
+        let targetLanguage: { refName: string; } | undefined;
 
         if (result.success && result.metadata) {
             const metadata = result.metadata as any;
@@ -604,8 +603,8 @@ export class MetadataManager {
         if (!sourceLanguage || !targetLanguage) {
             try {
                 const projectConfig = vscode.workspace.getConfiguration("codex-project-manager");
-                const configSourceLanguage = projectConfig.get("sourceLanguage") as { refName: string } | undefined;
-                const configTargetLanguage = projectConfig.get("targetLanguage") as { refName: string } | undefined;
+                const configSourceLanguage = projectConfig.get("sourceLanguage") as { refName: string; } | undefined;
+                const configTargetLanguage = projectConfig.get("targetLanguage") as { refName: string; } | undefined;
 
                 if (configSourceLanguage?.refName) {
                     sourceLanguage = configSourceLanguage;
@@ -648,7 +647,7 @@ export class MetadataManager {
         value: string,
         workspaceFolderUri?: vscode.Uri,
         author?: string
-    ): Promise<{ success: boolean; error?: string }> {
+    ): Promise<{ success: boolean; error?: string; }> {
         const workspaceFolder = workspaceFolderUri || vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceFolder) {
             return { success: false, error: "No workspace folder found" };
@@ -717,7 +716,7 @@ export class MetadataManager {
         value: boolean,
         workspaceFolderUri?: vscode.Uri,
         author?: string
-    ): Promise<{ success: boolean; error?: string }> {
+    ): Promise<{ success: boolean; error?: string; }> {
         const workspaceFolder = workspaceFolderUri || vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceFolder) {
             return { success: false, error: "No workspace folder found" };
@@ -769,7 +768,7 @@ export class MetadataManager {
      * Waits for any in-flight write before checking so we don't
      * incorrectly report an empty file mid-write.
      */
-    static async ensureMetadataIntegrity(workspaceUri: vscode.Uri): Promise<{ success: boolean; recovered?: boolean; error?: string }> {
+    static async ensureMetadataIntegrity(workspaceUri: vscode.Uri): Promise<{ success: boolean; recovered?: boolean; error?: string; }> {
         const pendingWrite = this.writeQueue.get(workspaceUri.fsPath);
         if (pendingWrite) {
             try {
@@ -812,7 +811,7 @@ export function registerMetadataCommands(context: vscode.ExtensionContext): void
     context.subscriptions.push(
         vscode.commands.registerCommand(
             "codex-editor.getMetadataExtensionVersions",
-            async (): Promise<{ success: boolean; versions?: { codexEditor?: string; frontierAuthentication?: string }; error?: string }> => {
+            async (): Promise<{ success: boolean; versions?: { codexEditor?: string; frontierAuthentication?: string; }; error?: string; }> => {
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
                 if (!workspaceFolder) {
                     return { success: false, error: "No workspace folder open" };

--- a/src/utils/metadataManager.ts
+++ b/src/utils/metadataManager.ts
@@ -210,6 +210,13 @@ export class MetadataManager {
                 };
             }
 
+            // Avoid rewriting metadata.json when an update function detects
+            // no semantic change. This is important for status snapshots,
+            // which are checked on every project open.
+            if (JSON.stringify(originalMetadata) === jsonContent) {
+                return { success: true, metadata: updatedMetadata };
+            }
+
             // Step 4: Direct write - simple, like every other file
             const encoded = new TextEncoder().encode(jsonContent);
             await vscode.workspace.fs.writeFile(metadataPath, encoded);

--- a/src/utils/nativeToolStatus.ts
+++ b/src/utils/nativeToolStatus.ts
@@ -1,0 +1,137 @@
+import type { NativeToolKey, NativeToolStatusEntry } from "../../types";
+import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
+import { MetadataManager } from "./metadataManager";
+import { addProjectMetadataEdit, EditMapUtils } from "./editMapUtils";
+import type { ToolCheckResult } from "./toolsManager";
+import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "./toolPreferences";
+
+const NATIVE_TOOL_ORDER: readonly NativeToolKey[] = ["search", "sync", "audio"];
+
+function normalizeNonNativeTools(value: unknown): NativeToolKey[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const values = new Set(value.filter(
+        (tool): tool is NativeToolKey => NATIVE_TOOL_ORDER.includes(tool as NativeToolKey),
+    ));
+    return NATIVE_TOOL_ORDER.filter((tool) => values.has(tool));
+}
+
+function sameToolList(left: NativeToolKey[], right: NativeToolKey[]): boolean {
+    return left.length === right.length && left.every((tool, index) => tool === right[index]);
+}
+
+export function normalizeNativeToolStatusEntries(value: unknown): NativeToolStatusEntry[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const entriesByUsername = new Map<string, NativeToolStatusEntry>();
+    for (const rawEntry of value) {
+        if (!rawEntry || typeof rawEntry !== "object") {
+            continue;
+        }
+
+        const entry = rawEntry as Partial<NativeToolStatusEntry>;
+        const username = typeof entry.username === "string" ? entry.username.trim() : "";
+        if (!username || typeof entry.timestamp !== "number") {
+            continue;
+        }
+
+        const normalizedEntry: NativeToolStatusEntry = {
+            username,
+            timestamp: entry.timestamp,
+            nonNative: normalizeNonNativeTools(entry.nonNative),
+        };
+        const existing = entriesByUsername.get(username);
+        if (!existing || normalizedEntry.timestamp >= existing.timestamp) {
+            entriesByUsername.set(username, normalizedEntry);
+        }
+    }
+
+    return Array.from(entriesByUsername.values()).sort((left, right) =>
+        left.username.localeCompare(right.username),
+    );
+}
+
+function getActiveNonNativeTools(result: ToolCheckResult): NativeToolKey[] {
+    const nonNative: NativeToolKey[] = [];
+
+    if (!result.nativeSqliteAvailable || getSqliteToolMode() !== "auto") {
+        nonNative.push("search");
+    }
+    if (!result.nativeGitAvailable || getGitToolMode() !== "auto") {
+        nonNative.push("sync");
+    }
+    // A usable x64 FFmpeg asset on Windows ARM64 is treated as native
+    // operation for this project status, even though it is not ARM-native.
+    if (!result.ffmpeg || getAudioToolMode() !== "auto") {
+        nonNative.push("audio");
+    }
+
+    return nonNative;
+}
+
+export async function updateNativeToolStatus(
+    workspaceUri: import("vscode").Uri,
+    result: ToolCheckResult,
+    frontierApi: FrontierAPI | undefined,
+): Promise<{ success: boolean; changed: boolean; }> {
+    const userInfo = await frontierApi?.getUserInfo?.();
+    const username = userInfo?.username?.trim();
+    if (!username) {
+        return { success: true, changed: false };
+    }
+    const nextEntry: NativeToolStatusEntry = {
+        username,
+        timestamp: Date.now(),
+        nonNative: getActiveNonNativeTools(result),
+    };
+    let changed = false;
+
+    const updateResult = await MetadataManager.safeUpdateMetadata<Record<string, unknown>>(
+        workspaceUri,
+        (metadata) => {
+            const currentMeta = metadata.meta && typeof metadata.meta === "object"
+                ? metadata.meta as Record<string, unknown>
+                : {};
+            const currentEntries = normalizeNativeToolStatusEntries(currentMeta.nativeToolStatus);
+            const currentEntry = currentEntries.find((entry) => entry.username === username);
+
+            if (currentEntry && sameToolList(currentEntry.nonNative, nextEntry.nonNative)) {
+                return metadata;
+            }
+
+            const nextEntries = [
+                ...currentEntries.filter((entry) => entry.username !== username),
+                nextEntry,
+            ].sort((left, right) => left.username.localeCompare(right.username));
+            const nextMeta: Record<string, unknown> = {};
+            for (const [key, value] of Object.entries(currentMeta)) {
+                if (key === "nativeToolStatus") {
+                    continue;
+                }
+                nextMeta[key] = value;
+                if (key === "validationCountAudio") {
+                    nextMeta.nativeToolStatus = nextEntries;
+                }
+            }
+            if (!("nativeToolStatus" in nextMeta)) {
+                nextMeta.nativeToolStatus = nextEntries;
+            }
+            metadata.meta = nextMeta;
+            addProjectMetadataEdit(
+                metadata,
+                EditMapUtils.nativeToolStatus(username),
+                nextEntry,
+                username,
+                nextEntry.timestamp,
+            );
+            changed = true;
+            return metadata;
+        },
+    );
+
+    return { success: updateResult.success, changed };
+}

--- a/src/utils/nativeToolStatus.ts
+++ b/src/utils/nativeToolStatus.ts
@@ -1,7 +1,6 @@
 import type { NativeToolKey, NativeToolStatusEntry } from "../../types";
 import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
 import { MetadataManager } from "./metadataManager";
-import { addProjectMetadataEdit, EditMapUtils } from "./editMapUtils";
 import type { ToolCheckResult } from "./toolsManager";
 import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "./toolPreferences";
 
@@ -47,6 +46,22 @@ export function normalizeNativeToolStatusEntries(value: unknown): NativeToolStat
         const existing = entriesByUsername.get(username);
         if (!existing || normalizedEntry.timestamp >= existing.timestamp) {
             entriesByUsername.set(username, normalizedEntry);
+        }
+    }
+
+    return Array.from(entriesByUsername.values()).sort((left, right) =>
+        left.username.localeCompare(right.username),
+    );
+}
+
+export function mergeNativeToolStatusEntries(...values: unknown[]): NativeToolStatusEntry[] {
+    const entriesByUsername = new Map<string, NativeToolStatusEntry>();
+    for (const value of values) {
+        for (const entry of normalizeNativeToolStatusEntries(value)) {
+            const existing = entriesByUsername.get(entry.username);
+            if (!existing || entry.timestamp > existing.timestamp) {
+                entriesByUsername.set(entry.username, entry);
+            }
         }
     }
 
@@ -121,13 +136,6 @@ export async function updateNativeToolStatus(
                 nextMeta.nativeToolStatus = nextEntries;
             }
             metadata.meta = nextMeta;
-            addProjectMetadataEdit(
-                metadata,
-                EditMapUtils.nativeToolStatus(username),
-                nextEntry,
-                username,
-                nextEntry.timestamp,
-            );
             changed = true;
             return metadata;
         },

--- a/src/utils/nativeToolStatus.ts
+++ b/src/utils/nativeToolStatus.ts
@@ -54,6 +54,35 @@ export function normalizeNativeToolStatusEntries(value: unknown): NativeToolStat
     );
 }
 
+export function normalizeNativeToolStatusHistory(value: unknown): NativeToolStatusEntry[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .filter((rawEntry): rawEntry is Record<string, unknown> =>
+            !!rawEntry && typeof rawEntry === "object",
+        )
+        .map((rawEntry) => {
+            const username = typeof rawEntry.username === "string"
+                ? rawEntry.username.trim()
+                : "";
+            const timestamp = rawEntry.timestamp;
+            if (!username || typeof timestamp !== "number") {
+                return null;
+            }
+            return {
+                username,
+                timestamp,
+                nonNative: normalizeNonNativeTools(rawEntry.nonNative),
+            };
+        })
+        .filter((entry): entry is NativeToolStatusEntry => entry !== null)
+        .sort((left, right) =>
+            left.timestamp - right.timestamp || left.username.localeCompare(right.username),
+        );
+}
+
 export function mergeNativeToolStatusEntries(...values: unknown[]): NativeToolStatusEntry[] {
     const entriesByUsername = new Map<string, NativeToolStatusEntry>();
     for (const value of values) {
@@ -67,6 +96,22 @@ export function mergeNativeToolStatusEntries(...values: unknown[]): NativeToolSt
 
     return Array.from(entriesByUsername.values()).sort((left, right) =>
         left.username.localeCompare(right.username),
+    );
+}
+
+export function mergeNativeToolStatusHistory(...values: unknown[]): NativeToolStatusEntry[] {
+    const entriesByKey = new Map<string, NativeToolStatusEntry>();
+    for (const value of values) {
+        for (const entry of normalizeNativeToolStatusHistory(value)) {
+            const key = `${entry.username}:${entry.timestamp}`;
+            if (!entriesByKey.has(key)) {
+                entriesByKey.set(key, entry);
+            }
+        }
+    }
+
+    return Array.from(entriesByKey.values()).sort((left, right) =>
+        left.timestamp - right.timestamp || left.username.localeCompare(right.username),
     );
 }
 
@@ -112,6 +157,9 @@ export async function updateNativeToolStatus(
                 ? metadata.meta as Record<string, unknown>
                 : {};
             const currentEntries = normalizeNativeToolStatusEntries(currentMeta.nativeToolStatus);
+            const currentHistory = normalizeNativeToolStatusHistory(
+                currentMeta.nativeToolStatusHistory,
+            );
             const currentEntry = currentEntries.find((entry) => entry.username === username);
 
             if (currentEntry && sameToolList(currentEntry.nonNative, nextEntry.nonNative)) {
@@ -135,6 +183,10 @@ export async function updateNativeToolStatus(
             if (!("nativeToolStatus" in nextMeta)) {
                 nextMeta.nativeToolStatus = nextEntries;
             }
+            nextMeta.nativeToolStatusHistory = [
+                ...currentHistory,
+                nextEntry,
+            ];
             metadata.meta = nextMeta;
             changed = true;
             return metadata;

--- a/src/utils/optimizedToolsManager.ts
+++ b/src/utils/optimizedToolsManager.ts
@@ -1,0 +1,153 @@
+import * as vscode from "vscode";
+import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
+import {
+    getAudioToolMode,
+    getGitToolMode,
+    getSqliteToolMode,
+    setAudioToolMode,
+    setGitToolMode,
+    setNativeGitAvailable,
+    setSqliteToolMode,
+} from "./toolPreferences";
+import { checkTools, type OptimizedToolKey, type ToolCheckResult } from "./toolsManager";
+
+export interface OptimizedToolsResult {
+    status: ToolCheckResult;
+    enabled: OptimizedToolKey[];
+    failed: Array<{ tool: OptimizedToolKey; reason: string }>;
+}
+
+/**
+ * Install and activate optimized tools for the requested tool set.
+ * Existing native binaries are reused; missing binaries are downloaded.
+ */
+export async function enableOptimizedTools(
+    context: vscode.ExtensionContext,
+    frontierApi: FrontierAPI | undefined,
+    tools: OptimizedToolKey[],
+): Promise<OptimizedToolsResult> {
+    const enabled: OptimizedToolKey[] = [];
+    const failed: Array<{ tool: OptimizedToolKey; reason: string }> = [];
+
+    for (const tool of tools) {
+        try {
+            const result = await enableOptimizedTool(context, frontierApi, tool);
+            if (result) {
+                enabled.push(tool);
+            } else {
+                failed.push({ tool, reason: "The optimized tool could not be installed or started." });
+            }
+        } catch (error) {
+            failed.push({
+                tool,
+                reason: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    const status = await checkTools(context, frontierApi);
+    const verifiedEnabled = enabled.filter((tool) => isOptimizedToolActive(status, tool));
+    for (const tool of enabled) {
+        if (!verifiedEnabled.includes(tool)) {
+            failed.push({ tool, reason: "The optimized tool was installed but is not active." });
+        }
+    }
+
+    return {
+        status,
+        enabled: verifiedEnabled,
+        failed,
+    };
+}
+
+function isOptimizedToolActive(status: ToolCheckResult, tool: OptimizedToolKey): boolean {
+    switch (tool) {
+        case "sqlite":
+            return status.nativeSqliteAvailable && getSqliteToolMode() !== "builtin";
+        case "git":
+            return status.nativeGitAvailable && getGitToolMode() !== "builtin";
+        case "ffmpeg":
+            return status.ffmpeg && getAudioToolMode() !== "builtin";
+    }
+}
+
+async function enableOptimizedTool(
+    context: vscode.ExtensionContext,
+    frontierApi: FrontierAPI | undefined,
+    tool: OptimizedToolKey,
+): Promise<boolean> {
+    switch (tool) {
+        case "sqlite":
+            return enableOptimizedSqlite(context);
+        case "git":
+            return enableOptimizedGit(frontierApi);
+        case "ffmpeg":
+            return enableOptimizedAudio(context);
+    }
+}
+
+async function enableOptimizedSqlite(context: vscode.ExtensionContext): Promise<boolean> {
+    const { ensureSqliteNativeBinary } = await import("./sqliteNativeBinaryManager");
+    const { initNativeSqlite } = await import("./nativeSqlite");
+    const { getSQLiteIndexManager } = await import(
+        "../activationHelpers/contextAware/contentIndexes/indexes/sqliteIndexManager"
+    );
+
+    const binaryPath = await ensureSqliteNativeBinary(context);
+    if (!binaryPath) {
+        return false;
+    }
+
+    initNativeSqlite(binaryPath);
+    if (getSqliteToolMode() === "builtin") {
+        await setSqliteToolMode("auto");
+    }
+
+    const manager = getSQLiteIndexManager();
+    if (manager && !manager.isClosed) {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Switching to optimized Search tools…",
+                cancellable: false,
+            },
+            async () => {
+                await manager.reopenWithCurrentBackend();
+            },
+        );
+    }
+
+    return true;
+}
+
+async function enableOptimizedGit(frontierApi: FrontierAPI | undefined): Promise<boolean> {
+    if (!frontierApi?.retryGitBinaryDownload) {
+        return false;
+    }
+
+    const { resetGitBinaryPath } = await import("./dugiteGit");
+    resetGitBinaryPath();
+    const success = await frontierApi.retryGitBinaryDownload();
+    if (!success) {
+        return false;
+    }
+
+    setNativeGitAvailable(true);
+    if (getGitToolMode() === "builtin") {
+        await setGitToolMode("auto");
+    }
+    return true;
+}
+
+async function enableOptimizedAudio(context: vscode.ExtensionContext): Promise<boolean> {
+    const { downloadFFmpeg } = await import("./ffmpegManager");
+    const binaryPath = await downloadFFmpeg(context, { showProgress: true });
+    if (!binaryPath) {
+        return false;
+    }
+
+    if (getAudioToolMode() === "builtin") {
+        await setAudioToolMode("auto");
+    }
+    return true;
+}

--- a/src/utils/projectCreationUtils/projectCreationUtils.ts
+++ b/src/utils/projectCreationUtils/projectCreationUtils.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import * as semver from "semver";
 import { initializeProjectMetadataAndGit, syncMetadataToConfiguration, isValidCodexProject, generateProjectId, ProjectDetails, sanitizeProjectName, extractProjectIdFromFolderName, validateProjectNameCharacters } from "../../projectManager/utils/projectUtils";
 import { getCodexProjectsDirectory } from "../projectLocationUtils";
-import { openFolderWithToolModeHandoff } from "../toolPreferences";
 
 /**
  * Checks if a folder or any of its parent folders is a Codex project
@@ -54,14 +53,14 @@ export async function createNewWorkspaceAndProject(context?: vscode.ExtensionCon
     }
 
     const projectName = sanitizeProjectName(projectNameInput);
-    
+
     // Check if user input already has a valid UUID suffix - if so, use it instead of generating new
     const existingUuid = extractProjectIdFromFolderName(projectName);
     const projectId = existingUuid || generateProjectId();
-    
+
     // Only append projectId if name doesn't already end with it
-    const fullProjectName = projectName.endsWith(`-${projectId}`) 
-        ? projectName 
+    const fullProjectName = projectName.endsWith(`-${projectId}`)
+        ? projectName
         : `${projectName}-${projectId}`;
 
     if (projectName !== projectNameInput) {
@@ -156,7 +155,7 @@ async function createProjectInNewFolder(folderNameOrProjectName: string, project
     const newFolderUri = vscode.Uri.joinPath(parentFolderUri[0], folderName);
     try {
         await vscode.workspace.fs.createDirectory(newFolderUri);
-        await openFolderWithToolModeHandoff(newFolderUri);
+        await vscode.commands.executeCommand("vscode.openFolder", newFolderUri);
 
         // NOTE: Do NOT call createNewProject here!
         // When the new window opens, the pending state mechanism in extension.ts
@@ -205,7 +204,7 @@ async function createProjectInExistingFolder() {
             return;
         }
 
-        await openFolderWithToolModeHandoff(folderUri[0]);
+        await vscode.commands.executeCommand("vscode.openFolder", folderUri[0]);
         await new Promise((resolve) => setTimeout(resolve, 1000));
         // Generate projectId for this flow (creating in existing folder)
         const projectId = generateProjectId();
@@ -285,7 +284,7 @@ export async function openProject(projectPath: string) {
             );
 
             // Open folder and wait for it to open
-            await openFolderWithToolModeHandoff(uri);
+            await vscode.commands.executeCommand("vscode.openFolder", uri);
 
             // Sync metadata values to configuration after folder is open
             // Note: This doesn't execute immediately as the above command opens a new window

--- a/src/utils/projectCreationUtils/projectCreationUtils.ts
+++ b/src/utils/projectCreationUtils/projectCreationUtils.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as semver from "semver";
 import { initializeProjectMetadataAndGit, syncMetadataToConfiguration, isValidCodexProject, generateProjectId, ProjectDetails, sanitizeProjectName, extractProjectIdFromFolderName, validateProjectNameCharacters } from "../../projectManager/utils/projectUtils";
 import { getCodexProjectsDirectory } from "../projectLocationUtils";
+import { openFolderWithToolModeHandoff } from "../toolPreferences";
 
 /**
  * Checks if a folder or any of its parent folders is a Codex project
@@ -155,7 +156,7 @@ async function createProjectInNewFolder(folderNameOrProjectName: string, project
     const newFolderUri = vscode.Uri.joinPath(parentFolderUri[0], folderName);
     try {
         await vscode.workspace.fs.createDirectory(newFolderUri);
-        await vscode.commands.executeCommand("vscode.openFolder", newFolderUri);
+        await openFolderWithToolModeHandoff(newFolderUri);
 
         // NOTE: Do NOT call createNewProject here!
         // When the new window opens, the pending state mechanism in extension.ts
@@ -204,7 +205,7 @@ async function createProjectInExistingFolder() {
             return;
         }
 
-        await vscode.commands.executeCommand("vscode.openFolder", folderUri[0]);
+        await openFolderWithToolModeHandoff(folderUri[0]);
         await new Promise((resolve) => setTimeout(resolve, 1000));
         // Generate projectId for this flow (creating in existing folder)
         const projectId = generateProjectId();
@@ -284,7 +285,7 @@ export async function openProject(projectPath: string) {
             );
 
             // Open folder and wait for it to open
-            await vscode.commands.executeCommand("vscode.openFolder", uri);
+            await openFolderWithToolModeHandoff(uri);
 
             // Sync metadata values to configuration after folder is open
             // Note: This doesn't execute immediately as the above command opens a new window

--- a/src/utils/sqliteNativeBinaryManager.ts
+++ b/src/utils/sqliteNativeBinaryManager.ts
@@ -577,7 +577,7 @@ export async function ensureSqliteNativeBinary(
     // or verification can recover without user intervention. Each retry
     // surfaces its state through the optional progress reporter.
     const runDownload = async (
-        progress?: vscode.Progress<{ message?: string }>
+        progress?: vscode.Progress<{ message?: string; }>
     ): Promise<string | null> => {
         let lastError: Error | undefined;
         for (let attempt = 1; attempt <= MAX_FULL_RETRIES; attempt++) {

--- a/src/utils/toolPreferences.ts
+++ b/src/utils/toolPreferences.ts
@@ -8,113 +8,25 @@ import { isNativeSqliteReady } from "./nativeSqlite";
 export type AudioToolMode = "auto" | "builtin" | "force-builtin";
 
 const AUDIO_TOOL_MODE_KEY = "toolPreferences.audioToolMode";
-const SQLITE_TOOL_MODE_KEY = "toolPreferences.sqliteToolMode";
-const SESSION_OVERRIDES_KEY = "toolPreferences.sessionOverrides";
-const PROJECT_HANDOFF_KEY = "toolPreferences.projectHandoff";
 
 let cachedContext: vscode.ExtensionContext | undefined;
-type SessionToolOverrides = Partial<{
-    audio: "builtin";
-    git: "builtin";
-    sqlite: "builtin";
-}>;
-interface StoredSessionOverrides {
-    sessionId: string;
-    overrides: SessionToolOverrides;
-}
-interface ProjectToolHandoff {
-    sourceSessionId: string;
-    targetPath: string;
-    createdAt: number;
-    overrides: SessionToolOverrides;
-}
-let sessionOverrides: SessionToolOverrides = {};
-
-const persistSessionOverrides = async (): Promise<void> => {
-    if (!cachedContext) {
-        return;
-    }
-    if (Object.keys(sessionOverrides).length === 0) {
-        await cachedContext.globalState.update(SESSION_OVERRIDES_KEY, undefined);
-        return;
-    }
-    const state: StoredSessionOverrides = {
-        sessionId: vscode.env.sessionId,
-        overrides: sessionOverrides,
-    };
-    await cachedContext.globalState.update(SESSION_OVERRIDES_KEY, state);
-};
 
 export const initToolPreferences = (context: vscode.ExtensionContext): void => {
     cachedContext = context;
-    sessionOverrides = {};
-
-    const stored = context.globalState.get<StoredSessionOverrides>(SESSION_OVERRIDES_KEY);
-    const handoff = context.globalState.get<ProjectToolHandoff>(PROJECT_HANDOFF_KEY);
-    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-
-    if (
-        handoff &&
-        Date.now() - handoff.createdAt < 120_000 &&
-        handoff.targetPath === workspacePath &&
-        handoff.sourceSessionId !== vscode.env.sessionId
-    ) {
-        sessionOverrides = { ...handoff.overrides };
-        void context.globalState.update(PROJECT_HANDOFF_KEY, undefined);
-        void persistSessionOverrides();
-    } else if (stored?.sessionId === vscode.env.sessionId) {
-        sessionOverrides = { ...stored.overrides };
-    } else {
-        void context.globalState.update(SESSION_OVERRIDES_KEY, undefined);
-        void context.globalState.update(PROJECT_HANDOFF_KEY, undefined);
-    }
-
-    // Migrate the old persistent "builtin" preference into this session only.
-    const persistedAudioMode = context.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY);
-    if (!sessionOverrides.audio && persistedAudioMode === "builtin") {
-        sessionOverrides.audio = "builtin";
-        void context.globalState.update(AUDIO_TOOL_MODE_KEY, "auto");
-    }
-    const persistedSqliteMode = context.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY);
-    if (!sessionOverrides.sqlite && persistedSqliteMode === "builtin") {
-        sessionOverrides.sqlite = "builtin";
-        void context.globalState.update(SQLITE_TOOL_MODE_KEY, "auto");
-    }
-    const persistedGitMode = vscode.workspace
-        .getConfiguration("codex-editor")
-        .get<GitToolMode>("gitBackendMode");
-    if (!sessionOverrides.git && persistedGitMode === "builtin") {
-        sessionOverrides.git = "builtin";
-        void vscode.workspace
-            .getConfiguration("codex-editor")
-            .update("gitBackendMode", "auto", vscode.ConfigurationTarget.Global);
-    }
-    void persistSessionOverrides();
 };
 
 export const getAudioToolMode = (): AudioToolMode => {
     if (!cachedContext) {
         return "auto";
     }
-    const persisted = cachedContext.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY) ?? "auto";
-    if (persisted === "force-builtin") {
-        return persisted;
-    }
-    return sessionOverrides.audio ?? "auto";
+    return cachedContext.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY) ?? "auto";
 };
 
 export const setAudioToolMode = async (mode: AudioToolMode): Promise<void> => {
     if (!cachedContext) {
         return;
     }
-    if (mode === "builtin") {
-        sessionOverrides.audio = mode;
-        await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, "auto");
-    } else {
-        delete sessionOverrides.audio;
-        await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, mode);
-    }
-    await persistSessionOverrides();
+    await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, mode);
 };
 
 /**
@@ -145,28 +57,16 @@ let _nativeGitAvailable = false;
  * so they always agree on which git backend to use.
  */
 export const getGitToolMode = (): GitToolMode => {
-    const persisted = vscode.workspace
+    const mode = vscode.workspace
         .getConfiguration("codex-editor")
         .get<GitToolMode>("gitBackendMode");
-    if (persisted === "force-builtin") {
-        return persisted;
-    }
-    return sessionOverrides.git ?? "auto";
+    return mode ?? "auto";
 };
 
 export const setGitToolMode = async (mode: GitToolMode): Promise<void> => {
-    if (mode === "builtin") {
-        sessionOverrides.git = mode;
-        await vscode.workspace
-            .getConfiguration("codex-editor")
-            .update("gitBackendMode", "auto", vscode.ConfigurationTarget.Global);
-    } else {
-        delete sessionOverrides.git;
-        await vscode.workspace
-            .getConfiguration("codex-editor")
-            .update("gitBackendMode", mode, vscode.ConfigurationTarget.Global);
-    }
-    await persistSessionOverrides();
+    await vscode.workspace
+        .getConfiguration("codex-editor")
+        .update("gitBackendMode", mode, vscode.ConfigurationTarget.Global);
 };
 
 export const setNativeGitAvailable = (available: boolean): void => {
@@ -199,55 +99,37 @@ export const shouldUseNativeGit = (): boolean => {
 
 export type SqliteToolMode = "auto" | "builtin" | "force-builtin";
 
+const SQLITE_TOOL_MODE_KEY = "toolPreferences.sqliteToolMode";
+
 export const getSqliteToolMode = (): SqliteToolMode => {
     if (!cachedContext) {
         return "auto";
     }
-    const persisted = cachedContext.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY) ?? "auto";
-    if (persisted === "force-builtin") {
-        return persisted;
-    }
-    return sessionOverrides.sqlite ?? "auto";
+    return cachedContext.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY) ?? "auto";
 };
 
 export const setSqliteToolMode = async (mode: SqliteToolMode): Promise<void> => {
     if (!cachedContext) {
         return;
     }
-    if (mode === "builtin") {
-        sessionOverrides.sqlite = mode;
-        await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, "auto");
-    } else {
-        delete sessionOverrides.sqlite;
-        await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, mode);
-    }
-    await persistSessionOverrides();
+    await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, mode);
 };
 
 /**
- * Preserve a temporary compatibility choice when Codex intentionally opens
- * another project window. A normal application restart has no handoff marker,
- * so the choice expires with the previous editor session.
+ * "builtin" is a session-level compatibility choice. On the next extension
+ * activation, retry optimized tools unless the user explicitly selected the
+ * persistent "force-builtin" lock.
  */
-export const markProjectToolModeHandoff = async (targetUri: vscode.Uri): Promise<void> => {
-    if (!cachedContext || Object.keys(sessionOverrides).length === 0) {
-        return;
+export const resetTemporaryBuiltinModesOnStartup = async (): Promise<void> => {
+    if (getAudioToolMode() === "builtin") {
+        await setAudioToolMode("auto");
     }
-    const handoff: ProjectToolHandoff = {
-        sourceSessionId: vscode.env.sessionId,
-        targetPath: targetUri.fsPath,
-        createdAt: Date.now(),
-        overrides: { ...sessionOverrides },
-    };
-    await cachedContext.globalState.update(PROJECT_HANDOFF_KEY, handoff);
-};
-
-export const openFolderWithToolModeHandoff = async (
-    targetUri: vscode.Uri,
-    newWindow?: boolean,
-): Promise<void> => {
-    await markProjectToolModeHandoff(targetUri);
-    await vscode.commands.executeCommand("vscode.openFolder", targetUri, newWindow);
+    if (getGitToolMode() === "builtin") {
+        await setGitToolMode("auto");
+    }
+    if (getSqliteToolMode() === "builtin") {
+        await setSqliteToolMode("auto");
+    }
 };
 
 /**

--- a/src/utils/toolPreferences.ts
+++ b/src/utils/toolPreferences.ts
@@ -8,25 +8,113 @@ import { isNativeSqliteReady } from "./nativeSqlite";
 export type AudioToolMode = "auto" | "builtin" | "force-builtin";
 
 const AUDIO_TOOL_MODE_KEY = "toolPreferences.audioToolMode";
+const SQLITE_TOOL_MODE_KEY = "toolPreferences.sqliteToolMode";
+const SESSION_OVERRIDES_KEY = "toolPreferences.sessionOverrides";
+const PROJECT_HANDOFF_KEY = "toolPreferences.projectHandoff";
 
 let cachedContext: vscode.ExtensionContext | undefined;
+type SessionToolOverrides = Partial<{
+    audio: "builtin";
+    git: "builtin";
+    sqlite: "builtin";
+}>;
+interface StoredSessionOverrides {
+    sessionId: string;
+    overrides: SessionToolOverrides;
+}
+interface ProjectToolHandoff {
+    sourceSessionId: string;
+    targetPath: string;
+    createdAt: number;
+    overrides: SessionToolOverrides;
+}
+let sessionOverrides: SessionToolOverrides = {};
+
+const persistSessionOverrides = async (): Promise<void> => {
+    if (!cachedContext) {
+        return;
+    }
+    if (Object.keys(sessionOverrides).length === 0) {
+        await cachedContext.globalState.update(SESSION_OVERRIDES_KEY, undefined);
+        return;
+    }
+    const state: StoredSessionOverrides = {
+        sessionId: vscode.env.sessionId,
+        overrides: sessionOverrides,
+    };
+    await cachedContext.globalState.update(SESSION_OVERRIDES_KEY, state);
+};
 
 export const initToolPreferences = (context: vscode.ExtensionContext): void => {
     cachedContext = context;
+    sessionOverrides = {};
+
+    const stored = context.globalState.get<StoredSessionOverrides>(SESSION_OVERRIDES_KEY);
+    const handoff = context.globalState.get<ProjectToolHandoff>(PROJECT_HANDOFF_KEY);
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+    if (
+        handoff &&
+        Date.now() - handoff.createdAt < 120_000 &&
+        handoff.targetPath === workspacePath &&
+        handoff.sourceSessionId !== vscode.env.sessionId
+    ) {
+        sessionOverrides = { ...handoff.overrides };
+        void context.globalState.update(PROJECT_HANDOFF_KEY, undefined);
+        void persistSessionOverrides();
+    } else if (stored?.sessionId === vscode.env.sessionId) {
+        sessionOverrides = { ...stored.overrides };
+    } else {
+        void context.globalState.update(SESSION_OVERRIDES_KEY, undefined);
+        void context.globalState.update(PROJECT_HANDOFF_KEY, undefined);
+    }
+
+    // Migrate the old persistent "builtin" preference into this session only.
+    const persistedAudioMode = context.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY);
+    if (!sessionOverrides.audio && persistedAudioMode === "builtin") {
+        sessionOverrides.audio = "builtin";
+        void context.globalState.update(AUDIO_TOOL_MODE_KEY, "auto");
+    }
+    const persistedSqliteMode = context.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY);
+    if (!sessionOverrides.sqlite && persistedSqliteMode === "builtin") {
+        sessionOverrides.sqlite = "builtin";
+        void context.globalState.update(SQLITE_TOOL_MODE_KEY, "auto");
+    }
+    const persistedGitMode = vscode.workspace
+        .getConfiguration("codex-editor")
+        .get<GitToolMode>("gitBackendMode");
+    if (!sessionOverrides.git && persistedGitMode === "builtin") {
+        sessionOverrides.git = "builtin";
+        void vscode.workspace
+            .getConfiguration("codex-editor")
+            .update("gitBackendMode", "auto", vscode.ConfigurationTarget.Global);
+    }
+    void persistSessionOverrides();
 };
 
 export const getAudioToolMode = (): AudioToolMode => {
     if (!cachedContext) {
         return "auto";
     }
-    return cachedContext.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY) ?? "auto";
+    const persisted = cachedContext.globalState.get<AudioToolMode>(AUDIO_TOOL_MODE_KEY) ?? "auto";
+    if (persisted === "force-builtin") {
+        return persisted;
+    }
+    return sessionOverrides.audio ?? "auto";
 };
 
 export const setAudioToolMode = async (mode: AudioToolMode): Promise<void> => {
     if (!cachedContext) {
         return;
     }
-    await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, mode);
+    if (mode === "builtin") {
+        sessionOverrides.audio = mode;
+        await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, "auto");
+    } else {
+        delete sessionOverrides.audio;
+        await cachedContext.globalState.update(AUDIO_TOOL_MODE_KEY, mode);
+    }
+    await persistSessionOverrides();
 };
 
 /**
@@ -57,16 +145,28 @@ let _nativeGitAvailable = false;
  * so they always agree on which git backend to use.
  */
 export const getGitToolMode = (): GitToolMode => {
-    const mode = vscode.workspace
+    const persisted = vscode.workspace
         .getConfiguration("codex-editor")
         .get<GitToolMode>("gitBackendMode");
-    return mode ?? "auto";
+    if (persisted === "force-builtin") {
+        return persisted;
+    }
+    return sessionOverrides.git ?? "auto";
 };
 
 export const setGitToolMode = async (mode: GitToolMode): Promise<void> => {
-    await vscode.workspace
-        .getConfiguration("codex-editor")
-        .update("gitBackendMode", mode, vscode.ConfigurationTarget.Global);
+    if (mode === "builtin") {
+        sessionOverrides.git = mode;
+        await vscode.workspace
+            .getConfiguration("codex-editor")
+            .update("gitBackendMode", "auto", vscode.ConfigurationTarget.Global);
+    } else {
+        delete sessionOverrides.git;
+        await vscode.workspace
+            .getConfiguration("codex-editor")
+            .update("gitBackendMode", mode, vscode.ConfigurationTarget.Global);
+    }
+    await persistSessionOverrides();
 };
 
 export const setNativeGitAvailable = (available: boolean): void => {
@@ -99,20 +199,55 @@ export const shouldUseNativeGit = (): boolean => {
 
 export type SqliteToolMode = "auto" | "builtin" | "force-builtin";
 
-const SQLITE_TOOL_MODE_KEY = "toolPreferences.sqliteToolMode";
-
 export const getSqliteToolMode = (): SqliteToolMode => {
     if (!cachedContext) {
         return "auto";
     }
-    return cachedContext.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY) ?? "auto";
+    const persisted = cachedContext.globalState.get<SqliteToolMode>(SQLITE_TOOL_MODE_KEY) ?? "auto";
+    if (persisted === "force-builtin") {
+        return persisted;
+    }
+    return sessionOverrides.sqlite ?? "auto";
 };
 
 export const setSqliteToolMode = async (mode: SqliteToolMode): Promise<void> => {
     if (!cachedContext) {
         return;
     }
-    await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, mode);
+    if (mode === "builtin") {
+        sessionOverrides.sqlite = mode;
+        await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, "auto");
+    } else {
+        delete sessionOverrides.sqlite;
+        await cachedContext.globalState.update(SQLITE_TOOL_MODE_KEY, mode);
+    }
+    await persistSessionOverrides();
+};
+
+/**
+ * Preserve a temporary compatibility choice when Codex intentionally opens
+ * another project window. A normal application restart has no handoff marker,
+ * so the choice expires with the previous editor session.
+ */
+export const markProjectToolModeHandoff = async (targetUri: vscode.Uri): Promise<void> => {
+    if (!cachedContext || Object.keys(sessionOverrides).length === 0) {
+        return;
+    }
+    const handoff: ProjectToolHandoff = {
+        sourceSessionId: vscode.env.sessionId,
+        targetPath: targetUri.fsPath,
+        createdAt: Date.now(),
+        overrides: { ...sessionOverrides },
+    };
+    await cachedContext.globalState.update(PROJECT_HANDOFF_KEY, handoff);
+};
+
+export const openFolderWithToolModeHandoff = async (
+    targetUri: vscode.Uri,
+    newWindow?: boolean,
+): Promise<void> => {
+    await markProjectToolModeHandoff(targetUri);
+    await vscode.commands.executeCommand("vscode.openFolder", targetUri, newWindow);
 };
 
 /**

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -130,7 +130,31 @@ function formatToolList(labels: string[]): string {
     if (labels.length === 2) {
         return `${labels[0]} and ${labels[1]}`;
     }
-    return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+    return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}
+
+function getToolImpactNotice(labels: string[]): string {
+    const notices: string[] = [];
+    const hasSearch = labels.includes("Search");
+    const hasSync = labels.includes("Sync");
+
+    if (hasSearch && hasSync) {
+        notices.push(
+            "Search and Sync may be slower, and Sync may make synchronized project files grow larger for everyone on the project",
+        );
+    } else if (hasSearch) {
+        notices.push("Search may be slower");
+    } else if (hasSync) {
+        notices.push(
+            "Sync may be slower and may make synchronized project files grow larger for everyone on the project",
+        );
+    }
+
+    if (labels.includes("Audio")) {
+        notices.push("Audio is limited to WAV format");
+    }
+
+    return `${notices.join(". ")}.`;
 }
 
 /**
@@ -146,7 +170,6 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             mode: getSqliteToolMode(),
             unsupported: result.platformUnsupported.sqlite,
             nativePlatformSupported: result.nativePlatformSupported.sqlite,
-            impact: "Search may be slower",
         },
         {
             label: "Sync",
@@ -154,7 +177,6 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             mode: getGitToolMode(),
             unsupported: result.platformUnsupported.git,
             nativePlatformSupported: result.nativePlatformSupported.git,
-            impact: "Sync may be slower and can make synchronized project files grow larger for everyone",
         },
         {
             label: "Audio",
@@ -162,9 +184,6 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             mode: getAudioToolMode(),
             unsupported: result.platformUnsupported.ffmpeg,
             nativePlatformSupported: result.nativePlatformSupported.ffmpeg,
-            impact: result.nativePlatformSupported.ffmpeg
-                ? "Audio may be limited"
-                : "Audio is running through x64 emulation",
         },
     ];
     const fallbackTools = tools.filter(
@@ -177,8 +196,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
         return null;
     }
 
-    const fallbackLabels = formatToolList(fallbackTools.map(({ label }) => label));
-    const impactNotice = formatToolList(fallbackTools.map(({ impact }) => impact));
+    const impactNotice = getToolImpactNotice(fallbackTools.map(({ label }) => label));
     const reasonNotices = [
         {
             labels: fallbackTools
@@ -207,7 +225,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
         .filter(({ labels }) => labels.length > 0)
         .map(({ labels, message }) => message(labels));
 
-    return `Compatibility mode active for ${fallbackLabels}. ${impactNotice}. ${reasonNotices.join(" ")}`;
+    return `${impactNotice} ${reasonNotices.join(" ")}`;
 }
 
 export type OptimizedToolKey = "sqlite" | "git" | "ffmpeg";

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -164,34 +164,34 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
                 .filter(({ unsupported }) => unsupported)
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Native ${formatToolList(labels)} tools aren't supported on this platform.`,
+                `Optimized ${formatToolList(labels)} tools aren't supported on this device.`,
         },
         {
             labels: fallbackTools
                 .filter(({ nativeAvailable, unsupported }) => !nativeAvailable && !unsupported)
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Native ${formatToolList(labels)} tools aren't available.`,
+                `Optimized ${formatToolList(labels)} tools aren't available.`,
         },
         {
             labels: fallbackTools
                 .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "builtin")
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Fallback mode is selected for ${formatToolList(labels)}.`,
+                `Compatibility mode is selected for ${formatToolList(labels)}.`,
         },
         {
             labels: fallbackTools
                 .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "force-builtin")
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Fallback mode is required for ${formatToolList(labels)}.`,
+                `Compatibility mode is required for ${formatToolList(labels)}.`,
         },
     ]
         .filter(({ labels }) => labels.length > 0)
         .map(({ labels, message }) => message(labels));
 
-    return `Fallback active for ${fallbackLabels}. ${impactNotice}. ${reasonNotices.join(" ")}`;
+    return `Compatibility mode active for ${fallbackLabels}. ${impactNotice}. ${reasonNotices.join(" ")}`;
 }
 
 /**

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -165,9 +165,12 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             impact: "Audio is WAV-only",
         },
     ];
+    // A user-selected or administratively locked compatibility mode is
+    // intentional. Only report compatibility that is active unexpectedly
+    // because the optimized implementation is unavailable.
     const fallbackTools = tools.filter(
         ({ nativeAvailable, mode }) =>
-            !nativeAvailable || mode === "builtin" || mode === "force-builtin",
+            !nativeAvailable && mode !== "builtin" && mode !== "force-builtin",
     );
 
     if (fallbackTools.length === 0) {
@@ -192,20 +195,6 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
                 .map(({ label }) => label),
             message: (labels: string[]) =>
                 `Optimized ${formatToolList(labels)} tools aren't available.`,
-        },
-        {
-            labels: fallbackTools
-                .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "builtin")
-                .map(({ label }) => label),
-            message: (labels: string[]) =>
-                `Compatibility mode is selected for ${formatToolList(labels)}.`,
-        },
-        {
-            labels: fallbackTools
-                .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "force-builtin")
-                .map(({ label }) => label),
-            message: (labels: string[]) =>
-                `Compatibility mode is locked for ${formatToolList(labels)}.`,
         },
     ]
         .filter(({ labels }) => labels.length > 0)

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -241,7 +241,7 @@ export function getToolsEligibleForOptimization(result: ToolCheckResult): Optimi
         eligible.push("git");
     }
     if (
-        result.nativePlatformSupported.ffmpeg &&
+        !result.platformUnsupported.ffmpeg &&
         audioMode !== "force-builtin" &&
         (!result.ffmpeg || audioMode === "builtin")
     ) {

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -154,7 +154,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             mode: getGitToolMode(),
             unsupported: result.platformUnsupported.git,
             nativePlatformSupported: result.nativePlatformSupported.git,
-            impact: "Sync may be limited",
+            impact: "Sync may be slower and can make synchronized project files grow larger for everyone",
         },
         {
             label: "Audio",
@@ -168,9 +168,9 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
         },
     ];
     const fallbackTools = tools.filter(
-        ({ nativeAvailable, mode, nativePlatformSupported }) =>
+        ({ nativeAvailable, mode }) =>
             mode !== "force-builtin"
-            && (!nativeAvailable || mode === "builtin" || !nativePlatformSupported),
+            && (!nativeAvailable || mode === "builtin"),
     );
 
     if (fallbackTools.length === 0) {

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -106,6 +106,95 @@ export function getUnavailableTools(result: ToolCheckResult): string[] {
 }
 
 /**
+ * Format a short human-readable list with "and" before the final item.
+ */
+function formatToolList(labels: string[]): string {
+    if (labels.length < 2) {
+        return labels[0] ?? "";
+    }
+    if (labels.length === 2) {
+        return `${labels[0]} and ${labels[1]}`;
+    }
+    return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
+
+/**
+ * Returns a startup notice when any feature is running on its fallback
+ * implementation instead of its native tool, including the reason when
+ * known and the practical limitation for each feature.
+ */
+export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
+    const tools = [
+        {
+            label: "Search",
+            nativeAvailable: result.nativeSqliteAvailable,
+            mode: getSqliteToolMode(),
+            unsupported: result.platformUnsupported.sqlite,
+            impact: "Search may be slower",
+        },
+        {
+            label: "Sync",
+            nativeAvailable: result.nativeGitAvailable,
+            mode: getGitToolMode(),
+            unsupported: result.platformUnsupported.git,
+            impact: "Sync may be limited",
+        },
+        {
+            label: "Audio",
+            nativeAvailable: result.ffmpeg,
+            mode: getAudioToolMode(),
+            unsupported: result.platformUnsupported.ffmpeg,
+            impact: "Audio is WAV-only",
+        },
+    ];
+    const fallbackTools = tools.filter(
+        ({ nativeAvailable, mode }) =>
+            !nativeAvailable || mode === "builtin" || mode === "force-builtin",
+    );
+
+    if (fallbackTools.length === 0) {
+        return null;
+    }
+
+    const fallbackLabels = formatToolList(fallbackTools.map(({ label }) => label));
+    const impactNotice = formatToolList(fallbackTools.map(({ impact }) => impact));
+    const reasonNotices = [
+        {
+            labels: fallbackTools
+                .filter(({ unsupported }) => unsupported)
+                .map(({ label }) => label),
+            message: (labels: string[]) =>
+                `Native ${formatToolList(labels)} tools aren't supported on this platform.`,
+        },
+        {
+            labels: fallbackTools
+                .filter(({ nativeAvailable, unsupported }) => !nativeAvailable && !unsupported)
+                .map(({ label }) => label),
+            message: (labels: string[]) =>
+                `Native ${formatToolList(labels)} tools aren't available.`,
+        },
+        {
+            labels: fallbackTools
+                .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "builtin")
+                .map(({ label }) => label),
+            message: (labels: string[]) =>
+                `Fallback mode is selected for ${formatToolList(labels)}.`,
+        },
+        {
+            labels: fallbackTools
+                .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "force-builtin")
+                .map(({ label }) => label),
+            message: (labels: string[]) =>
+                `Fallback mode is required for ${formatToolList(labels)}.`,
+        },
+    ]
+        .filter(({ labels }) => labels.length > 0)
+        .map(({ labels, message }) => message(labels));
+
+    return `Fallback active for ${fallbackLabels}. ${impactNotice}. ${reasonNotices.join(" ")}`;
+}
+
+/**
  * Permanently mark FFmpeg as required. Once set, it stays set forever.
  * On subsequent startups the tool will be checked and downloaded if missing.
  */

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -162,15 +162,15 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             mode: getAudioToolMode(),
             unsupported: result.platformUnsupported.ffmpeg,
             nativePlatformSupported: result.nativePlatformSupported.ffmpeg,
-            impact: "Audio is WAV-only",
+            impact: result.nativePlatformSupported.ffmpeg
+                ? "Audio may be limited"
+                : "Audio is running through x64 emulation",
         },
     ];
-    // A user-selected or administratively locked compatibility mode is
-    // intentional. Only report compatibility that is active unexpectedly
-    // because the optimized implementation is unavailable.
     const fallbackTools = tools.filter(
-        ({ nativeAvailable, mode }) =>
-            !nativeAvailable && mode !== "builtin" && mode !== "force-builtin",
+        ({ nativeAvailable, mode, nativePlatformSupported }) =>
+            mode !== "force-builtin"
+            && (!nativeAvailable || mode === "builtin" || !nativePlatformSupported),
     );
 
     if (fallbackTools.length === 0) {
@@ -195,6 +195,13 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
                 .map(({ label }) => label),
             message: (labels: string[]) =>
                 `Optimized ${formatToolList(labels)} tools aren't available.`,
+        },
+        {
+            labels: fallbackTools
+                .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "builtin")
+                .map(({ label }) => label),
+            message: (labels: string[]) =>
+                `Compatibility mode is selected for ${formatToolList(labels)}.`,
         },
     ]
         .filter(({ labels }) => labels.length > 0)

--- a/src/utils/toolsManager.ts
+++ b/src/utils/toolsManager.ts
@@ -5,7 +5,11 @@ import * as fs from "fs";
 import { isNativeSqliteReady } from "./nativeSqlite";
 import { isDatabaseReady } from "./sqliteDatabaseFactory";
 import { getAudioToolMode, getGitToolMode, getSqliteToolMode } from "./toolPreferences";
-import { getFfmpegBinaryPath, isFfmpegNativelySupported } from "./ffmpegManager";
+import {
+    getFfmpegBinaryPath,
+    isFfmpegNativeAssetSupported,
+    isFfmpegNativelySupported,
+} from "./ffmpegManager";
 import { isSqliteNativelySupported } from "./sqliteNativeBinaryManager";
 import type { FrontierAPI } from "../../webviews/codex-webviews/src/StartupFlow/types";
 
@@ -21,12 +25,17 @@ export interface ToolCheckResult {
     nativeSqliteAvailable: boolean;
     ffmpeg: boolean;
     /**
-     * Per-tool flag set to true when the CURRENT OS/arch has no prebuilt
-     * native asset available. On these platforms the "Download and install"
-     * action is a guaranteed no-op, so the UI should render "Not available
-     * on this platform" instead of a download button.
+     * Per-tool flag set to true when the CURRENT OS/arch has no usable
+     * compatible asset available. On these platforms the "Download and
+     * install" action is a guaranteed no-op.
      */
     platformUnsupported: {
+        git: boolean;
+        sqlite: boolean;
+        ffmpeg: boolean;
+    };
+    /** True only when a directly matching native asset exists for the OS/arch. */
+    nativePlatformSupported: {
         git: boolean;
         sqlite: boolean;
         ffmpeg: boolean;
@@ -76,6 +85,11 @@ export async function checkTools(
         sqlite: !isSqliteNativelySupported(),
         ffmpeg: !isFfmpegNativelySupported(),
     };
+    const nativePlatformSupported = {
+        git: frontierApi?.isGitBinaryNativelySupported?.() !== false,
+        sqlite: isSqliteNativelySupported(),
+        ffmpeg: isFfmpegNativeAssetSupported(),
+    };
 
     return {
         git,
@@ -84,6 +98,7 @@ export async function checkTools(
         nativeSqliteAvailable,
         ffmpeg,
         platformUnsupported,
+        nativePlatformSupported,
     };
 }
 
@@ -130,6 +145,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             nativeAvailable: result.nativeSqliteAvailable,
             mode: getSqliteToolMode(),
             unsupported: result.platformUnsupported.sqlite,
+            nativePlatformSupported: result.nativePlatformSupported.sqlite,
             impact: "Search may be slower",
         },
         {
@@ -137,6 +153,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             nativeAvailable: result.nativeGitAvailable,
             mode: getGitToolMode(),
             unsupported: result.platformUnsupported.git,
+            nativePlatformSupported: result.nativePlatformSupported.git,
             impact: "Sync may be limited",
         },
         {
@@ -144,6 +161,7 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
             nativeAvailable: result.ffmpeg,
             mode: getAudioToolMode(),
             unsupported: result.platformUnsupported.ffmpeg,
+            nativePlatformSupported: result.nativePlatformSupported.ffmpeg,
             impact: "Audio is WAV-only",
         },
     ];
@@ -161,14 +179,16 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
     const reasonNotices = [
         {
             labels: fallbackTools
-                .filter(({ unsupported }) => unsupported)
+                .filter(({ unsupported, nativePlatformSupported }) =>
+                    unsupported || !nativePlatformSupported)
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Optimized ${formatToolList(labels)} tools aren't supported on this device.`,
+                `Optimized ${formatToolList(labels)} tools aren't available natively on this device.`,
         },
         {
             labels: fallbackTools
-                .filter(({ nativeAvailable, unsupported }) => !nativeAvailable && !unsupported)
+                .filter(({ nativeAvailable, unsupported, nativePlatformSupported }) =>
+                    !nativeAvailable && !unsupported && nativePlatformSupported)
                 .map(({ label }) => label),
             message: (labels: string[]) =>
                 `Optimized ${formatToolList(labels)} tools aren't available.`,
@@ -185,13 +205,49 @@ export function getFallbackToolsNotice(result: ToolCheckResult): string | null {
                 .filter(({ nativeAvailable, mode }) => nativeAvailable && mode === "force-builtin")
                 .map(({ label }) => label),
             message: (labels: string[]) =>
-                `Compatibility mode is required for ${formatToolList(labels)}.`,
+                `Compatibility mode is locked for ${formatToolList(labels)}.`,
         },
     ]
         .filter(({ labels }) => labels.length > 0)
         .map(({ labels, message }) => message(labels));
 
     return `Compatibility mode active for ${fallbackLabels}. ${impactNotice}. ${reasonNotices.join(" ")}`;
+}
+
+export type OptimizedToolKey = "sqlite" | "git" | "ffmpeg";
+
+/**
+ * Return tools that can be switched to an optimized native implementation.
+ * Unsupported platforms and force-builtin preferences are deliberately
+ * excluded because the action cannot change those states.
+ */
+export function getToolsEligibleForOptimization(result: ToolCheckResult): OptimizedToolKey[] {
+    const eligible: OptimizedToolKey[] = [];
+    const sqliteMode = getSqliteToolMode();
+    const gitMode = getGitToolMode();
+    const audioMode = getAudioToolMode();
+    if (
+        result.nativePlatformSupported.sqlite &&
+        sqliteMode !== "force-builtin" &&
+        (!result.nativeSqliteAvailable || sqliteMode === "builtin")
+    ) {
+        eligible.push("sqlite");
+    }
+    if (
+        result.nativePlatformSupported.git &&
+        gitMode !== "force-builtin" &&
+        (!result.nativeGitAvailable || gitMode === "builtin")
+    ) {
+        eligible.push("git");
+    }
+    if (
+        result.nativePlatformSupported.ffmpeg &&
+        audioMode !== "force-builtin" &&
+        (!result.ffmpeg || audioMode === "builtin")
+    ) {
+        eligible.push("ffmpeg");
+    }
+    return eligible;
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2817,10 +2817,10 @@ export interface PlatformUnsupportedFlags {
 }
 
 export type MessagesToMissingToolsWarning =
-    | { command: "showWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags; }
-    | { command: "updateWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags; }
-    | { command: "showToolsStatus"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; syncInProgress?: boolean; audioProcessingInProgress?: boolean; platformUnsupported?: PlatformUnsupportedFlags; }
-    | { command: "toolDownloadResult"; tool: "sqlite" | "git" | "ffmpeg"; success: boolean; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; platformUnsupported?: PlatformUnsupportedFlags; }
+    | { command: "showWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags; nativePlatformSupported?: PlatformUnsupportedFlags; }
+    | { command: "updateWarnings"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; platformUnsupported?: PlatformUnsupportedFlags; nativePlatformSupported?: PlatformUnsupportedFlags; }
+    | { command: "showToolsStatus"; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; syncInProgress?: boolean; audioProcessingInProgress?: boolean; platformUnsupported?: PlatformUnsupportedFlags; nativePlatformSupported?: PlatformUnsupportedFlags; }
+    | { command: "toolDownloadResult"; tool: "sqlite" | "git" | "ffmpeg"; success: boolean; git: boolean; nativeGitAvailable?: boolean; sqlite: boolean; nativeSqliteAvailable?: boolean; ffmpeg: boolean; audioToolMode: AudioToolMode; gitToolMode: GitToolMode; sqliteToolMode: SqliteToolMode; platformUnsupported?: PlatformUnsupportedFlags; nativePlatformSupported?: PlatformUnsupportedFlags; }
     | { command: "audioModeChanged"; audioToolMode: AudioToolMode; ffmpeg: boolean; }
     | { command: "gitModeChanged"; gitToolMode: GitToolMode; git: boolean; nativeGitAvailable?: boolean; }
     | { command: "sqliteModeChanged"; sqliteToolMode: SqliteToolMode; sqlite: boolean; nativeSqliteAvailable?: boolean; }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1307,6 +1307,14 @@ type ProjectUserVersionEntry = {
     updatedAt: number;
 };
 
+export type NativeToolKey = "search" | "sync" | "audio";
+
+export type NativeToolStatusEntry = {
+    username: string;
+    timestamp: number;
+    nonNative: NativeToolKey[];
+};
+
 /* This is the project metadata that is saved in the metadata.json file */
 type ProjectMetadata = {
     projectName?: string;
@@ -1350,6 +1358,7 @@ type ProjectMetadata = {
         /** List of users that should be forced to restore/update their project when opening */
         initiateRemoteUpdatingFor?: RemoteUpdatingEntry[];
         abbreviation?: string;
+        nativeToolStatus?: NativeToolStatusEntry[];
         /** Project swap information for swapping to a new Git repository */
         projectSwap?: ProjectSwapInfo;
     };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1359,6 +1359,7 @@ type ProjectMetadata = {
         initiateRemoteUpdatingFor?: RemoteUpdatingEntry[];
         abbreviation?: string;
         nativeToolStatus?: NativeToolStatusEntry[];
+        nativeToolStatusHistory?: NativeToolStatusEntry[];
         /** Project swap information for swapping to a new Git repository */
         projectSwap?: ProjectSwapInfo;
     };

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -443,7 +443,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         && !isBuiltinMode(sqliteToolMode)
         && status.nativeGitAvailable && status.nativePlatformSupported.git
         && !isBuiltinMode(gitToolMode)
-        && status.ffmpeg && status.nativePlatformSupported.ffmpeg
+        && status.ffmpeg
         && !isBuiltinMode(audioToolMode);
 
     const getToolState = (
@@ -462,8 +462,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         const statusLabel =
             unsupported ? "Not available on this platform"
             : forced ? "Fallback Tools (locked)"
-            : nativeAvailable && !usingBuiltIn && nativePlatformSupported ? "Installed and Running Native Tools"
-            : nativeAvailable && !usingBuiltIn ? "Running Emulated Fallback Tools"
+            : nativeAvailable && !usingBuiltIn ? "Installed and Running Native Tools"
             : nativeAvailable && usingBuiltIn ? "Installed and Running Fallback Tools"
             : operational ? "Fallback Tools Active"
             : nativePlatformSupported ? "Native Tools Not Installed"
@@ -474,7 +473,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
             : nativeAvailable ? "Use Fallback Tools"
             : undefined;
         const showDownload = !forced && !nativeAvailable && !unsupported;
-        const showToggle = forced || nativeAvailable;
+        const showToggle = !unsupported && (forced || nativeAvailable);
 
         return { forced, usingBuiltIn, severity, statusLabel, toggleLabel, showDownload, showToggle };
     };
@@ -577,8 +576,6 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         description={
                             status.platformUnsupported.ffmpeg
                                 ? "Native audio tools are not available on this device. Codex is using fallback tools with limited format support (.wav only)."
-                                : status.ffmpeg && !status.nativePlatformSupported.ffmpeg
-                                    ? "Audio tools are emulating x64 on ARM64."
                                 : audio.usingBuiltIn
                                     ? TOOL_INFO.ffmpeg.descriptions.limited
                                     : TOOL_INFO.ffmpeg.descriptions.available

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -451,11 +451,12 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         nativeAvailable: boolean,
         unsupported: boolean,
         nativePlatformSupported: boolean,
+        operational: boolean,
     ) => {
         const forced = isForced(mode);
         const usingBuiltIn = isBuiltinMode(mode) || !nativeAvailable;
         const severity: "ok" | "warning" | "error" =
-            !nativeAvailable && !forced ? "error"
+            !operational && !forced ? "error"
             : isBuiltinMode(mode) ? "warning"
             : "ok";
         const statusLabel =
@@ -464,8 +465,9 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
             : nativeAvailable && !usingBuiltIn && nativePlatformSupported ? "Installed and Running Optimized Tools"
             : nativeAvailable && !usingBuiltIn ? "Running Emulated Compatibility Tools"
             : nativeAvailable && usingBuiltIn ? "Installed and Running Compatibility Tools"
-            : nativePlatformSupported ? "Not Installed \u2013 Compatibility Tools Active"
-            : "Not Installed \u2013 Compatibility Tools Available";
+            : operational ? "Compatibility Tools Active"
+            : nativePlatformSupported ? "Optimized Tools Not Installed"
+            : "Compatibility Tools Unavailable";
         const toggleLabel =
             forced ? "Unlock Optimized Tools"
             : nativeAvailable && usingBuiltIn ? "Use Optimized Tools"
@@ -482,18 +484,21 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
         status.nativeSqliteAvailable,
         status.platformUnsupported.sqlite,
         status.nativePlatformSupported.sqlite,
+        status.sqlite,
     );
     const git = getToolState(
         gitToolMode,
         status.nativeGitAvailable,
         status.platformUnsupported.git,
         status.nativePlatformSupported.git,
+        status.git,
     );
     const audio = getToolState(
         audioToolMode,
         status.ffmpeg,
         status.platformUnsupported.ffmpeg,
         status.nativePlatformSupported.ffmpeg,
+        status.ffmpeg,
     );
 
     return (

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -29,12 +29,13 @@ interface ToolStatus {
      * replaced with a "Not available on this platform" indicator.
      */
     platformUnsupported: PlatformUnsupportedFlags;
+    nativePlatformSupported: PlatformUnsupportedFlags;
 }
 
 type ViewMode = "warnings" | "status";
-type AudioToolMode = "auto" | "builtin";
-type GitToolMode = "auto" | "builtin";
-type SqliteToolMode = "auto" | "builtin";
+type AudioToolMode = "auto" | "builtin" | "force-builtin";
+type GitToolMode = "auto" | "builtin" | "force-builtin";
+type SqliteToolMode = "auto" | "builtin" | "force-builtin";
 
 interface InitialState {
     status: ToolStatus;
@@ -52,6 +53,12 @@ const EMPTY_UNSUPPORTED: PlatformUnsupportedFlags = {
     ffmpeg: false,
 };
 
+const ALL_NATIVE_SUPPORTED: PlatformUnsupportedFlags = {
+    git: true,
+    sqlite: true,
+    ffmpeg: true,
+};
+
 function readPlatformUnsupported(source: unknown): PlatformUnsupportedFlags {
     const raw = (source as { platformUnsupported?: Partial<PlatformUnsupportedFlags> })
         ?.platformUnsupported;
@@ -62,6 +69,19 @@ function readPlatformUnsupported(source: unknown): PlatformUnsupportedFlags {
         git: raw.git === true,
         sqlite: raw.sqlite === true,
         ffmpeg: raw.ffmpeg === true,
+    };
+}
+
+function readNativePlatformSupported(source: unknown): PlatformUnsupportedFlags {
+    const raw = (source as { nativePlatformSupported?: Partial<PlatformUnsupportedFlags> })
+        ?.nativePlatformSupported;
+    if (!raw) {
+        return ALL_NATIVE_SUPPORTED;
+    }
+    return {
+        git: raw.git !== false,
+        sqlite: raw.sqlite !== false,
+        ffmpeg: raw.ffmpeg !== false,
     };
 }
 
@@ -77,6 +97,7 @@ function getInitialState(): InitialState | null {
                     nativeSqliteAvailable: data.nativeSqliteAvailable ?? data.sqlite,
                     ffmpeg: data.ffmpeg ?? false,
                     platformUnsupported: readPlatformUnsupported(data),
+                    nativePlatformSupported: readNativePlatformSupported(data),
                 },
                 mode: data.mode === "status" ? "status" : "warnings",
                 audioToolMode: data.audioToolMode ?? "auto",
@@ -157,6 +178,7 @@ export const MissingToolsWarning: React.FC = () => {
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
                     platformUnsupported: readPlatformUnsupported(message),
+                    nativePlatformSupported: readNativePlatformSupported(message),
                 });
                 setMode("warnings");
                 setRetrying(false);
@@ -168,6 +190,7 @@ export const MissingToolsWarning: React.FC = () => {
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
                     platformUnsupported: readPlatformUnsupported(message),
+                    nativePlatformSupported: readNativePlatformSupported(message),
                 });
                 setAudioToolMode(message.audioToolMode ?? "auto");
                 setGitToolMode(message.gitToolMode ?? "auto");
@@ -183,6 +206,7 @@ export const MissingToolsWarning: React.FC = () => {
                     nativeSqliteAvailable: message.nativeSqliteAvailable ?? message.sqlite,
                     ffmpeg: message.ffmpeg,
                     platformUnsupported: readPlatformUnsupported(message),
+                    nativePlatformSupported: readNativePlatformSupported(message),
                 });
                 if (message.audioToolMode) {
                     setAudioToolMode(message.audioToolMode);
@@ -341,9 +365,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-error",
         descriptions: {
-            available: "The native AI learning and search tools are installed and running.",
-            limited: "Using fallback tools. Native tools are installed but not active.",
-            builtinActive: "Using fallback tools. Full functionality is available but less performant.",
+            available: "Optimized search tools are installed and running.",
+            limited: "Compatibility tools are active. Optimized tools are installed but not selected.",
+            builtinActive: "Compatibility tools are active. Full functionality is available but may be slower.",
             missing: "The AI learning and search tools could not be set up. Projects cannot be opened or created without this component.",
         },
     },
@@ -352,9 +376,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-warning",
         descriptions: {
-            available: "Native sync tools are active. Syncing and collaboration are fully operational.",
-            limited: "Using fallback sync tools. Native sync tools are installed but not active.",
-            builtinActive: "Using fallback sync tools. Syncing and collaboration may be limited.",
+            available: "Optimized sync tools are active. Syncing and collaboration are fully operational.",
+            limited: "Compatibility sync tools are active. Optimized tools are installed but not selected.",
+            builtinActive: "Compatibility sync tools are active. Syncing and collaboration may be limited.",
         },
     },
     ffmpeg: {
@@ -362,9 +386,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-warning",
         descriptions: {
-            available: "Native audio tools are active. Full audio format support is available for import/export.",
-            limited: "Using fallback audio tools (.wav format). Full audio format support requires native audio tools.",
-            missing: "Native audio tools could not be set up. Using fallback audio tools (.wav only).",
+            available: "Optimized audio tools are active. Full audio format support is available for import/export.",
+            limited: "Compatibility audio tools are active (.wav format).",
+            missing: "Optimized audio tools could not be set up. Compatibility audio tools are active (.wav only).",
         },
     },
 } as const;
@@ -415,48 +439,62 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
     const isForced = (mode: string) => mode === "force-builtin";
     const isBuiltinMode = (mode: string) => mode === "builtin" || mode === "force-builtin";
 
-    const allOk = status.nativeSqliteAvailable && !isBuiltinMode(sqliteToolMode)
-        && status.nativeGitAvailable && !isBuiltinMode(gitToolMode)
-        && status.ffmpeg && !isBuiltinMode(audioToolMode);
+    const allOk = status.nativeSqliteAvailable && status.nativePlatformSupported.sqlite
+        && !isBuiltinMode(sqliteToolMode)
+        && status.nativeGitAvailable && status.nativePlatformSupported.git
+        && !isBuiltinMode(gitToolMode)
+        && status.ffmpeg && status.nativePlatformSupported.ffmpeg
+        && !isBuiltinMode(audioToolMode);
 
-    const getToolState = (mode: string, nativeAvailable: boolean, unsupported: boolean) => {
+    const getToolState = (
+        mode: string,
+        nativeAvailable: boolean,
+        unsupported: boolean,
+        nativePlatformSupported: boolean,
+    ) => {
         const forced = isForced(mode);
         const usingBuiltIn = isBuiltinMode(mode) || !nativeAvailable;
-        // Severity priority: a missing native binary is always an error
-        // (unless admin has locked us into force-builtin, which is a softer
-        // "warning" state). Only when the binary is installed does the
-        // user's "builtin" preference downgrade to a warning.
         const severity: "ok" | "warning" | "error" =
             !nativeAvailable && !forced ? "error"
             : isBuiltinMode(mode) ? "warning"
             : "ok";
         const statusLabel =
             unsupported ? "Not available on this platform"
-            : forced ? "Running Fallback Tools (locked)"
-            : nativeAvailable && !usingBuiltIn ? "Installed and Running Native Tools"
-            : nativeAvailable && usingBuiltIn ? "Installed and Running Fallback Tools"
-            : "Not Installed \u2013 Running Fallback Tools";
+            : forced ? "Compatibility Tools (locked)"
+            : nativeAvailable && !usingBuiltIn && nativePlatformSupported ? "Installed and Running Optimized Tools"
+            : nativeAvailable && !usingBuiltIn ? "Running Emulated Compatibility Tools"
+            : nativeAvailable && usingBuiltIn ? "Installed and Running Compatibility Tools"
+            : nativePlatformSupported ? "Not Installed \u2013 Compatibility Tools Active"
+            : "Not Installed \u2013 Compatibility Tools Available";
         const toggleLabel =
-            forced ? "Unlock Native Tools"
-            : nativeAvailable && usingBuiltIn ? "Use Native Tools"
-            : nativeAvailable ? "Use Fallback Tools"
+            forced ? "Unlock Optimized Tools"
+            : nativeAvailable && usingBuiltIn ? "Use Optimized Tools"
+            : nativeAvailable ? "Use Compatibility Tools"
             : undefined;
-        // A "builtin" preference must not hide the download button: if the
-        // native binary isn't installed, the user should always be able to
-        // install it (the download handler flips mode back to "auto" so the
-        // newly-installed binary is actually used). Only force-builtin (admin
-        // lock) or an unsupported platform hides the option — on unsupported
-        // platforms the download can never succeed, so we render a passive
-        // "Not available" badge instead.
         const showDownload = !forced && !nativeAvailable && !unsupported;
         const showToggle = forced || nativeAvailable;
 
         return { forced, usingBuiltIn, severity, statusLabel, toggleLabel, showDownload, showToggle };
     };
 
-    const sqlite = getToolState(sqliteToolMode, status.nativeSqliteAvailable, status.platformUnsupported.sqlite);
-    const git = getToolState(gitToolMode, status.nativeGitAvailable, status.platformUnsupported.git);
-    const audio = getToolState(audioToolMode, status.ffmpeg, status.platformUnsupported.ffmpeg);
+    const sqlite = getToolState(
+        sqliteToolMode,
+        status.nativeSqliteAvailable,
+        status.platformUnsupported.sqlite,
+        status.nativePlatformSupported.sqlite,
+    );
+    const git = getToolState(
+        gitToolMode,
+        status.nativeGitAvailable,
+        status.platformUnsupported.git,
+        status.nativePlatformSupported.git,
+    );
+    const audio = getToolState(
+        audioToolMode,
+        status.ffmpeg,
+        status.platformUnsupported.ffmpeg,
+        status.nativePlatformSupported.ffmpeg,
+    );
 
     return (
         <div className="flex items-center justify-center min-h-screen p-6">
@@ -473,8 +511,8 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         style={{ color: "var(--muted-foreground)" }}
                     >
                         {allOk
-                            ? "All native tools are installed and running."
-                            : "Some native tools are not fully configured. Codex is using fallback alternatives where needed."}
+                            ? "All optimized tools are installed and running."
+                            : "Some optimized tools are not fully configured. Codex is using compatibility tools where needed."}
                     </p>
                 </div>
 
@@ -483,7 +521,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.sqlite.name}
                         description={
                             status.platformUnsupported.sqlite
-                                ? "The native AI learning and search tools are not available on this platform. Codex is using its built-in fallback."
+                                ? "Optimized search tools are not available on this device. Codex is using compatibility tools."
                                 : sqlite.usingBuiltIn
                                     ? (status.sqlite ? TOOL_INFO.sqlite.descriptions.builtinActive : TOOL_INFO.sqlite.descriptions.missing)
                                     : TOOL_INFO.sqlite.descriptions.available
@@ -494,6 +532,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         downloadState={downloadState.sqlite}
                         onDownload={sqlite.showDownload ? () => onDownloadTool("sqlite") : undefined}
                         platformUnsupported={status.platformUnsupported.sqlite}
+                        nativePlatformSupported={status.nativePlatformSupported.sqlite}
                         toggleLabel={sqlite.toggleLabel}
                         onToggle={sqlite.showToggle ? onToggleSqliteMode : undefined}
                         onDelete={deleteMode ? () => onDeleteTool("sqlite") : undefined}
@@ -506,7 +545,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.git.name}
                         description={
                             status.platformUnsupported.git
-                                ? "Native sync tools are not available on this platform. Codex is using its built-in fallback; syncing and collaboration may be limited."
+                                ? "Optimized sync tools are not available on this device. Codex is using compatibility tools; syncing and collaboration may be limited."
                                 : git.usingBuiltIn
                                     ? TOOL_INFO.git.descriptions.builtinActive
                                     : TOOL_INFO.git.descriptions.available
@@ -517,6 +556,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         downloadState={downloadState.git}
                         onDownload={git.showDownload ? () => onDownloadTool("git") : undefined}
                         platformUnsupported={status.platformUnsupported.git}
+                        nativePlatformSupported={status.nativePlatformSupported.git}
                         toggleLabel={git.toggleLabel}
                         onToggle={git.showToggle ? onToggleGitMode : undefined}
                         toggleDisabled={syncInProgress}
@@ -531,7 +571,9 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.ffmpeg.name}
                         description={
                             status.platformUnsupported.ffmpeg
-                                ? "Native audio tools are not available on this platform. Codex is using its built-in fallback with limited format support (.wav only)."
+                                ? "Optimized audio tools are not available on this device. Codex is using compatibility tools with limited format support (.wav only)."
+                                : status.ffmpeg && !status.nativePlatformSupported.ffmpeg
+                                    ? "Audio tools are emulating x64 on ARM64."
                                 : audio.usingBuiltIn
                                     ? TOOL_INFO.ffmpeg.descriptions.limited
                                     : TOOL_INFO.ffmpeg.descriptions.available
@@ -542,6 +584,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         downloadState={downloadState.ffmpeg}
                         onDownload={audio.showDownload ? () => onDownloadTool("ffmpeg") : undefined}
                         platformUnsupported={status.platformUnsupported.ffmpeg}
+                        nativePlatformSupported={status.nativePlatformSupported.ffmpeg}
                         toggleLabel={audio.toggleLabel}
                         onToggle={audio.showToggle ? onToggleAudioMode : undefined}
                         toggleDisabled={audioProcessingInProgress}
@@ -656,7 +699,7 @@ const WarningsView: React.FC<WarningsViewProps> = ({
                             icon="codicon-warning"
                             iconColor="var(--chart-4)"
                             title="Sync Tools"
-                            description="Native sync tools could not be set up. Fallback sync tools are active, but syncing and collaboration features may be limited. Your work will be saved locally."
+                            description="Optimized sync tools could not be set up. Compatibility sync tools are active, but syncing and collaboration features may be limited. Your work will be saved locally."
                             severity="warning"
                         />
                     )}
@@ -666,7 +709,7 @@ const WarningsView: React.FC<WarningsViewProps> = ({
                             icon="codicon-warning"
                             iconColor="var(--chart-4)"
                             title="Audio Tools"
-                            description="Native audio tools could not be set up. Fallback audio tools are active with limited format support (.wav only)."
+                            description="Optimized audio tools could not be set up. Compatibility audio tools are active with limited format support (.wav only)."
                             severity="warning"
                         />
                     )}
@@ -823,6 +866,7 @@ interface StatusCardProps {
      * download would be a guaranteed no-op.
      */
     platformUnsupported?: boolean;
+    nativePlatformSupported?: boolean;
     toggleLabel?: string;
     onToggle?: () => void;
     toggleDisabled?: boolean;
@@ -842,6 +886,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
     downloadState = "idle",
     onDownload,
     platformUnsupported = false,
+    nativePlatformSupported = true,
     toggleLabel,
     onToggle,
     toggleDisabled = false,
@@ -871,8 +916,8 @@ const StatusCard: React.FC<StatusCardProps> = ({
 
     const statusLabel = statusLabelOverride ?? (
         severity === "ok"
-            ? "Installed and Running Native Tools"
-            : "Not Installed \u2013 Running Fallback Tools"
+            ? "Installed and Running Optimized Tools"
+            : "Not Installed \u2013 Running Compatibility Tools"
     );
 
     return (
@@ -962,7 +1007,9 @@ const StatusCard: React.FC<StatusCardProps> = ({
                                 {!downloading && !failed && (
                                     <>
                                         <i className="codicon codicon-cloud-download mr-1.5" />
-                                        Download and Install
+                                        {nativePlatformSupported
+                                            ? "Install Optimized Tools"
+                                            : "Install Compatibility Tools"}
                                     </>
                                 )}
                             </Button>
@@ -1021,7 +1068,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
                             className="h-7 text-xs"
                         >
                             <i className="codicon codicon-lock mr-1.5" />
-                            Force Fallback Only
+                            Lock Compatibility Mode
                         </Button>
                     )}
                 </div>

--- a/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
+++ b/webviews/codex-webviews/src/MissingToolsWarning/MissingToolsWarning.tsx
@@ -365,9 +365,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-error",
         descriptions: {
-            available: "Optimized search tools are installed and running.",
-            limited: "Compatibility tools are active. Optimized tools are installed but not selected.",
-            builtinActive: "Compatibility tools are active. Full functionality is available but may be slower.",
+            available: "Native search tools are installed and running.",
+            limited: "Fallback tools are active. Native tools are installed but not selected.",
+            builtinActive: "Fallback tools are active. Full functionality is available but may be slower.",
             missing: "The AI learning and search tools could not be set up. Projects cannot be opened or created without this component.",
         },
     },
@@ -376,9 +376,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-warning",
         descriptions: {
-            available: "Optimized sync tools are active. Syncing and collaboration are fully operational.",
-            limited: "Compatibility sync tools are active. Optimized tools are installed but not selected.",
-            builtinActive: "Compatibility sync tools are active. Syncing and collaboration may be limited.",
+            available: "Native sync tools are active. Syncing and collaboration are fully operational.",
+            limited: "Fallback sync tools are active. Native tools are installed but not selected.",
+            builtinActive: "Fallback sync tools are active. Syncing and collaboration may be limited.",
         },
     },
     ffmpeg: {
@@ -386,9 +386,9 @@ const TOOL_INFO = {
         iconOk: "codicon-check",
         iconMissing: "codicon-warning",
         descriptions: {
-            available: "Optimized audio tools are active. Full audio format support is available for import/export.",
-            limited: "Compatibility audio tools are active (.wav format).",
-            missing: "Optimized audio tools could not be set up. Compatibility audio tools are active (.wav only).",
+            available: "Native audio tools are active. Full audio format support is available for import/export.",
+            limited: "Fallback audio tools are active (.wav format).",
+            missing: "Native audio tools could not be set up. Fallback audio tools are active (.wav only).",
         },
     },
 } as const;
@@ -461,17 +461,17 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
             : "ok";
         const statusLabel =
             unsupported ? "Not available on this platform"
-            : forced ? "Compatibility Tools (locked)"
-            : nativeAvailable && !usingBuiltIn && nativePlatformSupported ? "Installed and Running Optimized Tools"
-            : nativeAvailable && !usingBuiltIn ? "Running Emulated Compatibility Tools"
-            : nativeAvailable && usingBuiltIn ? "Installed and Running Compatibility Tools"
-            : operational ? "Compatibility Tools Active"
-            : nativePlatformSupported ? "Optimized Tools Not Installed"
-            : "Compatibility Tools Unavailable";
+            : forced ? "Fallback Tools (locked)"
+            : nativeAvailable && !usingBuiltIn && nativePlatformSupported ? "Installed and Running Native Tools"
+            : nativeAvailable && !usingBuiltIn ? "Running Emulated Fallback Tools"
+            : nativeAvailable && usingBuiltIn ? "Installed and Running Fallback Tools"
+            : operational ? "Fallback Tools Active"
+            : nativePlatformSupported ? "Native Tools Not Installed"
+            : "Fallback Tools Unavailable";
         const toggleLabel =
-            forced ? "Unlock Optimized Tools"
-            : nativeAvailable && usingBuiltIn ? "Use Optimized Tools"
-            : nativeAvailable ? "Use Compatibility Tools"
+            forced ? "Unlock Native Tools"
+            : nativeAvailable && usingBuiltIn ? "Use Native Tools"
+            : nativeAvailable ? "Use Fallback Tools"
             : undefined;
         const showDownload = !forced && !nativeAvailable && !unsupported;
         const showToggle = forced || nativeAvailable;
@@ -516,8 +516,8 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         style={{ color: "var(--muted-foreground)" }}
                     >
                         {allOk
-                            ? "All optimized tools are installed and running."
-                            : "Some optimized tools are not fully configured. Codex is using compatibility tools where needed."}
+                            ? "All native tools are installed and running."
+                            : "Some native tools are not fully configured. Codex is using fallback tools where needed."}
                     </p>
                 </div>
 
@@ -526,7 +526,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.sqlite.name}
                         description={
                             status.platformUnsupported.sqlite
-                                ? "Optimized search tools are not available on this device. Codex is using compatibility tools."
+                                ? "Native search tools are not available on this device. Codex is using fallback tools."
                                 : sqlite.usingBuiltIn
                                     ? (status.sqlite ? TOOL_INFO.sqlite.descriptions.builtinActive : TOOL_INFO.sqlite.descriptions.missing)
                                     : TOOL_INFO.sqlite.descriptions.available
@@ -550,7 +550,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.git.name}
                         description={
                             status.platformUnsupported.git
-                                ? "Optimized sync tools are not available on this device. Codex is using compatibility tools; syncing and collaboration may be limited."
+                                ? "Native sync tools are not available on this device. Codex is using fallback tools; syncing and collaboration may be limited."
                                 : git.usingBuiltIn
                                     ? TOOL_INFO.git.descriptions.builtinActive
                                     : TOOL_INFO.git.descriptions.available
@@ -576,7 +576,7 @@ const ToolsStatusView: React.FC<ToolsStatusViewProps> = ({
                         title={TOOL_INFO.ffmpeg.name}
                         description={
                             status.platformUnsupported.ffmpeg
-                                ? "Optimized audio tools are not available on this device. Codex is using compatibility tools with limited format support (.wav only)."
+                                ? "Native audio tools are not available on this device. Codex is using fallback tools with limited format support (.wav only)."
                                 : status.ffmpeg && !status.nativePlatformSupported.ffmpeg
                                     ? "Audio tools are emulating x64 on ARM64."
                                 : audio.usingBuiltIn
@@ -704,7 +704,7 @@ const WarningsView: React.FC<WarningsViewProps> = ({
                             icon="codicon-warning"
                             iconColor="var(--chart-4)"
                             title="Sync Tools"
-                            description="Optimized sync tools could not be set up. Compatibility sync tools are active, but syncing and collaboration features may be limited. Your work will be saved locally."
+                            description="Native sync tools could not be set up. Fallback sync tools are active, but syncing and collaboration features may be limited. Your work will be saved locally."
                             severity="warning"
                         />
                     )}
@@ -714,7 +714,7 @@ const WarningsView: React.FC<WarningsViewProps> = ({
                             icon="codicon-warning"
                             iconColor="var(--chart-4)"
                             title="Audio Tools"
-                            description="Optimized audio tools could not be set up. Compatibility audio tools are active with limited format support (.wav only)."
+                            description="Native audio tools could not be set up. Fallback audio tools are active with limited format support (.wav only)."
                             severity="warning"
                         />
                     )}
@@ -921,8 +921,8 @@ const StatusCard: React.FC<StatusCardProps> = ({
 
     const statusLabel = statusLabelOverride ?? (
         severity === "ok"
-            ? "Installed and Running Optimized Tools"
-            : "Not Installed \u2013 Running Compatibility Tools"
+            ? "Installed and Running Native Tools"
+            : "Not Installed \u2013 Running Fallback Tools"
     );
 
     return (
@@ -1013,8 +1013,8 @@ const StatusCard: React.FC<StatusCardProps> = ({
                                     <>
                                         <i className="codicon codicon-cloud-download mr-1.5" />
                                         {nativePlatformSupported
-                                            ? "Install Optimized Tools"
-                                            : "Install Compatibility Tools"}
+                                            ? "Install Native Tools"
+                                            : "Install Fallback Tools"}
                                     </>
                                 )}
                             </Button>
@@ -1073,7 +1073,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
                             className="h-7 text-xs"
                         >
                             <i className="codicon codicon-lock mr-1.5" />
-                            Lock Compatibility Mode
+                            Lock Fallback Mode
                         </Button>
                     )}
                 </div>


### PR DESCRIPTION
## Tools alert

## Summary

Added per-user native tool status tracking to `metadata.json`. The current tool status and status history are stored directly as metadata snapshots without using `editMap`.

## Changes

- Added `meta.nativeToolStatus` for the latest tool status per username.
- Added `meta.nativeToolStatusHistory` to record status changes over time.
- Records:
  - `username`
  - `timestamp`
  - `nonNative`
- Only creates a new history entry when a user’s `nonNative` tool set changes.
- Removed `editMap` handling for native tool status.
- Added conflict resolution based on username and timestamp.
- Preserves different users’ statuses during metadata merges.
- Keeps the `nonNative` array in a consistent order.
- Does not add or require `userId`.
- Avoids rewriting metadata when the status has not changed.

## Test Checklist

- [x] Verified native tool status is stored per username.
- [x] Verified unchanged `nonNative` configurations do not create duplicate history entries.
- [x] Verified status changes create new history entries with updated timestamps.
- [x] Verified native status arrays are normalized consistently.
- [x] Verified metadata conflicts merge different users independently.
- [x] Verified the newest timestamp wins for the same user.
- [x] Verified legacy native-tool `editMap` entries no longer drive status merging.
- [x] Ran lint checks on the changed files.
- [x] Ran `npm run compile` successfully.