### PR TITLE
1147-Task: Pin pnpm version in CI and add build-script approvals (pnpm 12 breaks installs)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -85,7 +85,7 @@ jobs:
                   echo "$(dirname "$(which node)")" >> "$GITHUB_PATH"
 
             - name: Setup pnpm
-              run: npm install -g pnpm
+              run: npm install -g pnpm@10
 
             - name: Generate version
               id: version

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -97,7 +97,7 @@ jobs:
 
             - name: Setup pnpm
               if: steps.version.outputs.skip != 'true'
-              run: npm install -g pnpm
+              run: npm install -g pnpm@10
 
             - name: Set package.json version
               if: steps.version.outputs.skip != 'true'

--- a/package.json
+++ b/package.json
@@ -1220,5 +1220,14 @@
     },
     "extensionDependencies": [
         "project-accelerate.shared-state-store"
-    ]
+    ],
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "@vscode/vsce-sign",
+            "canvas",
+            "dugite",
+            "edgedriver",
+            "geckodriver"
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
Closes #1147

PR Build run [33006618071](https://github.com/genesis-ai-dev/codex-editor/actions/runs/33006618071) failed with `ERR_PNPM_IGNORED_BUILDS` because `pr-build.yml` and `tag-build.yml` install pnpm unpinned (`npm install -g pnpm`) and briefly picked up pnpm 12.0.0, which turns unapproved dependency build scripts into a hard install failure (pnpm 10/11 only warn). This pins pnpm to major 10 in both workflows and approves the five packages with install scripts so they build again, as they did under pnpm 9.

One deviation from the issue's acceptance criteria: the approvals live in `package.json` (`pnpm.onlyBuiltDependencies`) instead of a root `pnpm-workspace.yaml`. Testing showed a root workspace file makes pnpm treat the repo root as a workspace root, which silently breaks the standalone `pnpm install` CI runs inside `webviews/codex-webviews`. Testing also showed pnpm 12 ignores `onlyBuiltDependencies` entirely (it was renamed to an `allowBuilds` mapping), so the version pin is the real protection; migrating the approvals is a task for a future pnpm 12 upgrade.

## Changes
- `pr-build.yml` and `tag-build.yml`: `npm install -g pnpm` → `npm install -g pnpm@10`, so a pnpm major release can no longer change CI behavior on its own schedule. (Note: these are comment-triggered workflows, so the pin only takes effect once this merges to `main`.)
- `package.json`: added `pnpm.onlyBuiltDependencies` approving `@vscode/vsce-sign`, `canvas`, `dugite`, `edgedriver`, and `geckodriver`.

## Test Checklist

### Install works under the pinned pnpm 10
- [x] Full `pnpm@10` install of the real dependency tree exits 0 with no "Ignored build scripts" warning
- [x] Install log confirms all five approved packages' install scripts execute (dugite downloads its embedded git, vsce-sign/edgedriver/geckodriver complete)
- [x] A failed `canvas` native build is skipped, not fatal — it is an *optional* dependency of `pdfjs-dist`, so platforms without prebuilts behave exactly as before

### No regression for the webviews install
- [x] Confirmed no root `pnpm-workspace.yaml` is introduced: with one present, `pnpm install` inside a nested project (as CI does in `webviews/codex-webviews`) resolves to the workspace root and skips the nested project's own install
- [x] With approvals in `package.json` instead, a nested `pnpm install` still gets its own lockfile and `node_modules`

### Post-merge
- [ ] `/build` comment on a PR produces a green PR Build run (only verifiable after this lands on `main`, since comment-triggered workflows run the default branch's workflow file)