### PR TITLE
Fix roundtrip cell mapping

### DIFF
--- a/sharedUtils/docxHtmlFormatting.ts
+++ b/sharedUtils/docxHtmlFormatting.ts
@@ -1,0 +1,197 @@
+import { matchFullWrapper, peelWrapperChain } from "./htmlWrapperUtils";
+
+export interface HtmlStructureOptions {
+    importerType?: string;
+    corpusMarker?: string;
+}
+
+export const isDocxFormattingContext = (options?: HtmlStructureOptions): boolean =>
+    options?.importerType === "docx" ||
+    (!options?.importerType && options?.corpusMarker === "docx");
+
+const SIMPLE_FORMAT = /^<(?:u|strong|em|b|i|s|sup|sub)>$/i;
+const WRAPPER = /^<(?:p|span|u|strong|em|b|i|s|sup|sub)\b/i;
+
+/** Only quoted, well-formed attributes are eligible for deterministic repair. */
+function attributes(openTag: string): Map<string, string> | null {
+    const rest = openTag.replace(/^<[\w]+/, "").replace(/>$/, "");
+    const result = new Map<string, string>();
+    const attribute = /\s+([\w:-]+)\s*=\s*("[^"]*"|'[^']*')/gy;
+    let cursor = 0;
+    while (cursor < rest.length) {
+        if (!rest.slice(cursor).trim()) break;
+        attribute.lastIndex = cursor;
+        const match = attribute.exec(rest);
+        if (!match) return null;
+        const name = match[1].toLowerCase();
+        if (result.has(name)) return null;
+        result.set(name, match[2].slice(1, -1));
+        cursor = attribute.lastIndex;
+    }
+    return result;
+}
+
+/**
+ * Legacy Word imports stored arbitrary run boundaries, sometimes mid-word.
+ * Collapse only uniformly styled spans covering a whole paragraph. Keep every
+ * inter-span character; never coalesce semantic spans or mixed formatting.
+ */
+export function collapseAdjacentEquivalentStyledSpans(html: string): string {
+    const paragraph = matchFullWrapper(html);
+    if (!paragraph || paragraph.tagName !== "p") return html;
+    const span = /(<span\b[^>]*>)([\s\S]*?)<\/span>/giy;
+    let cursor = 0;
+    let count = 0;
+    let firstOpen = "";
+    let firstFormatting = "";
+    let firstClosing = "";
+    let text = "";
+    while (cursor < paragraph.inner.length) {
+        const gap = /^\s*/.exec(paragraph.inner.slice(cursor))![0];
+        text += gap;
+        cursor += gap.length;
+        if (cursor === paragraph.inner.length) break;
+        span.lastIndex = cursor;
+        const match = span.exec(paragraph.inner);
+        if (!match) return html;
+        const attrs = attributes(match[1]);
+        if (!attrs || attrs.size !== 1 || !attrs.has("style")) return html;
+        const formatting = peelWrapperChain(match[2], (tag) => SIMPLE_FORMAT.test(tag));
+        if (/<[^>]*>/.test(formatting.inner)) return html;
+        const open = formatting.openTags.join("");
+        const close = formatting.closeTags.join("");
+        if (count && (match[1] !== firstOpen || open !== firstFormatting || close !== firstClosing)) {
+            return html;
+        }
+        firstOpen = match[1];
+        firstFormatting = open;
+        firstClosing = close;
+        text += formatting.inner;
+        count++;
+        cursor = span.lastIndex;
+    }
+    if (count < 2) return html;
+    return `${paragraph.openTag}${firstOpen}${firstFormatting}${text}${firstClosing}</span></p>`;
+}
+
+// These are the presentation properties emitted by the DOCX importer. Never
+// copy arbitrary CSS, links, language/direction, or semantic data attributes.
+const PRESENTATION_PROPERTIES = new Set([
+    "font-family", "font-size", "color", "background-color", "text-align",
+    "margin-left", "margin-right", "margin-top", "margin-bottom", "text-indent", "line-height",
+]);
+const ALL_PRESENTATION_CONTROLS = [
+    ...PRESENTATION_PROPERTIES, "font-weight", "font-style", "text-decoration", "vertical-align",
+];
+
+function styles(value: string): Map<string, string> | null {
+    const result = new Map<string, string>();
+    for (const declaration of value.split(";")) {
+        if (!declaration.trim()) continue;
+        const match = /^\s*([\w-]+)\s*:\s*(.+?)\s*$/.exec(declaration);
+        if (!match) return null;
+        result.set(match[1].toLowerCase(), match[2]);
+    }
+    return result;
+}
+
+const escapeAttribute = (value: string): string => value.replace(/"/g, "&quot;");
+
+function presentationControls(attrs: Map<string, string>): Set<string> {
+    const controls = new Set(styles(attrs.get("style") ?? "")?.keys());
+    if (controls.has("font")) {
+        ["font-family", "font-size", "font-weight", "font-style", "line-height"].forEach((key) => controls.add(key));
+    }
+    if (controls.has("margin")) {
+        ["margin-left", "margin-right", "margin-top", "margin-bottom"].forEach((key) => controls.add(key));
+    }
+    if (controls.has("background")) controls.add("background-color");
+    if (controls.has("text-decoration-line")) controls.add("text-decoration");
+    if (attrs.has("align") || attrs.has("data-alignment")) controls.add("text-align");
+    if (controls.has("all")) {
+        ALL_PRESENTATION_CONTROLS.forEach((key) => controls.add(key));
+    }
+    if (attrs.has("dir") || attrs.has("lang")) {
+        PRESENTATION_PROPERTIES.forEach((key) => controls.add(key));
+    }
+    for (const token of (attrs.get("class") ?? "").split(/\s+/).filter(Boolean)) {
+        if (token.startsWith("ql-align-")) controls.add("text-align");
+        else if (token.startsWith("ql-font-")) controls.add("font-family");
+        else if (token.startsWith("ql-size-")) controls.add("font-size");
+        else ALL_PRESENTATION_CONTROLS.forEach((key) => controls.add(key));
+    }
+    return controls;
+}
+
+/** Add missing source defaults without replacing any existing target attribute. */
+function restoreOpeningTag(sourceTag: string, targetTag: string, ancestorControls: Set<string>): string | null {
+    const source = attributes(sourceTag);
+    const target = attributes(targetTag);
+    if (!source || !target) return null;
+    if ([...source.keys()].some((key) => !["style", "data-style-id", "data-alignment"].includes(key))) {
+        return null;
+    }
+    let result = targetTag;
+    const additions: string[] = [];
+    const controls = new Set([...ancestorControls, ...presentationControls(target)]);
+    const targetStyles = styles(target.get("style") ?? "");
+    const sourceStyles = styles(source.get("style") ?? "");
+    if (!targetStyles || !sourceStyles) return null;
+    const missing: string[] = [];
+    for (const [key, value] of sourceStyles) {
+        if (!PRESENTATION_PROPERTIES.has(key) || /[<>\\()]/.test(value)) return null;
+        if (!controls.has(key)) missing.push(`${key}: ${value}`);
+    }
+    if (missing.length) {
+        const value = [target.get("style")?.replace(/;\s*$/, ""), ...missing].filter(Boolean).join("; ");
+        if (target.has("style")) {
+            result = result.replace(/\sstyle\s*=\s*("[^"]*"|'[^']*')/i, () => ` style="${escapeAttribute(value)}"`);
+        } else {
+            additions.push(`style="${escapeAttribute(value)}"`);
+        }
+    }
+    for (const key of ["data-style-id", "data-alignment"]) {
+        if (!source.has(key) || target.has(key)) continue;
+        if (key === "data-alignment" && controls.has("text-align")) continue;
+        additions.push(`${key}="${escapeAttribute(source.get(key)!)}"`);
+    }
+    return additions.length ? result.replace(/>$/, () => ` ${additions.join(" ")}>`) : result;
+}
+
+/**
+ * Propose a DOCX-only repair. The caller must still verify structure equality.
+ * Only full-coverage presentation wrappers can be inserted. Existing target
+ * wrappers and innermost HTML (including links and whitespace) stay intact.
+ */
+export function restoreDocxFormatting(sourceHtml: string, targetHtml: string): string | null {
+    const source = peelWrapperChain(collapseAdjacentEquivalentStyledSpans(sourceHtml), (tag) => WRAPPER.test(tag));
+    const target = peelWrapperChain(targetHtml, (tag) => WRAPPER.test(tag));
+    if (!source.openTags.length || !target.inner.trim()) return null;
+    const tagName = (tag: string) => /^<(\w+)/.exec(tag)![1].toLowerCase();
+    const openTags: string[] = [];
+    const ancestorControls = new Set<string>();
+    let targetIndex = 0;
+    for (const sourceTag of source.openTags) {
+        const name = tagName(sourceTag);
+        const targetTag = target.openTags[targetIndex];
+        const matching = targetTag !== undefined && tagName(targetTag) === name;
+        if (!matching && /<[^>]*>/.test(source.inner)) return null;
+        const emphasisProperty: Record<string, string> = {
+            strong: "font-weight", b: "font-weight", em: "font-style", i: "font-style",
+            u: "text-decoration", s: "text-decoration", sup: "vertical-align", sub: "vertical-align",
+        };
+        if (!matching && ancestorControls.has(emphasisProperty[name])) return null;
+        const restored = restoreOpeningTag(sourceTag, matching ? targetTag : `<${name}>`, ancestorControls);
+        if (restored === null) return null;
+        openTags.push(restored);
+        if (matching) {
+            presentationControls(attributes(targetTag)!).forEach((key) => ancestorControls.add(key));
+            targetIndex++;
+        }
+    }
+    if (targetIndex !== target.openTags.length) return null;
+    const closing = [...openTags].reverse().map((tag) => `</${tagName(tag)}>`).join("");
+    const restored = openTags.join("") + target.inner + closing;
+    if (restored.replace(/<[^>]*>/g, "") !== targetHtml.replace(/<[^>]*>/g, "")) return null;
+    return restored === targetHtml ? null : restored;
+}

--- a/sharedUtils/htmlStructureUtils.ts
+++ b/sharedUtils/htmlStructureUtils.ts
@@ -1,15 +1,16 @@
+import { isSelfClosingHtmlTag as isSelfClosing, peelWrapperChain } from "./htmlWrapperUtils";
+import {
+    collapseAdjacentEquivalentStyledSpans,
+    isDocxFormattingContext,
+    restoreDocxFormatting,
+    type HtmlStructureOptions,
+} from "./docxHtmlFormatting";
+export type { HtmlStructureOptions } from "./docxHtmlFormatting";
+
 export interface HtmlStructureDiff {
     isMatch: boolean;
     errors: string[];
 }
-
-const SELF_CLOSING_TAGS = new Set([
-    "br", "hr", "img", "input", "meta", "link",
-    "area", "base", "col", "embed", "source", "track", "wbr",
-]);
-
-const isSelfClosing = (tagName: string): boolean =>
-    SELF_CLOSING_TAGS.has(tagName.toLowerCase());
 
 export const extractHtmlSkeleton = (html: string): string => {
     if (!html) return "";
@@ -145,14 +146,17 @@ export const joinMergedCellHtml = (previousHtml: string, currentHtml: string): s
  * - adjacent bare-paragraph boundaries are collapsed, so a paragraph the
  *   user split with Enter still compares as one block.
  */
-const normalizeForStructureComparison = (html: string): string =>
-    stripEmptyBareSpans(stripEmptyParagraphs(html))
+const normalizeForStructureComparison = (html: string, options?: HtmlStructureOptions): string => {
+    const cleaned = stripEmptyBareSpans(stripEmptyParagraphs(html));
+    return (isDocxFormattingContext(options) ? collapseAdjacentEquivalentStyledSpans(cleaned) : cleaned)
         .replace(/<br\s*\/?>/gi, " ")
         .replace(/<\/p>\s*<p>/gi, " ");
+};
 
 export const compareHtmlStructure = (
     sourceHtml: string,
     targetHtml: string,
+    options?: HtmlStructureOptions,
 ): HtmlStructureDiff => {
     // Untranslated / spacer-only targets are not mismatches. Checking them
     // would flag every empty cell against a paragraph-based source (IDML,
@@ -161,8 +165,8 @@ export const compareHtmlStructure = (
         return { isMatch: true, errors: [] };
     }
 
-    const sourceSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(sourceHtml));
-    const targetSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(targetHtml));
+    const sourceSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(sourceHtml, options));
+    const targetSkeleton = extractHtmlSkeleton(normalizeForStructureComparison(targetHtml, options));
     if (sourceSkeleton === targetSkeleton) {
         return { isMatch: true, errors: [] };
     }
@@ -278,60 +282,6 @@ export const convertBareSpanPairsToParagraphs = (html: string): string => {
 };
 
 /**
- * If the (trimmed) fragment is exactly one element wrapping all remaining
- * content, return its opening tag, tag name, and inner content; otherwise null.
- */
-const matchFullWrapper = (
-    html: string,
-): { openTag: string; tagName: string; inner: string } | null => {
-    const trimmed = html.trim();
-    const openMatch = /^<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/.exec(trimmed);
-    if (!openMatch || openMatch[0].endsWith("/>")) return null;
-    const tagName = openMatch[1].toLowerCase();
-    if (isSelfClosing(tagName)) return null;
-    const closeTag = `</${tagName}>`;
-    if (!trimmed.toLowerCase().endsWith(closeTag)) return null;
-    const inner = trimmed.slice(openMatch[0].length, trimmed.length - closeTag.length);
-    // Reject when the closing tag at the end pairs with a nested opening tag
-    // rather than the leading one (e.g. `<p>a</p><p>b</p>`).
-    let depth = 0;
-    const tagRegex = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
-    let m: RegExpExecArray | null;
-    while ((m = tagRegex.exec(inner)) !== null) {
-        if (m[1].toLowerCase() !== tagName) continue;
-        if (m[0].startsWith("</")) {
-            depth--;
-            if (depth < 0) return null;
-        } else if (!m[0].endsWith("/>")) {
-            depth++;
-        }
-    }
-    return depth === 0 ? { openTag: openMatch[0], tagName, inner } : null;
-};
-
-/**
- * Peel off the chain of full-coverage wrapper elements accepted by `accept`,
- * outermost first. Returns the opening tags, matching closing tags (in
- * closing order), and the innermost content.
- */
-const peelWrapperChain = (
-    html: string,
-    accept: (openTag: string) => boolean,
-): { openTags: string[]; closeTags: string[]; inner: string } => {
-    const openTags: string[] = [];
-    const closeTags: string[] = [];
-    let inner = html;
-    let wrapper = matchFullWrapper(inner);
-    while (wrapper && accept(wrapper.openTag)) {
-        openTags.push(wrapper.openTag);
-        closeTags.unshift(`</${wrapper.tagName}>`);
-        inner = wrapper.inner;
-        wrapper = matchFullWrapper(inner);
-    }
-    return { openTags, closeTags, inner };
-};
-
-/**
  * Re-dress a target fragment with the source's exact wrapper chain: peel the
  * bare `<p>`/`<span>` wrappers the editor leaves behind (Quill drops inline
  * styles it has no registered format for, e.g. docx `<span style="font-family:
@@ -371,9 +321,18 @@ export const rewrapWithSourceWrappers = (
 export const tryDeterministicStructureFix = (
     sourceHtml: string,
     targetHtml: string,
+    options?: HtmlStructureOptions,
 ): string | null => {
-    if (compareHtmlStructure(sourceHtml, targetHtml).isMatch) return null;
-    const rewrapped = rewrapWithSourceWrappers(sourceHtml, targetHtml);
+    if (isEmptyOrPlaceholderHtml(targetHtml)) return null;
+    const docx = isDocxFormattingContext(options);
+    const formattingFix = docx ? restoreDocxFormatting(sourceHtml, targetHtml) : null;
+    if (formattingFix !== null && compareHtmlStructure(sourceHtml, formattingFix, options).isMatch) {
+        return formattingFix;
+    }
+    if (compareHtmlStructure(sourceHtml, targetHtml, options).isMatch) return null;
+    // DOCX uses the attribute-preserving repair above, never the generic
+    // source-wrapper replacement that can overwrite target presentation.
+    const rewrapped = docx ? null : rewrapWithSourceWrappers(sourceHtml, targetHtml);
     const candidates = [
         // Preferred: re-dressing with the source's verbatim wrappers keeps the
         // source's attributes (styles, data-style-id) for round-trip export.
@@ -387,9 +346,23 @@ export const tryDeterministicStructureFix = (
         `<p>${targetHtml}</p>`,
     ];
     for (const candidate of candidates) {
-        if (candidate !== targetHtml && compareHtmlStructure(sourceHtml, candidate).isMatch) {
+        if (candidate !== targetHtml && compareHtmlStructure(sourceHtml, candidate, options).isMatch) {
             return candidate;
         }
     }
     return null;
+};
+
+/** Shared by cell warnings and Resolve All so attribute-only repairs are reachable. */
+export const getHtmlStructureRepairDiff = (
+    sourceHtml: string,
+    targetHtml: string,
+    options?: HtmlStructureOptions,
+): HtmlStructureDiff => {
+    const diff = compareHtmlStructure(sourceHtml, targetHtml, options);
+    if (!diff.isMatch || !isDocxFormattingContext(options)) return diff;
+    if (tryDeterministicStructureFix(sourceHtml, targetHtml, options) !== null) {
+        return { isMatch: false, errors: ["Missing DOCX formatting attributes"] };
+    }
+    return diff;
 };

--- a/sharedUtils/htmlWrapperUtils.ts
+++ b/sharedUtils/htmlWrapperUtils.ts
@@ -1,0 +1,50 @@
+const SELF_CLOSING_TAGS = new Set([
+    "br", "hr", "img", "input", "meta", "link",
+    "area", "base", "col", "embed", "source", "track", "wbr",
+]);
+
+export const isSelfClosingHtmlTag = (tagName: string): boolean =>
+    SELF_CLOSING_TAGS.has(tagName.toLowerCase());
+
+/** Match one element covering the entire fragment, never adjacent siblings. */
+export const matchFullWrapper = (
+    html: string,
+): { openTag: string; tagName: string; inner: string } | null => {
+    const trimmed = html.trim();
+    const openMatch = /^<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/.exec(trimmed);
+    if (!openMatch || openMatch[0].endsWith("/>")) return null;
+    const tagName = openMatch[1].toLowerCase();
+    if (isSelfClosingHtmlTag(tagName)) return null;
+    const closeTag = `</${tagName}>`;
+    if (!trimmed.toLowerCase().endsWith(closeTag)) return null;
+    const inner = trimmed.slice(openMatch[0].length, trimmed.length - closeTag.length);
+    let depth = 0;
+    const tagRegex = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
+    let match: RegExpExecArray | null;
+    while ((match = tagRegex.exec(inner)) !== null) {
+        if (match[1].toLowerCase() !== tagName) continue;
+        if (match[0].startsWith("</")) {
+            if (--depth < 0) return null;
+        } else if (!match[0].endsWith("/>")) {
+            depth++;
+        }
+    }
+    return depth === 0 ? { openTag: openMatch[0], tagName, inner } : null;
+};
+
+export const peelWrapperChain = (
+    html: string,
+    accept: (openTag: string) => boolean,
+): { openTags: string[]; closeTags: string[]; inner: string } => {
+    const openTags: string[] = [];
+    const closeTags: string[] = [];
+    let inner = html;
+    let wrapper = matchFullWrapper(inner);
+    while (wrapper && accept(wrapper.openTag)) {
+        openTags.push(wrapper.openTag);
+        closeTags.unshift(`</${wrapper.tagName}>`);
+        inner = wrapper.inner;
+        wrapper = matchFullWrapper(inner);
+    }
+    return { openTags, closeTags, inner };
+};

--- a/src/exportHandler/exportHandler.ts
+++ b/src/exportHandler/exportHandler.ts
@@ -1292,6 +1292,7 @@ async function exportCodexContentAsSpreadsheetRoundtrip(
             const extension = getSpreadsheetExtension(originalFileName, delimiter, notebookImporterType);
             const columnHeaders = (codexNotebook.metadata as any)?.columnHeaders;
             const sourceColumnIndex = (codexNotebook.metadata as any)?.sourceColumnIndex;
+            const hasHeader = (codexNotebook.metadata as any)?.hasHeader;
 
             console.log(`[Spreadsheet Export] Processing ${fileName}`);
             console.log(`[Spreadsheet Export] - importerType: ${notebookImporterType}`);
@@ -1334,6 +1335,7 @@ async function exportCodexContentAsSpreadsheetRoundtrip(
                     columnHeaders,
                     sourceColumnIndex,
                     importerType: notebookImporterType,
+                    hasHeader,
                 }
             );
 

--- a/src/projectManager/projectExportView.ts
+++ b/src/projectManager/projectExportView.ts
@@ -75,7 +75,7 @@ async function checkHtmlStructureMismatches(
                 if (!cellId || !cell.value) continue;
                 const sourceContent = sourceMap.get(cellId);
                 if (!sourceContent) continue;
-                const diff = compareHtmlStructure(sourceContent, cell.value);
+                const diff = compareHtmlStructure(sourceContent, cell.value, metadata);
                 if (!diff.isMatch) mismatchCount++;
             }
 

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -973,37 +973,19 @@ function applyEditToCell(cell: CustomNotebookCellData, edit: EditHistory): void 
             // Direct cell value edit
             cell.value = value as string;
         } else if (path.length >= 2 && path[0] === 'metadata') {
-            // Metadata field edit
-            if (path.length === 2) {
-                // Direct metadata field (e.g., cellLabel)
-                const field = path[1];
-                if (field === 'cellLabel') {
-                    cell.metadata.cellLabel = value as string;
-                } else if (field === 'selectedAudioId') {
-                    cell.metadata.selectedAudioId = value as string;
-                } else if (field === 'selectionTimestamp') {
-                    cell.metadata.selectionTimestamp = value as number;
-                } else if (field === 'isLocked') {
-                    cell.metadata.isLocked = value as boolean;
+            // Importers add format-specific locator metadata over time. Apply
+            // arbitrary metadata paths generically so those fields do not need
+            // a resolver code change each time a round-trip format evolves.
+            let target = cell.metadata as unknown as Record<string, unknown>;
+            for (let index = 1; index < path.length - 1; index++) {
+                const field = path[index];
+                const existing = target[field];
+                if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+                    target[field] = {};
                 }
-            } else if (path.length === 3 && path[1] === 'data') {
-                // Data field edit (e.g., startTime, endTime)
-                const dataField = path[2];
-                if (!cell.metadata.data) {
-                    cell.metadata.data = {};
-                }
-
-                if (dataField === 'startTime') {
-                    cell.metadata.data.startTime = value as number;
-                } else if (dataField === 'endTime') {
-                    cell.metadata.data.endTime = value as number;
-                } else if (dataField === 'deleted') {
-                    cell.metadata.data.deleted = value as boolean;
-                } else {
-                    // Generic data field assignment
-                    (cell.metadata.data as any)[dataField] = value as any;
-                }
+                target = target[field] as Record<string, unknown>;
             }
+            target[path[path.length - 1]] = value;
         }
     } catch (error) {
         debugLog(`Error applying edit to cell: ${error}`);
@@ -2920,4 +2902,3 @@ export async function resolveConflictFiles(
 
     return { resolved: resolvedFiles, failed: failedFiles };
 }
-

--- a/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
+++ b/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
@@ -20,7 +20,7 @@ import { NotebookPreview, CustomNotebookMetadata } from "../../../types";
 import { CodexCell } from "../../utils/codexNotebookUtils";
 import { CodexCellTypes } from "../../../types/enums";
 import { importBookNamesFromXmlContent } from "../../bookNameSettings/bookNameSettings";
-import { createStandardizedFilename, extractUsfmCodeFromFilename, getDefaultBookName } from "../../utils/bookNameUtils";
+import { createStandardizedFilename, extractUsfmCodeFromFilename, getDefaultBookName, isBiblicalImporterType } from "../../utils/bookNameUtils";
 import { formatJsonForNotebookFile } from "../../utils/notebookFileFormattingUtils";
 import { CodexContentSerializer } from "../../serializer";
 import { getCorpusMarkerForBook } from "../../../sharedUtils/corpusUtils";
@@ -991,7 +991,21 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
             fileDisplayName = `${languagePrefix} ${fileDisplayName}`;
         }
 
+        // Persist importer metadata by default. Round-trip formats evolve and
+        // their exporters depend on format-specific fields (for example
+        // obsStory, pdfDocumentMetadata, markdownRoundTripSource, and TMS
+        // language/format data). An allowlist silently discarded those fields.
+        // Remove only import-time payloads that are large or recursively
+        // duplicate metadata; canonical originals live in attachments.
+        const persistableImporterMetadata = {
+            ...(processedNotebook.metadata as unknown as Record<string, unknown>),
+        };
+        delete persistableImporterMetadata.originalFileData;
+        delete persistableImporterMetadata.docxDocument;
+        delete persistableImporterMetadata.sourceMetadata;
+
         const metadata: CustomNotebookMetadata = {
+            ...(persistableImporterMetadata as Partial<CustomNotebookMetadata>),
             id: processedNotebook.metadata.id,
             originalName: processedNotebook.metadata.originalFileName,
             sourceFsPath: "",
@@ -1106,7 +1120,7 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         const pairsWithOriginalFiles = new Set<number>();
         // Content hash per pair, used to detect re-imports of an already-imported file
-        const originalFileHashes = new Map<number, string>();
+        const originalFileHashes = new Map<number, { hash: string; requestedFileName: string }>();
         if (workspaceFolder) {
             for (let pairIdx = 0; pairIdx < message.notebookPairs.length; pairIdx++) {
                 const pair = message.notebookPairs[pairIdx];
@@ -1166,7 +1180,7 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                     );
 
                     console.log(`[NewSourceUploader] Original file: ${result.message}`);
-                    originalFileHashes.set(pairIdx, result.hash);
+                    originalFileHashes.set(pairIdx, { hash: result.hash, requestedFileName });
 
                     // Store the file hash in metadata for integrity verification and deduplication tracking
                     (pair.source.metadata as any).originalFileHash = result.hash;
@@ -1258,27 +1272,34 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         const skippedPairs = new Set<number>();
         if (workspaceFolder) {
             const { findExistingImportPairs } = await import('./updateExistingImport');
-            for (const [pairIdx, hash] of originalFileHashes) {
+            for (const [pairIdx, originalFile] of originalFileHashes) {
                 // Imports whose standardized filename already exists (biblical
                 // books like GEN.source, or legacy non-UUID names) went through
                 // the overwrite-confirmation flow in handleWriteNotebooks; the
                 // user already chose to overwrite, so don't ask again here.
-                const standardizedName = await createStandardizedFilename(
-                    message.notebookPairs[pairIdx].source.name,
-                    ".source"
-                );
-                try {
-                    await vscode.workspace.fs.stat(
-                        vscode.Uri.joinPath(workspaceFolder.uri, ".project", "sourceTexts", standardizedName)
+                const importerType = message.notebookPairs[pairIdx].source.metadata.importerType;
+                if (isBiblicalImporterType(importerType)) {
+                    const standardizedName = await createStandardizedFilename(
+                        message.notebookPairs[pairIdx].source.name,
+                        ".source",
+                        true,
                     );
-                    continue;
-                } catch {
-                    // No standardized-name file; this pair is eligible for
-                    // re-import detection.
+                    try {
+                        await vscode.workspace.fs.stat(
+                            vscode.Uri.joinPath(workspaceFolder.uri, ".project", "sourceTexts", standardizedName)
+                        );
+                        continue;
+                    } catch {
+                        // No standardized-name file; this pair is eligible for
+                        // re-import detection.
+                    }
                 }
 
-                const fileName = message.notebookPairs[pairIdx].source.metadata.originalFileName;
-                const matches = await findExistingImportPairs(workspaceFolder, hash, fileName);
+                // Use the filename the user selected, not the deduplicated
+                // attachment filename (e.g. "document(1).docx"). Changed-file
+                // re-import detection is keyed by the requested original name.
+                const fileName = originalFile.requestedFileName;
+                const matches = await findExistingImportPairs(workspaceFolder, originalFile.hash, fileName);
                 if (!matches) continue;
 
                 const displayFileName = fileName || "This document";
@@ -2653,4 +2674,3 @@ async function confirmOverwriteWithDetails(
 
     return action === "Overwrite Files";
 }
-

--- a/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
+++ b/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
@@ -1382,6 +1382,7 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                     sourceNotebooks[pairIdx],
                     codexNotebooks[pairIdx]
                 );
+                if (result.cancelled) continue;
                 allFiles.push({ pairIdx, sourceUri: result.sourceUri, codexUri: result.codexUri });
 
                 const { stats } = result;
@@ -1431,6 +1432,13 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         createdFiles.forEach((file, i) => {
             allFiles.push({ pairIdx: createIndices[i], sourceUri: file.sourceUri, codexUri: file.codexUri });
         });
+
+        // All updates may have been cancelled by the unmatched-translation
+        // warning. Do not run successful-import cleanup for an empty batch.
+        if (allFiles.length === 0) {
+            webviewPanel.webview.postMessage({ command: "importCancelled" });
+            return;
+        }
 
         // Register notebook references in the original files registry
         // Only for pairs that had an actual original file saved via deduplication

--- a/src/providers/NewSourceUploader/reimportMerge.ts
+++ b/src/providers/NewSourceUploader/reimportMerge.ts
@@ -18,8 +18,8 @@
  *   same tombstone mechanism the editor's delete-cell action uses.
  * - Matched cells keep their OLD cell id (so translations, edit history,
  *   comments, and audio stay attached), keep their old edit history, and any
- *   changed value or `data` field gets a timestamped MIGRATION edit appended
- *   so the change wins the sync merge on every machine.
+ *   changed value or importer metadata field gets a timestamped MIGRATION
+ *   edit appended so the change wins the sync merge on every machine.
  * - New cells with no old counterpart start with an empty target.
  * - Milestone cells are matched by chapter number so their ids are stable
  *   across the re-import too.
@@ -30,6 +30,12 @@
 import { CodexCellTypes, EditType } from "../../../types/enums";
 import { EditMapUtils } from "../../utils/editMapUtils";
 import { extractPlainTextFromHtml } from "../../../sharedUtils/htmlStructureUtils";
+import {
+    appendImporterMetadataEdits,
+    makeReimportEdit as makeEdit,
+    mergeNotebookMetadata,
+    remapNotebookMetadataCellIds,
+} from "./reimportMetadata";
 
 export interface ReimportEdit {
     editMap: readonly string[];
@@ -88,21 +94,6 @@ const PRESERVED_TARGET_METADATA_KEYS = [
     "isLocked",
 ] as const;
 
-/** Notebook metadata that identifies the existing pair and must not change. */
-const PRESERVED_NOTEBOOK_METADATA_KEYS = [
-    "id",
-    "fileDisplayName",
-    "sourceFsPath",
-    "codexFsPath",
-    "navigation",
-    "sourceCreatedAt",
-    "corpusMarker",
-    "textDirection",
-    "videoUrl",
-    "lineNumbersEnabled",
-    "lineNumbersEnabledSource",
-] as const;
-
 const normalizeText = (html: string | undefined): string =>
     extractPlainTextFromHtml(html ?? "");
 
@@ -133,57 +124,9 @@ interface OldCellEntry {
 const hasTranslation = (entry: OldCellEntry): boolean =>
     Boolean(entry.targetCell?.value && entry.targetCell.value.trim() !== "");
 
-const mergeNotebookMetadata = (
-    existing: Record<string, unknown> | undefined,
-    incoming: Record<string, unknown> | undefined,
-): Record<string, unknown> => {
-    const merged: Record<string, unknown> = { ...(existing ?? {}), ...(incoming ?? {}) };
-    for (const key of PRESERVED_NOTEBOOK_METADATA_KEYS) {
-        if (existing && existing[key] !== undefined) {
-            merged[key] = existing[key];
-        }
-    }
-    return merged;
-};
-
-const REIMPORT_AUTHOR = "system";
-
-const makeEdit = (
-    editMap: readonly string[],
-    value: unknown,
-    timestamp: number,
-): ReimportEdit => ({
-    editMap,
-    value,
-    timestamp,
-    type: EditType.MIGRATION,
-    author: REIMPORT_AUTHOR,
-    validatedBy: [],
-});
-
 const ensureEdits = (cell: ReimportCell): ReimportEdit[] => {
     const metadata = (cell.metadata ??= {});
     return (metadata.edits ??= []);
-};
-
-/**
- * Append MIGRATION edits describing every difference between the cell's old
- * `data` fields and its new ones, so the changes (e.g. corrected
- * `paragraphIndex`) propagate through the sync merge instead of being
- * reverted to the remote's newest edit.
- */
-const appendDataFieldEdits = (
-    cell: ReimportCell,
-    oldData: Record<string, unknown> | undefined,
-    timestamp: number,
-): void => {
-    const newData = cell.metadata?.data ?? {};
-    const edits = ensureEdits(cell);
-    for (const [field, value] of Object.entries(newData)) {
-        if (value === undefined) continue;
-        if (JSON.stringify(oldData?.[field]) === JSON.stringify(value)) continue;
-        edits.push(makeEdit(EditMapUtils.metadataNested("data", field), value, timestamp));
-    }
 };
 
 /** Append a value edit when the cell's value differs from its previous value. */
@@ -229,6 +172,7 @@ export const mergeReimportedNotebookPair = (
     newCodex: ReimportNotebook,
 ): ReimportMergeResult => {
     const now = Date.now();
+    const freshToRetainedCellIds = new Map<string, string>();
 
     const oldTargetById = new Map<string, ReimportCell>();
     for (const cell of existingCodex.cells ?? []) {
@@ -330,19 +274,21 @@ export const mergeReimportedNotebookPair = (
     const adoptOldCell = (cell: PendingCell, entry: OldCellEntry, carriedValue: string) => {
         entry.consumed = true;
         const oldId = entry.sourceCell.metadata!.id as string;
+        const freshId = cell.sourceCell.metadata?.id;
+        if (typeof freshId === "string") freshToRetainedCellIds.set(freshId, oldId);
         const oldSourceMetadata = entry.sourceCell.metadata as Record<string, unknown>;
 
         // Source side: keep the old id and edit history; record the new value
-        // and data changes as MIGRATION edits so they survive the sync merge.
+        // and locator changes as MIGRATION edits so they survive the sync merge.
         cell.sourceCell.metadata = {
             ...(cell.sourceCell.metadata ?? {}),
             id: oldId,
             edits: [...(entry.sourceCell.metadata?.edits ?? [])],
         };
         appendValueEditIfChanged(cell.sourceCell, entry.sourceCell.value, now);
-        appendDataFieldEdits(
+        appendImporterMetadataEdits(
             cell.sourceCell,
-            oldSourceMetadata.data as Record<string, unknown> | undefined,
+            oldSourceMetadata,
             now,
         );
 
@@ -370,9 +316,9 @@ export const mergeReimportedNotebookPair = (
         };
         cell.codexCell.value = carriedValue;
         appendValueEditIfChanged(cell.codexCell, entry.targetCell?.value, now);
-        appendDataFieldEdits(
+        appendImporterMetadataEdits(
             cell.codexCell,
-            oldTargetMetadata?.data as Record<string, unknown> | undefined,
+            oldTargetMetadata,
             now,
         );
 
@@ -394,6 +340,8 @@ export const mergeReimportedNotebookPair = (
         const entry = candidates[0];
         entry.consumed = true;
         const oldId = entry.sourceCell.metadata!.id as string;
+        const freshId = cell.sourceCell.metadata?.id;
+        if (typeof freshId === "string") freshToRetainedCellIds.set(freshId, oldId);
         // Keep the old value (e.g. "<docName> 1" vs the importer's bare "1")
         // so no value edit is needed; only the id and history carry over.
         cell.sourceCell.metadata = {
@@ -537,14 +485,23 @@ export const mergeReimportedNotebookPair = (
     }
     mergedCodexCells.push(...orphanedParatext);
 
+    const remappedSourceMetadata = remapNotebookMetadataCellIds(
+        newSource.metadata,
+        freshToRetainedCellIds,
+    );
+    const remappedCodexMetadata = remapNotebookMetadataCellIds(
+        newCodex.metadata,
+        freshToRetainedCellIds,
+    );
+
     return {
         mergedSource: {
             cells: mergedSourceCells,
-            metadata: mergeNotebookMetadata(existingSource.metadata, newSource.metadata),
+            metadata: mergeNotebookMetadata(existingSource.metadata, remappedSourceMetadata, now),
         },
         mergedCodex: {
             cells: mergedCodexCells,
-            metadata: mergeNotebookMetadata(existingCodex.metadata, newCodex.metadata),
+            metadata: mergeNotebookMetadata(existingCodex.metadata, remappedCodexMetadata, now),
         },
         stats,
     };

--- a/src/providers/NewSourceUploader/reimportMerge.ts
+++ b/src/providers/NewSourceUploader/reimportMerge.ts
@@ -29,7 +29,8 @@
 
 import { CodexCellTypes, EditType } from "../../../types/enums";
 import { EditMapUtils } from "../../utils/editMapUtils";
-import { extractPlainTextFromHtml } from "../../../sharedUtils/htmlStructureUtils";
+import { isDocxFormattingContext } from "../../../sharedUtils/docxHtmlFormatting";
+import { getReimportSourceText } from "./reimportSourceText";
 import {
     appendImporterMetadataEdits,
     makeReimportEdit as makeEdit,
@@ -93,9 +94,6 @@ const PRESERVED_TARGET_METADATA_KEYS = [
     "cellLabel",
     "isLocked",
 ] as const;
-
-const normalizeText = (html: string | undefined): string =>
-    extractPlainTextFromHtml(html ?? "");
 
 const isTextCell = (cell: ReimportCell): boolean =>
     (cell.metadata?.type ?? CodexCellTypes.TEXT) === CodexCellTypes.TEXT;
@@ -172,6 +170,8 @@ export const mergeReimportedNotebookPair = (
     newCodex: ReimportNotebook,
 ): ReimportMergeResult => {
     const now = Date.now();
+    const docx = isDocxFormattingContext(existingSource.metadata) && isDocxFormattingContext(newSource.metadata);
+    const sourceText = (cell: ReimportCell): string => getReimportSourceText(cell, docx);
     const freshToRetainedCellIds = new Map<string, string>();
 
     const oldTargetById = new Map<string, ReimportCell>();
@@ -216,7 +216,7 @@ export const mergeReimportedNotebookPair = (
             }
             return;
         }
-        const text = normalizeText(cell.value);
+        const text = sourceText(cell);
         if (!isTextCell(cell) || !text) {
             // Unmatched cell shapes (empty text, unexpected types) are kept
             // as-is rather than removed — a removed cell would just be
@@ -268,7 +268,7 @@ export const mergeReimportedNotebookPair = (
             };
         const isText = isTextCell(sourceCell) && sourceCell.metadata?.type !== CodexCellTypes.MILESTONE;
         if (isText) stats.totalNewCells++;
-        return { sourceCell, codexCell, normalizedText: normalizeText(sourceCell.value), isText };
+        return { sourceCell, codexCell, normalizedText: sourceText(sourceCell), isText };
     });
 
     const adoptOldCell = (cell: PendingCell, entry: OldCellEntry, carriedValue: string) => {
@@ -385,7 +385,7 @@ export const mergeReimportedNotebookPair = (
     for (const cell of unmatched) {
         const contained = oldEntries.filter((entry) => {
             if (entry.consumed) return false;
-            const oldText = normalizeText(entry.sourceCell.value);
+            const oldText = sourceText(entry.sourceCell);
             return oldText.length >= MIN_CONTAINMENT_LENGTH && cell.normalizedText.includes(oldText);
         });
         if (contained.length === 0) continue;

--- a/src/providers/NewSourceUploader/reimportMetadata.ts
+++ b/src/providers/NewSourceUploader/reimportMetadata.ts
@@ -1,0 +1,191 @@
+import { EditType } from "../../../types/enums";
+import { EditMapUtils } from "../../utils/editMapUtils";
+import type { ReimportCell, ReimportEdit } from "./reimportMerge";
+
+/** Importer-owned locator fields that must be explicitly cleared when a new parse omits them. */
+const IMPORTER_LOCATOR_METADATA_KEYS = [
+    "paragraphId",
+    "paragraphIndex",
+    "paragraphIndices",
+    "paragraphMappingVersion",
+    "segmentIndex",
+    "segmentCount",
+    "sourceSpan",
+    "originalMarkdown",
+    "segmentType",
+    "storyId",
+    "appliedParagraphStyle",
+    "isBibleVerse",
+    "verseId",
+    "bookAbbreviation",
+    "chapterNumber",
+    "verseNumber",
+    "beforeVerse",
+    "afterVerse",
+    "footnotes",
+    "verseStructureXml",
+    "unitId",
+    "sourceLanguage",
+    "targetLanguage",
+    "targetText",
+    "note",
+    "cellIndex",
+    "lineIndex",
+    "originalLine",
+    "originalText",
+    "verseReference",
+    "verseEnd",
+    "book",
+    "bookCode",
+    "bookName",
+    "vref",
+    "fileName",
+    "chapter",
+    "marker",
+    "verse",
+    "breakTag",
+    "hasFootnotes",
+    "isChild",
+    "parentId",
+    "elementType",
+    "hasHeading",
+    "headingText",
+    "headingLevel",
+    "storyNumber",
+    "storyTitle",
+    "documentId",
+    "sectionId",
+    "imageAlt",
+    "imageTitle",
+    "originalImageSrc",
+] as const;
+
+const IMPORTER_LOCATOR_DATA_KEYS = [
+    "rowIndex",
+    "sourceColumnIndex",
+    "originalRowValues",
+    "originalContent",
+    "lineIndex",
+    "originalLine",
+    "originalText",
+    "verseNumber",
+    "startTime",
+    "endTime",
+    "format",
+    "globalReferences",
+    "idmlStructure",
+    "relationships",
+    "unitId",
+] as const;
+
+/** Notebook metadata that identifies the existing pair and must not change. */
+const PRESERVED_NOTEBOOK_METADATA_KEYS = [
+    "id",
+    "fileDisplayName",
+    "sourceFsPath",
+    "codexFsPath",
+    "navigation",
+    "sourceCreatedAt",
+    "corpusMarker",
+    "textDirection",
+    "videoUrl",
+    "lineNumbersEnabled",
+    "lineNumbersEnabledSource",
+] as const;
+
+const REIMPORT_AUTHOR = "system";
+
+export const makeReimportEdit = (
+    editMap: readonly string[],
+    value: unknown,
+    timestamp: number,
+): ReimportEdit => ({
+    editMap,
+    value,
+    timestamp,
+    type: EditType.MIGRATION,
+    author: REIMPORT_AUTHOR,
+    validatedBy: [],
+});
+
+const ensureEdits = (cell: ReimportCell): ReimportEdit[] => {
+    const metadata = (cell.metadata ??= {});
+    return (metadata.edits ??= []);
+};
+
+export const mergeNotebookMetadata = (
+    existing: Record<string, unknown> | undefined,
+    incoming: Record<string, unknown> | undefined,
+    timestamp: number,
+): Record<string, unknown> => {
+    const merged: Record<string, unknown> = { ...(existing ?? {}), ...(incoming ?? {}) };
+    for (const key of PRESERVED_NOTEBOOK_METADATA_KEYS) {
+        if (existing && existing[key] !== undefined) {
+            merged[key] = existing[key];
+        }
+    }
+    const existingEdits = Array.isArray(existing?.edits) ? existing.edits : [];
+    const incomingEdits = Array.isArray(incoming?.edits) ? incoming.edits : [];
+    const edits = [...existingEdits, ...incomingEdits] as ReimportEdit[];
+    for (const [field, value] of Object.entries(incoming ?? {})) {
+        if (field === "edits" || value === undefined) continue;
+        if ((PRESERVED_NOTEBOOK_METADATA_KEYS as readonly string[]).includes(field)) continue;
+        if (JSON.stringify(existing?.[field]) === JSON.stringify(value)) continue;
+        edits.push(makeReimportEdit(EditMapUtils.metadata(field), value, timestamp));
+    }
+    merged.edits = edits;
+    return merged;
+};
+
+/** Record all refreshed importer locators as edits so they survive sync merges. */
+export const appendImporterMetadataEdits = (
+    cell: ReimportCell,
+    oldMetadata: Record<string, unknown> | undefined,
+    timestamp: number,
+): void => {
+    const newMetadata = (cell.metadata ??= {});
+    const edits = ensureEdits(cell);
+    for (const [field, value] of Object.entries(newMetadata)) {
+        if (field === "id" || field === "edits" || field === "data" || value === undefined) continue;
+        if (JSON.stringify(oldMetadata?.[field]) === JSON.stringify(value)) continue;
+        edits.push(makeReimportEdit(EditMapUtils.metadata(field), value, timestamp));
+    }
+    for (const field of IMPORTER_LOCATOR_METADATA_KEYS) {
+        if (oldMetadata?.[field] === undefined || newMetadata[field] !== undefined) continue;
+        newMetadata[field] = null;
+        edits.push(makeReimportEdit(EditMapUtils.metadata(field), null, timestamp));
+    }
+
+    const newData = (newMetadata.data ??= {});
+    const oldData = oldMetadata?.data as Record<string, unknown> | undefined;
+    for (const [field, value] of Object.entries(newData)) {
+        if (value === undefined) continue;
+        if (JSON.stringify(oldData?.[field]) === JSON.stringify(value)) continue;
+        edits.push(makeReimportEdit(EditMapUtils.metadataNested("data", field), value, timestamp));
+    }
+    for (const field of IMPORTER_LOCATOR_DATA_KEYS) {
+        if (oldData?.[field] === undefined || newData[field] !== undefined) continue;
+        newData[field] = null;
+        edits.push(makeReimportEdit(EditMapUtils.metadataNested("data", field), null, timestamp));
+    }
+};
+
+export const remapNotebookMetadataCellIds = (
+    metadata: Record<string, unknown> | undefined,
+    idMap: Map<string, string>,
+): Record<string, unknown> | undefined => {
+    if (!metadata || idMap.size === 0) return metadata;
+
+    const remap = (value: unknown): unknown => {
+        if (typeof value === "string") return idMap.get(value) ?? value;
+        if (Array.isArray(value)) return value.map(remap);
+        if (value && typeof value === "object") {
+            return Object.fromEntries(
+                Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, remap(child)])
+            );
+        }
+        return value;
+    };
+
+    return remap(metadata) as Record<string, unknown>;
+};

--- a/src/providers/NewSourceUploader/reimportMetadata.ts
+++ b/src/providers/NewSourceUploader/reimportMetadata.ts
@@ -143,7 +143,7 @@ export const appendImporterMetadataEdits = (
     oldMetadata: Record<string, unknown> | undefined,
     timestamp: number,
 ): void => {
-    const newMetadata = (cell.metadata ??= {});
+    const newMetadata = (cell.metadata ??= {}) as Record<string, unknown>;
     const edits = ensureEdits(cell);
     for (const [field, value] of Object.entries(newMetadata)) {
         if (field === "id" || field === "edits" || field === "data" || value === undefined) continue;
@@ -156,7 +156,7 @@ export const appendImporterMetadataEdits = (
         edits.push(makeReimportEdit(EditMapUtils.metadata(field), null, timestamp));
     }
 
-    const newData = (newMetadata.data ??= {});
+    const newData = (newMetadata.data ??= {}) as Record<string, unknown>;
     const oldData = oldMetadata?.data as Record<string, unknown> | undefined;
     for (const [field, value] of Object.entries(newData)) {
         if (value === undefined) continue;

--- a/src/providers/NewSourceUploader/reimportSourceText.ts
+++ b/src/providers/NewSourceUploader/reimportSourceText.ts
@@ -1,0 +1,27 @@
+import type { ReimportCell } from "./reimportMerge";
+import { extractPlainTextFromHtml } from "../../../sharedUtils/htmlStructureUtils";
+
+const normalizeWhitespace = (text: string): string => text.replace(/\s+/g, " ").trim();
+
+/** DOCX inline runs can split words; only block/line boundaries introduce spaces. */
+function docxHtmlText(html: string): string {
+    const entities: Record<string, string> = {
+        amp: "&", lt: "<", gt: ">", quot: '"', apos: "'", nbsp: " ",
+    };
+    return normalizeWhitespace(html
+        .replace(/<(?:br\b[^>]*|\/(?:p|div|li|td|th|tr|h[1-6]))\s*\/?>/gi, " ")
+        .replace(/<[^>]*>/g, "")
+        .replace(/&(#x[\da-f]+|#\d+|amp|lt|gt|quot|apos|nbsp);/gi, (entity, code: string) => {
+            if (!code.startsWith("#")) return entities[code.toLowerCase()] ?? entity;
+            const hex = code[1].toLowerCase() === "x";
+            const point = Number.parseInt(code.slice(hex ? 2 : 1), hex ? 16 : 10);
+            return point > 0 && point <= 0x10ffff && !(point >= 0xd800 && point <= 0xdfff)
+                ? String.fromCodePoint(point) : entity;
+        }));
+}
+
+export function getReimportSourceText(cell: ReimportCell, docx: boolean): string {
+    // Read current source content, not potentially stale originalText metadata:
+    // user source corrections must still affect which translations can match.
+    return docx ? docxHtmlText(cell.value ?? "") : extractPlainTextFromHtml(cell.value ?? "");
+}

--- a/src/providers/NewSourceUploader/updateExistingImport.ts
+++ b/src/providers/NewSourceUploader/updateExistingImport.ts
@@ -11,6 +11,7 @@ import * as vscode from "vscode";
 import type { CodexNotebookAsJSONData, NotebookPreview } from "../../../types";
 import { findOriginalFileByHash, loadOriginalFilesRegistry } from "./originalFileUtils";
 import { writeNotebook } from "./codexFIleCreateUtils";
+import { isDocxFormattingContext } from "../../../sharedUtils/docxHtmlFormatting";
 import {
     mergeReimportedNotebookPair,
     type ReimportMergeStats,
@@ -183,6 +184,7 @@ export interface UpdateExistingImportResult {
     sourceUri: vscode.Uri;
     codexUri: vscode.Uri;
     stats: ReimportMergeStats;
+    cancelled?: boolean;
 }
 
 /**
@@ -214,6 +216,24 @@ export const updateExistingImportPair = async (
         newSource as unknown as ReimportNotebook,
         newCodex as unknown as ReimportNotebook,
     );
+
+    // A different sentence split cannot safely split an existing translation.
+    // Keep this guard DOCX-specific; other importers retain their current flow.
+    if (isDocxFormattingContext(existingSource.metadata) && stats.droppedTranslations > 0) {
+        const choice = await vscode.window.showWarningMessage(
+            `Updating "${pair.displayName}" would hide ${stats.droppedTranslations} translated cell(s) whose source segments could not be matched.`,
+            {
+                modal: true,
+                detail: "This can happen when the original text or sentence segmentation changes. " +
+                    "Cancel to keep both notebooks unchanged. If you continue, unmatched translations " +
+                    "remain in deleted cells with their history, but will not be used in exports.",
+            },
+            "Update Anyway",
+        );
+        if (choice !== "Update Anyway") {
+            return { sourceUri: pair.sourceUri, codexUri: pair.codexUri, stats, cancelled: true };
+        }
+    }
 
     const reimportContext = {
         timestamp: new Date().toISOString(),

--- a/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
+++ b/src/providers/codexCellEditorProvider/utils/htmlStructureResolver.ts
@@ -3,6 +3,7 @@ import {
     compareHtmlStructure,
     extractPlainTextFromHtml,
     tryDeterministicStructureFix,
+    type HtmlStructureOptions,
 } from "../../../../sharedUtils/htmlStructureUtils";
 import type { CompletionConfig } from "../../../utils/llmUtils";
 import type { CodexCellDocument } from "../codexDocument";
@@ -73,9 +74,10 @@ export const verifyResolvedContent = (
     sourceHtml: string,
     originalTargetHtml: string,
     resolvedHtml: string,
+    options?: HtmlStructureOptions,
 ): string | null => {
     if (!resolvedHtml) return null;
-    if (!compareHtmlStructure(sourceHtml, resolvedHtml).isMatch) return null;
+    if (!compareHtmlStructure(sourceHtml, resolvedHtml, options).isMatch) return null;
 
     const sourceText = extractPlainTextFromHtml(sourceHtml);
     const originalText = extractPlainTextFromHtml(originalTargetHtml);
@@ -109,14 +111,14 @@ export const resolveCellHtmlStructure = async (
         return { status: "missing-content" };
     }
     const targetHtml = targetCell.cellContent;
-
-    if (compareHtmlStructure(sourceHtml, targetHtml).isMatch) {
-        return { status: "already-matched" };
-    }
-
-    const deterministicFix = tryDeterministicStructureFix(sourceHtml, targetHtml);
+    const metadata = document.getNotebookMetadata();
+    const deterministicFix = tryDeterministicStructureFix(sourceHtml, targetHtml, metadata);
     if (deterministicFix !== null) {
         return { status: "resolved", content: deterministicFix, method: "deterministic" };
+    }
+
+    if (compareHtmlStructure(sourceHtml, targetHtml, metadata).isMatch) {
+        return { status: "already-matched" };
     }
 
     try {
@@ -127,7 +129,7 @@ export const resolveCellHtmlStructure = async (
             targetHtml,
             completionConfig,
         );
-        const verified = verifyResolvedContent(sourceHtml, targetHtml, llmResult);
+        const verified = verifyResolvedContent(sourceHtml, targetHtml, llmResult, metadata);
         if (verified !== null) {
             return { status: "resolved", content: verified, method: "llm" };
         }
@@ -172,9 +174,7 @@ export const maybeRepairStructureDeterministically = async (
 
     const sourceHtml = await getSourceCellContent(cellId);
     if (!sourceHtml) return html;
-    if (compareHtmlStructure(sourceHtml, html).isMatch) return html;
-
-    return tryDeterministicStructureFix(sourceHtml, html) ?? html;
+    return tryDeterministicStructureFix(sourceHtml, html, metadata) ?? html;
 };
 
 export type AutoResolveHtmlStructureOptions = {
@@ -210,13 +210,13 @@ export const maybeAutoResolveHtmlStructure = async (
         return translatedHtml;
     }
 
-    if (compareHtmlStructure(sourceHtml, translatedHtml).isMatch) {
-        return translatedHtml;
-    }
-
-    const deterministicFix = tryDeterministicStructureFix(sourceHtml, translatedHtml);
+    const deterministicFix = tryDeterministicStructureFix(sourceHtml, translatedHtml, metadata);
     if (deterministicFix !== null) {
         return deterministicFix;
+    }
+
+    if (compareHtmlStructure(sourceHtml, translatedHtml, metadata).isMatch) {
+        return translatedHtml;
     }
 
     try {
@@ -225,7 +225,7 @@ export const maybeAutoResolveHtmlStructure = async (
         options?.onResolving?.();
         const resolveWithLLM = options?.resolveWithLLM ?? resolveHtmlStructureWithLLM;
         const llmResult = await resolveWithLLM(sourceHtml, translatedHtml, completionConfig);
-        return verifyResolvedContent(sourceHtml, translatedHtml, llmResult) ?? translatedHtml;
+        return verifyResolvedContent(sourceHtml, translatedHtml, llmResult, metadata) ?? translatedHtml;
     } catch (error) {
         console.error("[maybeAutoResolveHtmlStructure] Error:", error);
         return translatedHtml;

--- a/src/test/suite/newSourceUploader.test.ts
+++ b/src/test/suite/newSourceUploader.test.ts
@@ -214,6 +214,36 @@ suite("NewSourceUploaderProvider Test Suite", () => {
         assert.strictEqual(result.metadata.corpusMarker, "NT", "Should preserve corpusMarker");
     });
 
+    test("convertToNotebookPreview preserves round-trip metadata and drops binary import payloads", async () => {
+        const processedNotebook = {
+            name: "Story 1",
+            cells: [],
+            metadata: {
+                id: "test-obs",
+                originalFileName: "01.md",
+                sourceFile: "01.md",
+                importerType: "obs",
+                createdAt: new Date().toISOString(),
+                corpusMarker: "obs",
+                obsStory: '{"storyNumber":1}',
+                storyNumber: 1,
+                originalFileData: new ArrayBuffer(8),
+                docxDocument: "large transient XML",
+                sourceMetadata: { recursively: "duplicated" },
+            },
+        };
+
+        const convertToNotebookPreview = (provider as any).convertToNotebookPreview.bind(provider);
+        const result = await convertToNotebookPreview(processedNotebook);
+
+        assert.strictEqual(result.metadata.obsStory, '{"storyNumber":1}');
+        assert.strictEqual(result.metadata.storyNumber, 1);
+        assert.strictEqual(result.metadata.originalFileName, "01.md");
+        assert.strictEqual(result.metadata.originalFileData, undefined);
+        assert.strictEqual(result.metadata.docxDocument, undefined);
+        assert.strictEqual(result.metadata.sourceMetadata, undefined);
+    });
+
     test("convertToNotebookPreview converts USFM codes to full names for OT books during import", async () => {
         // Skip if no workspace folder
         if (!vscode.workspace.workspaceFolders?.[0]) {
@@ -462,4 +492,3 @@ suite("NewSourceUploaderProvider Test Suite", () => {
         );
     });
 });
-

--- a/src/test/suite/resolveCodexCustomMerge.test.ts
+++ b/src/test/suite/resolveCodexCustomMerge.test.ts
@@ -93,6 +93,50 @@ suite("Codex Custom Merge - Edit and Label Conflict Resolution", () => {
         assert.ok(gen1v10);
         assert.strictEqual(gen1v10.value, "<span>test from user 1</span>");
     });
+
+    test("applies arbitrary importer locator edits at top-level and nested metadata paths", async () => {
+        const ours: any = createCell("CELL-1", "Translated");
+        ours.metadata.paragraphIndex = 7;
+        ours.metadata.sourceSpan = { start: 40, end: 50 };
+        ours.metadata.data = { rowIndex: 7 };
+        ours.metadata.edits = [
+            {
+                editMap: ["metadata", "paragraphIndex"],
+                value: 7,
+                timestamp: 20,
+                type: "migration",
+                author: "system",
+            },
+            {
+                editMap: ["metadata", "sourceSpan", "start"],
+                value: 40,
+                timestamp: 20,
+                type: "migration",
+                author: "system",
+            },
+            {
+                editMap: ["metadata", "data", "rowIndex"],
+                value: 7,
+                timestamp: 20,
+                type: "migration",
+                author: "system",
+            },
+        ];
+        const theirs: any = createCell("CELL-1", "Translated");
+        theirs.metadata.paragraphIndex = 3;
+        theirs.metadata.sourceSpan = { start: 10, end: 20 };
+        theirs.metadata.data = { rowIndex: 3 };
+
+        const merged = JSON.parse(await resolveCodexCustomMerge(
+            createNotebook([ours]),
+            createNotebook([theirs]),
+        ));
+        const metadata = merged.cells[0].metadata;
+
+        assert.strictEqual(metadata.paragraphIndex, 7);
+        assert.deepStrictEqual(metadata.sourceSpan, { start: 40, end: 50 });
+        assert.strictEqual(metadata.data.rowIndex, 7);
+    });
 });
 
 suite("Codex Custom Merge - Paratextual Cell Position Preservation", () => {

--- a/src/test/suite/unit/htmlStructureResolver.test.ts
+++ b/src/test/suite/unit/htmlStructureResolver.test.ts
@@ -1,11 +1,13 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
+import { CodexCellTypes } from "../../../../types/enums";
 import type { CompletionConfig } from "../../../utils/llmUtils";
 import type { CodexCellDocument } from "../../../providers/codexCellEditorProvider/codexDocument";
 import {
     maybeAutoResolveHtmlStructure,
     maybeRepairStructureDeterministically,
+    resolveCellHtmlStructure,
     resolveHtmlStructureWithLLM,
     stripMarkdownCodeFences,
     verifyResolvedContent,
@@ -13,9 +15,9 @@ import {
 
 const mockConfig = { model: "test" } as CompletionConfig;
 
-const createMockDocument = (enforceHtmlStructure: boolean): CodexCellDocument =>
+const createMockDocument = (enforceHtmlStructure: boolean, importerType?: string): CodexCellDocument =>
     ({
-        getNotebookMetadata: () => ({ enforceHtmlStructure }),
+        getNotebookMetadata: () => ({ enforceHtmlStructure, importerType }),
     }) as CodexCellDocument;
 
 suite("htmlStructureResolver", () => {
@@ -138,6 +140,20 @@ suite("htmlStructureResolver", () => {
             assert.strictEqual(result, "<p>Hola</p>");
         });
 
+        test("restores DOCX style-only loss on save and on explicit resolve", async () => {
+            executeCommandStub.resolves({ cellId: "cell-13", content: '<p data-style-id="ListParagraph">Conscience is not the law.</p>' });
+            const target = "<p>La conciencia no es la ley.</p>";
+            const document = createMockDocument(true, "docx");
+            document.getCellContent = () => ({ cellContent: target, cellMarkers: ["cell-13"], cellType: CodexCellTypes.TEXT, editHistory: [] });
+            const expected = '<p data-style-id="ListParagraph">La conciencia no es la ley.</p>';
+            assert.strictEqual(await maybeRepairStructureDeterministically("cell-13", target, document), expected);
+            assert.deepStrictEqual(await resolveCellHtmlStructure("cell-13", document), {
+                status: "resolved", content: expected, method: "deterministic",
+            });
+            assert.strictEqual(await maybeRepairStructureDeterministically("cell-13", target, createMockDocument(true, "usfm")), target);
+            assert.strictEqual(await maybeRepairStructureDeterministically("cell-13", target, createMockDocument(false, "docx")), target);
+        });
+
         test("returns content unchanged when no deterministic fix applies", async () => {
             executeCommandStub.resolves({ cellId: "cell-1", content: "<p>Hello <em>World</em></p>" });
 
@@ -216,6 +232,15 @@ suite("htmlStructureResolver", () => {
             );
 
             assert.strictEqual(result, "<p>Hola</p>");
+        });
+
+        test("repairs DOCX attributes without calling the LLM", async () => {
+            executeCommandStub.resolves({ cellId: "cell", content: '<p data-style-id="ListParagraph">Source</p>' });
+            const resolveWithLLM = sinon.stub().resolves("must not be called");
+            const result = await maybeAutoResolveHtmlStructure("cell", "<p>Traducción</p>",
+                createMockDocument(true, "docx"), { config: mockConfig, resolveWithLLM });
+            assert.strictEqual(result, '<p data-style-id="ListParagraph">Traducción</p>');
+            assert.strictEqual(resolveWithLLM.callCount, 0);
         });
 
         test("fixes spurious span wrappers deterministically without calling the LLM", async () => {

--- a/src/test/suite/unit/reimportMerge.test.ts
+++ b/src/test/suite/unit/reimportMerge.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { getReimportSourceText } from "../../../providers/NewSourceUploader/reimportSourceText";
 import { CodexCellTypes, EditType } from "../../../../types/enums";
 import {
     mergeReimportedNotebookPair,
@@ -28,6 +29,66 @@ const findCell = (nb: ReimportNotebook, id: string): ReimportCell | undefined =>
 
 suite("reimportMerge", () => {
     suite("mergeReimportedNotebookPair", () => {
+        test("DOCX formatting-only re-import keeps the old heading id, translation and history", () => {
+            const metadata = { importerType: "docx" };
+            const data = { originalText: "Lesson #6, Chapter 2 Overview" };
+            const oldSource = textCell("old-title", '<p><span style="font-size: 18pt">Le</span><span style="font-size: 18pt">sson #6, Chapter 2 Overview</span></p>', {
+                paragraphIndex: 9, data,
+            });
+            const oldTarget = textCell("old-title", "<p>Lección #6, Resumen del Capítulo 2</p>", {
+                attachments: { audio: "recording.mp3" }, cellLabel: "Title",
+                edits: [{ editMap: ["value"], value: "Spanish", timestamp: 1, type: EditType.USER_EDIT }],
+            });
+            const newCell = textCell("fresh-title", '<p><span style="font-size: 18pt">Lesson #6, Chapter 2 Overview</span></p>', {
+                paragraphIndex: 30, paragraphMappingVersion: "outermost-no-fallback-v1", data,
+            });
+            const result = mergeReimportedNotebookPair(
+                notebook([oldSource], metadata), notebook([oldTarget], metadata),
+                notebook([newCell], metadata), notebook([textCell("fresh-title", "", newCell.metadata)], metadata),
+            );
+            assert.strictEqual(result.stats.matchedCells, 1);
+            assert.strictEqual(result.stats.droppedTranslations, 0);
+            const target = findCell(result.mergedCodex, "old-title")!;
+            assert.strictEqual(target.value, oldTarget.value);
+            assert.deepStrictEqual(target.metadata?.attachments, oldTarget.metadata?.attachments);
+            assert.strictEqual(target.metadata?.cellLabel, "Title");
+            assert.strictEqual(target.metadata?.paragraphIndex, 30);
+            assert.strictEqual(edits(target)[0].type, EditType.USER_EDIT);
+            assert.ok(edits(target).some((edit) => edit.editMap.join(".") === "metadata.paragraphIndex"));
+            assert.ok(edits(result.mergedSource.cells[0]).some((edit) => edit.editMap[0] === "value"));
+        });
+
+        test("DOCX text normalization keeps inline words, boundaries and single-decoded entities", () => {
+            const cell = textCell("x", '<p>Le<span>sson</span> A&amp;B</p><p>&#x43;&#68;&nbsp;&amp;lt;</p><p>x<br/>y</p>');
+            assert.strictEqual(getReimportSourceText(cell, true), "Lesson A&B CD &lt; x y");
+            assert.strictEqual(getReimportSourceText(cell, false), "Le sson A&B &#x43;&#68; < x y");
+        });
+
+        test("DOCX source corrections take precedence over stale originalText", () => {
+            const old = textCell("old", "<p>Changed source</p>", { data: { originalText: "Old source" } });
+            const fresh = textCell("new", "<p>Old source</p>", { data: { originalText: "Old source" } });
+            const metadata = { importerType: "docx" };
+            const result = mergeReimportedNotebookPair(
+                notebook([old], metadata), notebook([textCell("old", "Translation")], metadata),
+                notebook([fresh], metadata), notebook([textCell("new", "")], metadata),
+            );
+            assert.strictEqual(result.stats.matchedCells, 0);
+            assert.strictEqual(findCell(result.mergedCodex, "new")?.value, "");
+        });
+
+        test("does not apply DOCX inline matching to other importer types", () => {
+            for (const importerType of ["markdown", "obs", "usfm", "biblica", "indesign", "spreadsheet-csv", "spreadsheet-tsv"]) {
+                const metadata = { importerType };
+                const result = mergeReimportedNotebookPair(
+                    notebook([textCell("old", "<p>Le<span>sson</span></p>")], metadata),
+                    notebook([textCell("old", "Translation")], metadata),
+                    notebook([textCell("new", "<p>Lesson</p>")], metadata),
+                    notebook([textCell("new", "")], metadata),
+                );
+                assert.strictEqual(result.stats.matchedCells, 0, importerType);
+            }
+        });
+
         test("carries translations over for cells with identical source text", () => {
             const existingSource = notebook([textCell("old-1", "<p>Hello world</p>")]);
             const existingCodex = notebook([

--- a/src/test/suite/unit/reimportMerge.test.ts
+++ b/src/test/suite/unit/reimportMerge.test.ts
@@ -215,21 +215,38 @@ suite("reimportMerge", () => {
             assert.strictEqual(stats.droppedOldCells, 1);
         });
 
-        test("preserves target attachments and audio selection, and records data field changes as edits", () => {
-            const existingSource = notebook([textCell("old-1", "<p>Hello</p>")]);
+        test("preserves target attachments and records top-level and nested locator changes as edits", () => {
+            const existingSource = notebook([
+                textCell("old-1", "<p>Hello</p>", {
+                    paragraphIndex: 3,
+                    paragraphIndices: [3, 4],
+                    segmentIndex: 1,
+                }),
+            ]);
             const existingCodex = notebook([
                 textCell("old-1", "<p>Hola</p>", {
                     attachments: { "audio-1": { type: "audio" } },
                     selectedAudioId: "audio-1",
                     selectionTimestamp: 123,
-                    data: { paragraphIndex: 3 },
+                    paragraphIndex: 3,
+                    paragraphIndices: [3, 4],
+                    segmentIndex: 1,
+                    data: { rowIndex: 3 },
                 }),
             ]);
             const newSource = notebook([
-                textCell("new-1", "<p>Hello</p>", { data: { paragraphIndex: 7 } }),
+                textCell("new-1", "<p>Hello</p>", {
+                    paragraphIndex: 7,
+                    paragraphMappingVersion: "outermost-no-fallback-v1",
+                    data: { rowIndex: 7 },
+                }),
             ]);
             const newCodex = notebook([
-                textCell("new-1", "", { data: { paragraphIndex: 7 } }),
+                textCell("new-1", "", {
+                    paragraphIndex: 7,
+                    paragraphMappingVersion: "outermost-no-fallback-v1",
+                    data: { rowIndex: 7 },
+                }),
             ]);
 
             const { mergedCodex } = mergeReimportedNotebookPair(
@@ -244,13 +261,61 @@ suite("reimportMerge", () => {
             assert.strictEqual(metadata.selectedAudioId, "audio-1");
             assert.deepStrictEqual(metadata.attachments, { "audio-1": { type: "audio" } });
             // Structural metadata comes from the new parse...
-            assert.deepStrictEqual(metadata.data, { paragraphIndex: 7 });
+            assert.strictEqual(metadata.paragraphIndex, 7);
+            assert.strictEqual(metadata.paragraphMappingVersion, "outermost-no-fallback-v1");
+            assert.strictEqual(metadata.paragraphIndices, null);
+            assert.strictEqual(metadata.segmentIndex, null);
+            assert.deepStrictEqual(metadata.data, { rowIndex: 7 });
             // ...and the change is recorded as an edit so it survives sync.
-            const dataEdits = edits(mergedCodex.cells[0]).filter(
-                (e) => e.editMap.join(".") === "metadata.data.paragraphIndex"
+            const paragraphEdits = edits(mergedCodex.cells[0]).filter(
+                (e) => e.editMap.join(".") === "metadata.paragraphIndex"
             );
-            assert.strictEqual(dataEdits.length, 1);
-            assert.strictEqual(dataEdits[0].value, 7);
+            assert.strictEqual(paragraphEdits.length, 1);
+            assert.strictEqual(paragraphEdits[0].value, 7);
+            const rowEdits = edits(mergedCodex.cells[0]).filter(
+                (e) => e.editMap.join(".") === "metadata.data.rowIndex"
+            );
+            assert.strictEqual(rowEdits.length, 1);
+            assert.strictEqual(rowEdits[0].value, 7);
+            const clearedLocatorEdits = edits(mergedCodex.cells[0]).filter(
+                (e) => ["metadata.paragraphIndices", "metadata.segmentIndex"].includes(e.editMap.join("."))
+            );
+            assert.strictEqual(clearedLocatorEdits.length, 2);
+            assert.ok(clearedLocatorEdits.every((edit) => edit.value === null));
+        });
+
+        test("remaps file-level cell references to retained ids and records metadata edits", () => {
+            const existingSource = notebook([textCell("old-1", "<p>Hello</p>")], {
+                structureMetadata: {
+                    lineMappings: [{ lineIndex: 1, cellId: "old-1" }],
+                },
+                edits: [],
+            });
+            const existingCodex = notebook([textCell("old-1", "<p>Hola</p>")]);
+            const newSource = notebook([textCell("new-1", "<p>Hello</p>")], {
+                structureMetadata: {
+                    lineMappings: [{ lineIndex: 2, cellId: "new-1" }],
+                },
+                edits: [],
+            });
+            const newCodex = notebook([textCell("new-1", "")]);
+
+            const { mergedSource } = mergeReimportedNotebookPair(
+                existingSource,
+                existingCodex,
+                newSource,
+                newCodex
+            );
+
+            assert.deepStrictEqual(mergedSource.metadata?.structureMetadata, {
+                lineMappings: [{ lineIndex: 2, cellId: "old-1" }],
+            });
+            const metadataEdits = mergedSource.metadata?.edits as ReimportEdit[];
+            const structureEdit = metadataEdits.find(
+                (edit) => edit.editMap.join(".") === "metadata.structureMetadata"
+            );
+            assert.ok(structureEdit);
+            assert.deepStrictEqual(structureEdit?.value, mergedSource.metadata?.structureMetadata);
         });
 
         test("re-inserts paratext cells after their surviving parent and tombstones orphaned ones", () => {

--- a/src/test/suite/unit/updateExistingImport.test.ts
+++ b/src/test/suite/unit/updateExistingImport.test.ts
@@ -1,0 +1,72 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import type { NotebookPreview } from "../../../../types";
+import { updateExistingImportPair } from "../../../providers/NewSourceUploader/updateExistingImport";
+import type { ReimportNotebook } from "../../../providers/NewSourceUploader/reimportMerge";
+
+suite("DOCX update-existing safety", () => {
+    const pair = {
+        notebookBaseName: "lesson", displayName: "Lesson",
+        sourceUri: vscode.Uri.parse("docx-update-safety-test:/lesson.source"),
+        codexUri: vscode.Uri.parse("docx-update-safety-test:/lesson.codex"),
+    };
+    const notebook = (id: string, value: string, importerType: string): ReimportNotebook => ({
+        metadata: { importerType },
+        cells: [{ kind: 2, value, metadata: { id, type: "text", data: {}, edits: [] } }],
+    });
+    let sandbox: sinon.SinonSandbox;
+    let files: Map<string, Uint8Array>;
+    let writes: number;
+    let registration: vscode.Disposable;
+    let events: vscode.EventEmitter<vscode.FileChangeEvent[]>;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        files = new Map();
+        writes = 0;
+        events = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+        registration = vscode.workspace.registerFileSystemProvider("docx-update-safety-test", {
+            onDidChangeFile: events.event,
+            watch: () => ({ dispose() {} }),
+            stat: (uri) => ({ type: vscode.FileType.File, ctime: 0, mtime: 0, size: files.get(uri.path)?.length ?? 0 }),
+            readDirectory: () => [],
+            createDirectory: () => {},
+            readFile: (uri) => {
+                const content = files.get(uri.path);
+                if (!content) throw vscode.FileSystemError.FileNotFound(uri);
+                return content;
+            },
+            writeFile: (uri, content) => { writes++; files.set(uri.path, content); },
+            delete: (uri) => { files.delete(uri.path); },
+            rename: () => { throw new Error("Unexpected rename"); },
+        });
+    });
+    teardown(() => {
+        sandbox.restore();
+        registration.dispose();
+        events.dispose();
+    });
+
+    for (const scenario of ["cancel", "confirm", "other-format", "matched"] as const) {
+        test(`${scenario}: checks before any notebook write`, async () => {
+            const importer = scenario === "other-format" ? "markdown" : "docx";
+            files.set(pair.sourceUri.path, new TextEncoder().encode(JSON.stringify(notebook("old", "<p>Original sentence.</p>", importer))));
+            files.set(pair.codexUri.path, new TextEncoder().encode(JSON.stringify(notebook("old", "<p>Traducción.</p>", importer))));
+            const originalFiles = new Map(files);
+            const warning = sandbox.stub(vscode.window, "showWarningMessage");
+            warning.callsFake(async () => {
+                assert.strictEqual(writes, 0);
+                return scenario === "confirm" ? "Update Anyway" as never : undefined;
+            });
+            const freshSource = notebook("new", scenario === "matched" ? "<p>Original sentence.</p>" : "<p>Different text.</p>", importer);
+            const result = await updateExistingImportPair(pair,
+                freshSource as unknown as NotebookPreview,
+                notebook("new", "", importer) as unknown as NotebookPreview);
+            assert.strictEqual(Boolean(result.cancelled), scenario === "cancel");
+            assert.strictEqual(writes, scenario === "cancel" ? 0 : 2);
+            if (scenario === "cancel") assert.deepStrictEqual(files, originalFiles);
+            assert.strictEqual(warning.callCount, ["cancel", "confirm"].includes(scenario) ? 1 : 0);
+        });
+    }
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CellList.tsx
@@ -30,7 +30,7 @@ import SourceCellContext from "./contextProviders/SourceCellContext";
 import CommentsBadge from "./CommentsBadge";
 import { useMessageHandler } from "./hooks/useCentralizedMessageDispatcher";
 import { sanitizeQuillHtml } from "./utils";
-import { compareHtmlStructure, getStructureMismatchDescription } from "./utils/htmlStructureValidator";
+import { getHtmlStructureRepairDiff, getStructureMismatchDescription } from "./utils/htmlStructureValidator";
 import type { ReactPlayerRef } from "./types/reactPlayerTypes";
 import type { AudioAvailability } from "./utils/audioViewMode";
 
@@ -312,13 +312,13 @@ const CellList: React.FC<CellListProps> = ({
             const targetHtml = cell.cellContent;
             if (!sourceHtml || !targetHtml) continue;
 
-            const diff = compareHtmlStructure(sourceHtml, targetHtml);
+            const diff = getHtmlStructureRepairDiff(sourceHtml, targetHtml, metadata);
             if (!diff.isMatch) {
                 errors.set(cellId, getStructureMismatchDescription(diff));
             }
         }
         return errors;
-    }, [workingTranslationUnits, enforceHtmlStructure, isSourceText, sourceCellMap]);
+    }, [workingTranslationUnits, enforceHtmlStructure, isSourceText, sourceCellMap, metadata?.importerType, metadata?.corpusMarker]);
 
     // Convert arrays to Sets for faster lookups
     const translationQueueSet = useMemo(() => new Set(translationQueue), [translationQueue]);

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -3254,11 +3254,14 @@ const CodexCellEditor: React.FC = () => {
                 sourceCellMap,
                 metadata?.enforceHtmlStructure ?? false,
                 isSourceText,
+                metadata,
             ),
         [
             translationUnitsWithCurrentEditorContent,
             sourceCellMap,
             metadata?.enforceHtmlStructure,
+            metadata?.importerType,
+            metadata?.corpusMarker,
             isSourceText,
         ],
     );

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/docxHtmlFormatting.test.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/docxHtmlFormatting.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import Quill from "quill";
+import {
+    collapseAdjacentEquivalentStyledSpans,
+} from "../../../../../sharedUtils/docxHtmlFormatting";
+import {
+    compareHtmlStructure,
+    getHtmlStructureRepairDiff,
+    tryDeterministicStructureFix,
+} from "../../../../../sharedUtils/htmlStructureUtils";
+import { getStructureMismatchCellIds } from "./structureMismatchCells";
+import type { QuillCellContent } from "../../../../../types";
+
+const docx = { importerType: "docx" };
+const sourceTitle = '<p data-alignment="center" style="text-align: center">' +
+    '<span style="font-size: 18pt; font-family: FFF Tusj Bold"><u>Le</u></span>' +
+    '<span style="font-size: 18pt; font-family: FFF Tusj Bold"><u>sson #6, Chapter 2 Overview</u></span></p>';
+const spanish = "Lección #6, Resumen del Capítulo 2";
+const fix = (source: string, target: string) => tryDeterministicStructureFix(source, target, docx);
+
+describe("DOCX formatting compatibility", () => {
+    it("recognizes equivalent legacy title spans without rewriting the translation", () => {
+        const target = collapseAdjacentEquivalentStyledSpans(sourceTitle).replace("Lesson #6, Chapter 2 Overview", spanish);
+        expect(compareHtmlStructure(sourceTitle, target, docx).isMatch).toBe(true);
+        expect(fix(sourceTitle, target)).toBeNull();
+        expect(compareHtmlStructure(sourceTitle, target).isMatch).toBe(false);
+    });
+
+    it("repairs a plain translated heading, preserving text and all source presentation", () => {
+        const repaired = fix(sourceTitle, `<p>${spanish}</p>`)!;
+        const element = document.createElement("div");
+        element.innerHTML = repaired;
+        expect(element.textContent).toBe(spanish);
+        expect(element.querySelector("p")?.style.textAlign).toBe("center");
+        expect(element.querySelector("span")?.style.fontSize).toBe("18pt");
+        expect(element.querySelector("u")?.textContent).toBe(spanish);
+        expect(fix(sourceTitle, repaired)).toBeNull();
+    });
+
+    it.each([" ", "\n", "\t", "  "])("keeps inter-span whitespace %j", (space) => {
+        const html = `<p><span style="color: red">Hola</span>${space}<span style="color: red">mundo</span></p>`;
+        expect(collapseAdjacentEquivalentStyledSpans(html)).toBe(`<p><span style="color: red">Hola${space}mundo</span></p>`);
+    });
+
+    it.each([
+        '<p><span style="color: red">A</span><span style="color: blue">B</span></p>',
+        '<p><span style="color: red" data-tag="bd">A</span><span style="color: red" data-tag="bd">B</span></p>',
+        '<p><span style="color: red"><strong>A</strong></span><span style="color: red"><em>B</em></span></p>',
+        '<p><span style="color: red"><a href="/a">A</a></span><span style="color: red">B</span></p>',
+        '<p><span style="color: red" lang="en">A</span><span style="color: red" lang="en">B</span></p>',
+        '<p><span style="color: red">A</span></p><p><span style="color: red">B</span></p>',
+    ])("leaves different formatting and semantic content intact: %s", (html) => {
+        expect(collapseAdjacentEquivalentStyledSpans(html)).toBe(html);
+    });
+
+    it("repairs attribute-only loss and exposes it to Resolve All", () => {
+        const source = '<p data-style-id="ListParagraph">Conscience is not the law.</p>';
+        const target = "<p>La conciencia no es la ley.</p>";
+        expect(compareHtmlStructure(source, target, docx).isMatch).toBe(true);
+        expect(getHtmlStructureRepairDiff(source, target, docx).isMatch).toBe(false);
+        const repaired = fix(source, target)!;
+        expect(repaired).toBe('<p data-style-id="ListParagraph">La conciencia no es la ley.</p>');
+        const cells = [{ cellMarkers: ["cell-13"], cellContent: target }] as QuillCellContent[];
+        const sources = { "cell-13": { content: source } };
+        expect(getStructureMismatchCellIds(cells, sources, true, false, docx)).toEqual(["cell-13"]);
+        expect(getStructureMismatchCellIds(cells, sources, false, false, docx)).toEqual([]);
+        expect(getStructureMismatchCellIds(cells, sources, true, true, docx)).toEqual([]);
+        cells[0].cellContent = repaired;
+        expect(getStructureMismatchCellIds(cells, sources, true, false, docx)).toEqual([]);
+    });
+
+    it("supports legacy DOCX notebook metadata but does not override another importer", () => {
+        const source = '<p data-style-id="ListParagraph">Source</p>';
+        expect(tryDeterministicStructureFix(source, "<p>Target</p>", { corpusMarker: "docx" })).not.toBeNull();
+        expect(tryDeterministicStructureFix(source, "<p>Target</p>", { importerType: "markdown", corpusMarker: "docx" })).toBeNull();
+    });
+
+    it.each(["markdown", "obs", "usfm", "biblica", "indesign", "spreadsheet-csv", "spreadsheet-tsv", "pdf", "tms"])(
+        "does not apply DOCX normalization or attribute repair to %s", (importerType) => {
+            const context = { importerType };
+            const canonical = collapseAdjacentEquivalentStyledSpans(sourceTitle);
+            expect(compareHtmlStructure(sourceTitle, canonical, context).isMatch).toBe(false);
+            const source = '<p data-style-id="ListParagraph">Source</p>';
+            expect(tryDeterministicStructureFix(source, "<p>Target</p>", context)).toBeNull();
+            expect(getHtmlStructureRepairDiff(source, "<p>Target</p>", context).isMatch).toBe(true);
+        },
+    );
+
+    it.each([
+        ['<p style="text-align: left">English</p>', '<p style="text-align: right" dir="rtl">Español</p>'],
+        ['<p><a href="/en">English</a></p>', '<p><a href="/es">Español</a></p>'],
+        ['<p lang="en">English</p>', '<p lang="es">Español</p>'],
+        ['<p data-style-id="Normal">English</p>', '<p data-style-id="Title">Español</p>'],
+        ['<p style="font-size: 18pt">English</p>', '<p class="ql-size-large">Español</p>'],
+        ['<p><em>English</em></p>', '<p class="custom-target-format">Español</p>'],
+        ['<p style="font-size: 18pt; font-family: Arial">English</p>', '<p style="font: italic 24pt Georgia">Español</p>'],
+        ['<p style="margin-left: 20pt">English</p>', '<p style="margin: 0">Español</p>'],
+        ['<p style="text-align: left">English</p>', '<p align="right">Español</p>'],
+        ['<p style="text-align: left">English</p>', '<p data-alignment="right">Español</p>'],
+        ['<p data-style-id="Normal">English</p>', '<p>Hola</p><p>mundo</p>'],
+        ['<p data-style-id="Normal">English</p>', '<p><br></p>'],
+        ['<p data-style-id="Normal">English</p>', '<p>Click to translate</p>'],
+    ])("does not overwrite target presentation, semantics, or user line breaks", (source, target) => {
+        expect(fix(source, target)).toBeNull();
+    });
+
+    it("keeps target links, footnotes, and whitespace when restoring the paragraph style", () => {
+        const source = '<p data-style-id="Normal">See <a href="/en">link</a><sup>1</sup>.</p>';
+        const target = '<p>Ver <a href="/es" title="Español">enlace</a><sup data-footnote="Nota">1</sup>. </p>';
+        expect(fix(source, target)).toBe(target.replace("<p>", '<p data-style-id="Normal">'));
+    });
+
+    it("does not override inherited target font size while inserting a missing span", () => {
+        const source = '<p><span style="font-size: 18pt">Source</span></p>';
+        const target = '<p style="font-size: 24pt">Traducción</p>';
+        const repaired = fix(source, target)!;
+        expect(repaired).toBe('<p style="font-size: 24pt"><span>Traducción</span></p>');
+        expect(fix(source, repaired)).toBeNull();
+    });
+
+    it("preserves missing CSS defaults alongside existing target properties", () => {
+        const source = '<p style="text-align: center; line-height: 1.2">Source</p>';
+        const target = '<p style="text-align: right; color: blue">Traducción</p>';
+        expect(fix(source, target)).toBe('<p style="text-align: right; color: blue; line-height: 1.2">Traducción</p>');
+    });
+
+    it("keeps formatting after repeated real Quill load/save/repair cycles", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const quill = new Quill(container);
+        let saved = fix(sourceTitle, `<p>${spanish}</p>`)!;
+        try {
+            for (let cycle = 0; cycle < 3; cycle++) {
+                quill.clipboard.dangerouslyPasteHTML(saved);
+                const serialized = quill.root.innerHTML;
+                saved = fix(sourceTitle, serialized) ?? serialized;
+                expect(compareHtmlStructure(sourceTitle, saved, docx).isMatch).toBe(true);
+                expect(saved).toContain("font-size: 18pt");
+                expect(saved).toContain("FFF Tusj Bold");
+                expect(saved.replace(/<[^>]*>/g, "")).toBe(spanish);
+            }
+        } finally {
+            container.remove();
+        }
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureValidator.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/htmlStructureValidator.ts
@@ -1,6 +1,8 @@
 export {
     extractHtmlSkeleton,
     compareHtmlStructure,
+    getHtmlStructureRepairDiff,
     getStructureMismatchDescription,
     type HtmlStructureDiff,
+    type HtmlStructureOptions,
 } from "../../../../../sharedUtils/htmlStructureUtils";

--- a/webviews/codex-webviews/src/CodexCellEditor/utils/structureMismatchCells.ts
+++ b/webviews/codex-webviews/src/CodexCellEditor/utils/structureMismatchCells.ts
@@ -1,11 +1,12 @@
 import type { QuillCellContent } from "../../../../../types";
-import { compareHtmlStructure } from "./htmlStructureValidator";
+import { getHtmlStructureRepairDiff, type HtmlStructureOptions } from "./htmlStructureValidator";
 
 export function getStructureMismatchCellIds(
     cells: QuillCellContent[],
     sourceCellMap: Record<string, { content: string }>,
     enforceHtmlStructure: boolean,
     isSourceText: boolean,
+    options?: HtmlStructureOptions,
 ): string[] {
     if (!enforceHtmlStructure || isSourceText) {
         return [];
@@ -21,7 +22,7 @@ export function getStructureMismatchCellIds(
         const targetHtml = cell.cellContent;
         if (!sourceHtml || !targetHtml) continue;
 
-        const diff = compareHtmlStructure(sourceHtml, targetHtml);
+        const diff = getHtmlStructureRepairDiff(sourceHtml, targetHtml, options);
         if (!diff.isMatch) {
             mismatchedCellIds.push(cellId);
         }

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/csvRecordUtils.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/csvRecordUtils.ts
@@ -1,0 +1,35 @@
+export type DelimitedRecord = {
+    content: string;
+    /** Exact record terminator from the source ("\n", "\r\n", "\r", or empty). */
+    ending: string;
+};
+
+/** Split CSV/TSV into logical records without splitting newlines inside quoted fields. */
+export function splitDelimitedRecords(source: string): DelimitedRecord[] {
+    const records: DelimitedRecord[] = [];
+    let start = 0;
+    let inQuotes = false;
+
+    for (let index = 0; index < source.length; index++) {
+        const char = source[index];
+        if (char === '"') {
+            if (inQuotes && source[index + 1] === '"') {
+                index++;
+            } else {
+                inQuotes = !inQuotes;
+            }
+            continue;
+        }
+        if (!inQuotes && (char === '\n' || char === '\r')) {
+            const ending = char === '\r' && source[index + 1] === '\n' ? '\r\n' : char;
+            records.push({ content: source.slice(start, index), ending });
+            if (ending === '\r\n') index++;
+            start = index + 1;
+        }
+    }
+
+    if (start < source.length || records.length === 0) {
+        records.push({ content: source.slice(start), ending: '' });
+    }
+    return records;
+}

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/parser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/parser.ts
@@ -1,4 +1,5 @@
 import { ParsedSpreadsheet, SpreadsheetColumn, SpreadsheetRow } from './types';
+import { splitDelimitedRecords } from './csvRecordUtils';
 
 /**
  * Lightweight analysis for UI stats (no full row normalization).
@@ -21,7 +22,9 @@ export function quickAnalyzeSpreadsheet(content: string): SpreadsheetQuickAnalys
     }
 
     const delimiter = detectDelimiter(content);
-    const allLines = content.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+    const allLines = splitDelimitedRecords(content)
+        .map((record) => record.content.trim())
+        .filter((line) => line.length > 0);
 
     if (allLines.length === 0) {
         return {
@@ -66,7 +69,10 @@ export function quickAnalyzeSpreadsheet(content: string): SpreadsheetQuickAnalys
  * Detect the delimiter used in a CSV/TSV file
  */
 function detectDelimiter(content: string): string {
-    const lines = content.split('\n').slice(0, 5); // Check first 5 lines
+    const lines = splitDelimitedRecords(content)
+        .map((record) => record.content)
+        .filter((line) => line.trim())
+        .slice(0, 5);
     const delimiters = [',', '\t', ';', '|'];
     const counts: { [key: string]: number; } = {};
 
@@ -74,7 +80,7 @@ function detectDelimiter(content: string): string {
         counts[delimiter] = 0;
         for (const line of lines) {
             if (line.trim()) {
-                counts[delimiter] += (line.match(new RegExp(`\\${delimiter}`, 'g')) || []).length;
+                counts[delimiter] += Math.max(0, parseCSVLine(line, delimiter).length - 1);
             }
         }
     }
@@ -154,15 +160,16 @@ function getSampleValues(rows: SpreadsheetRow[], columnIndex: number, maxSamples
  */
 export async function parseSpreadsheetFile(file: File): Promise<ParsedSpreadsheet> {
     const content = await file.text();
+    const parseContent = content.charCodeAt(0) === 0xFEFF ? content.slice(1) : content;
 
-    if (!content.trim()) {
+    if (!parseContent.trim()) {
         throw new Error('File is empty');
     }
 
-    const delimiter = detectDelimiter(content);
-    const allLines = content.split('\n').map(line => line.trim()).filter(line => line);
+    const delimiter = detectDelimiter(parseContent);
+    const allLines = splitDelimitedRecords(parseContent).map((record) => record.content.trim());
 
-    if (allLines.length === 0) {
+    if (allLines.length === 0 || allLines.every((line) => !line)) {
         throw new Error('No data found in file');
     }
 
@@ -206,7 +213,8 @@ export async function parseSpreadsheetFile(file: File): Promise<ParsedSpreadshee
         columns,
         rows: normalizedRows,
         delimiter,
-        filename: file.name.replace(/\.[^/.]+$/, '') // Remove extension
+        filename: file.name.replace(/\.[^/.]+$/, ''), // Remove extension
+        hasHeader,
     };
 }
 
@@ -236,4 +244,4 @@ export function validateSpreadsheetFile(file: File): { isValid: boolean; errors:
         isValid: errors.length === 0,
         errors
     };
-} 
+}

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetExporter.ts
@@ -8,12 +8,14 @@
  * 
  * Supports both spreadsheet-csv and spreadsheet-tsv importer types.
  */
+import { splitDelimitedRecords } from './csvRecordUtils';
 
 export interface SpreadsheetCell {
     id: string;
     value: string;
     metadata: {
         id?: string;
+        type?: string;
         data?: {
             rowIndex?: number;
             originalRowValues?: string[];
@@ -35,6 +37,7 @@ export interface SpreadsheetNotebookMetadata {
     sourceColumnIndex?: number;
     columnCount?: number;
     importerType?: string;
+    hasHeader?: boolean;
 }
 
 /**
@@ -140,7 +143,7 @@ export function exportSpreadsheetWithTranslations(
     for (const cell of cells) {
         const rowIndex = cell.metadata?.data?.rowIndex;
         const data = cell.metadata?.data;
-        if (data?.merged || data?.deleted || data?.hidden) {
+        if (data?.merged || data?.deleted || data?.hidden || cell.metadata?.type === 'milestone') {
             continue;
         }
         const translation = stripHtmlTags(cell.value || '');
@@ -164,49 +167,38 @@ export function exportSpreadsheetWithTranslations(
 
         // Remove BOM if present (UTF-8 BOM: EF BB BF)
         let cleanContent = originalFileContent;
+        let byteOrderMark = '';
         if (cleanContent.charCodeAt(0) === 0xFEFF) {
+            byteOrderMark = '\uFEFF';
             cleanContent = cleanContent.substring(1);
-            console.log(`[Spreadsheet Export] Removed BOM from content`);
+            console.log(`[Spreadsheet Export] Preserving BOM from original content`);
         }
 
-        // Handle both Unix (\n) and Windows (\r\n) line endings
-        const lines = cleanContent.split(/\r?\n/);
-        const outputLines: string[] = [];
+        const records = splitDelimitedRecords(cleanContent);
+        const outputRecords: string[] = [];
+        const dataStartIndex = metadata.hasHeader === false ? 0 : 1;
 
-        console.log(`[Spreadsheet Export] File has ${lines.length} lines`);
+        console.log(`[Spreadsheet Export] File has ${records.length} logical records`);
 
-        // First line is ALWAYS the header - keep it EXACTLY as is
-        if (lines.length > 0) {
-            const headerLine = lines[0];
-            // Keep header line unchanged - DO NOT parse or modify it
-            outputLines.push(headerLine);
-            console.log(`[Spreadsheet Export] Preserved header (${headerLine.length} chars): "${headerLine.substring(0, 100)}${headerLine.length > 100 ? '...' : ''}"`);
+        for (let i = 0; i < dataStartIndex && i < records.length; i++) {
+            outputRecords.push(records[i].content + records[i].ending);
         }
 
-        // Process data rows (skip first line which is header)
-        for (let i = 1; i < lines.length; i++) {
-            const line = lines[i];
-
-            // Skip empty lines at the end
-            if (!line.trim() && i === lines.length - 1) {
+        for (let i = dataStartIndex; i < records.length; i++) {
+            const record = records[i];
+            if (!record.content.trim()) {
+                outputRecords.push(record.content + record.ending);
                 continue;
             }
 
-            // Skip completely empty lines
-            if (!line.trim()) {
-                outputLines.push(line);
-                continue;
-            }
-
-            // Data row index (0-based, excluding header)
-            const dataRowIndex = i - 1;
+            const dataRowIndex = i - dataStartIndex;
 
             // Check if we have a translation for this row
             const translation = translationsByRow.get(dataRowIndex);
 
             if (translation) {
                 // Parse the line to replace the source column
-                const fields = parseCSVLine(line, delimiter);
+                const fields = parseCSVLine(record.content, delimiter);
 
                 if (effectiveSourceColumnIndex < fields.length) {
                     // Replace the source column with the translation
@@ -215,15 +207,15 @@ export function exportSpreadsheetWithTranslations(
 
                 // Rebuild the line with proper escaping
                 const outputLine = fields.map(f => escapeField(f, delimiter)).join(delimiter);
-                outputLines.push(outputLine);
+                outputRecords.push(outputLine + record.ending);
             } else {
                 // No translation for this row - keep it exactly as is
-                outputLines.push(line);
+                outputRecords.push(record.content + record.ending);
             }
         }
 
-        console.log(`[Spreadsheet Export] Output ${outputLines.length} lines (1 header + ${outputLines.length - 1} data rows)`);
-        return outputLines.join('\n');
+        console.log(`[Spreadsheet Export] Output ${outputRecords.length} logical records`);
+        return byteOrderMark + outputRecords.join('');
     }
 
     // Fallback: reconstruct from cell metadata (for legacy imports without originalFileContent)
@@ -250,7 +242,12 @@ export function exportSpreadsheetWithTranslations(
         const cellData = cell.metadata?.data;
         const originalRowValues = cellData?.originalRowValues;
         const cellSourceColumnIndex = cellData?.sourceColumnIndex ?? sourceColumnIndex;
-        const isInactive = !!(cellData?.merged || cellData?.deleted || cellData?.hidden);
+        const isInactive = !!(
+            cellData?.merged ||
+            cellData?.deleted ||
+            cellData?.hidden ||
+            cell.metadata?.type === 'milestone'
+        );
         // For inactive cells, keep the original row values (treat as untranslated)
         const translation = isInactive ? '' : stripHtmlTags(cell.value || '');
 

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetImportCore.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetImportCore.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildSpreadsheetImportResult } from "./spreadsheetImportCore";
+import { parseSpreadsheetFile } from "./parser";
+import { exportSpreadsheetWithTranslations } from "./spreadsheetExporter";
+
+describe("spreadsheet round-trip row coordinates", () => {
+    it("accepts source column zero and retains physical row indices after empty rows", async () => {
+        const content = "Source,Notes\nFirst,a\n,b\nThird,c\n";
+        const file = {
+            name: "sample.csv",
+            size: content.length,
+            text: async () => content,
+        } as File;
+        const parsedData = {
+            filename: "sample",
+            delimiter: ",",
+            columns: [
+                { index: 0, name: "Source", sampleValues: ["First", "Third"] },
+                { index: 1, name: "Notes", sampleValues: ["a", "b", "c"] },
+            ],
+            rows: [
+                { 0: "First", 1: "a" },
+                { 0: "", 1: "b" },
+                { 0: "Third", 1: "c" },
+            ],
+            hasHeader: true,
+        };
+
+        const result = await buildSpreadsheetImportResult(
+            file,
+            parsedData,
+            { isTranslationImport: false, columnMapping: { 0: "source", 1: "unused" } },
+            () => undefined,
+        );
+        const textCells = result.notebookPairWithMilestones.source.cells.filter(
+            (cell) => cell.metadata?.type === "text",
+        );
+
+        expect(textCells.map((cell) => cell.metadata?.data?.rowIndex)).toEqual([0, 2]);
+    });
+
+    it("keeps multiline records, blank rows, BOM, and CRLF aligned during export", async () => {
+        const content = '\uFEFFSource,Notes\r\n"First\ncontinued",a\r\n,b\r\nThird,c\r\n';
+        const file = {
+            name: "multiline.csv",
+            size: content.length,
+            text: async () => content,
+        } as File;
+        const parsedData = await parseSpreadsheetFile(file);
+        expect(parsedData.rows).toHaveLength(3);
+        expect(parsedData.rows[0][0]).toBe("First\ncontinued");
+
+        const built = await buildSpreadsheetImportResult(
+            file,
+            parsedData,
+            { isTranslationImport: false, columnMapping: { 0: "source", 1: "unused" } },
+            () => undefined,
+        );
+        const textCells = built.notebookPairWithMilestones.codex.cells.filter(
+            (cell) => cell.metadata?.type === "text",
+        );
+        expect(textCells.map((cell) => cell.metadata?.data?.rowIndex)).toEqual([0, 2]);
+        textCells[1].content = "<p>Tercero</p>";
+
+        const output = exportSpreadsheetWithTranslations(
+            textCells.map((cell) => ({
+                id: cell.id,
+                value: cell.content,
+                metadata: cell.metadata,
+            })) as never,
+            built.notebookPairWithMilestones.codex.metadata as never,
+        );
+        expect(output).toBe('\uFEFFSource,Notes\r\n"First\ncontinued",a\r\n,b\r\nTercero,c\r\n');
+    });
+
+    it("translates the first physical record when the spreadsheet has no header", () => {
+        const output = exportSpreadsheetWithTranslations(
+            [{
+                id: "row-0",
+                value: "<p>Primero</p>",
+                metadata: { data: { rowIndex: 0, sourceColumnIndex: 0 } },
+            }],
+            {
+                originalFileContent: "First,a\nSecond,b\n",
+                sourceColumnIndex: 0,
+                delimiter: ",",
+                hasHeader: false,
+            },
+        );
+
+        expect(output).toBe("Primero,a\nSecond,b\n");
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetImportCore.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/spreadsheetImportCore.ts
@@ -96,7 +96,7 @@ export async function buildSpreadsheetImportResult(
     const targetColumnIndex = findColumnIndex(columnMapping, "target");
     const attachmentsColumnIndex = findColumnIndex(columnMapping, "attachments");
 
-    if (!sourceColumnIndex && !targetColumnIndex) {
+    if (sourceColumnIndex === undefined && targetColumnIndex === undefined) {
         throw new Error("Could not detect a source or target text column from headers. Name a column Source, Target, or similar.");
     }
 
@@ -112,8 +112,9 @@ export async function buildSpreadsheetImportResult(
 
     if (isTranslationImport) {
         const cells = parsedData.rows
-            .filter((row) => row[targetColumnIndex!]?.trim())
-            .map((row, index) => {
+            .map((row, rowIndex) => ({ row, rowIndex }))
+            .filter(({ row }) => row[targetColumnIndex!]?.trim())
+            .map(({ row, rowIndex }) => {
                 const globalReferences = globalReferencesColumnIndex !== undefined
                     ? parseGlobalReferencesField(row[globalReferencesColumnIndex])
                     : [];
@@ -127,7 +128,7 @@ export async function buildSpreadsheetImportResult(
                         type: CodexCellTypes.TEXT,
                         edits: [],
                         data: {
-                            rowIndex: index,
+                            rowIndex,
                             globalReferences,
                         },
                     },
@@ -158,8 +159,9 @@ export async function buildSpreadsheetImportResult(
     }
 
     const sourceCells = parsedData.rows
-        .filter((row) => row[sourceColumnIndex!]?.trim())
-        .map((row, index) => {
+        .map((row, rowIndex) => ({ row, rowIndex }))
+        .filter(({ row }) => row[sourceColumnIndex!]?.trim())
+        .map(({ row, rowIndex }) => {
             const globalReferences =
                 globalReferencesColumnIndex !== undefined
                     ? parseGlobalReferencesField(row[globalReferencesColumnIndex])
@@ -172,7 +174,7 @@ export async function buildSpreadsheetImportResult(
 
             const { cellId, metadata: cellMetadata } = createSpreadsheetCellMetadata({
                 originalContent: row[sourceColumnIndex!],
-                rowIndex: index,
+                rowIndex,
                 originalRowValues,
                 sourceColumnIndex: sourceColumnIndex!,
                 fileName: file.name,
@@ -220,6 +222,7 @@ export async function buildSpreadsheetImportResult(
                 columnHeaders,
                 sourceColumnIndex: sourceColumnIndex!,
                 originalFileContent,
+                hasHeader: parsedData.hasHeader,
             },
         },
         codex: {
@@ -243,6 +246,7 @@ export async function buildSpreadsheetImportResult(
                 columnHeaders,
                 sourceColumnIndex: sourceColumnIndex!,
                 originalFileContent,
+                hasHeader: parsedData.hasHeader,
             },
         },
     };

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/types.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/bibleSpredSheet/types.ts
@@ -19,6 +19,7 @@ export interface ParsedSpreadsheet {
     rows: SpreadsheetRow[];
     delimiter: string;
     filename: string;
+    hasHeader: boolean;
 }
 
 export interface SpreadsheetCell {
@@ -32,4 +33,4 @@ export type ColumnType = 'globalReferences' | 'source' | 'target' | 'attachments
 
 export interface ColumnTypeSelection {
     [columnIndex: number]: ColumnType;
-} 
+}

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/biblica/biblicaExporter.ts
@@ -737,7 +737,7 @@ export async function exportIdmlRoundtrip(
         // Soft-deleted cells (e.g. retired by a re-import) keep their content
         // and stale paragraph coordinates — exporting them would write old
         // translations into the wrong paragraphs.
-        if (meta?.data?.deleted === true) continue;
+        if (meta?.data?.merged || meta?.data?.deleted || meta?.data?.hidden) continue;
 
         const translatedHtml = getTranslatedHtml(cell);
         const translated = removeHtmlTags(translatedHtml).trim();

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/cellMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/cellMetadata.ts
@@ -9,6 +9,9 @@ import { CodexCellTypes } from 'types/enums';
 import type { DocxParagraph, DocxDocument } from './docxTypes';
 import { v4 as uuidv4 } from 'uuid';
 
+/** Stable identifier for the paragraph coordinate system used by new imports. */
+export const DOCX_PARAGRAPH_MAPPING_VERSION = 'outermost-no-fallback-v1';
+
 /**
  * Parameters for creating DOCX cell metadata
  */
@@ -60,6 +63,7 @@ export function createDocxCellMetadata(params: DocxCellMetadataParams): { metada
         edits: [],
         paragraphId,
         paragraphIndex,
+        paragraphMappingVersion: DOCX_PARAGRAPH_MAPPING_VERSION,
 
         // Present only when the paragraph was split into multiple cells
         ...(segmentIndex !== undefined && { segmentIndex }),
@@ -110,6 +114,7 @@ export function createDocxTableCellMetadata(
         // but prefer `paragraphIndices` when present.
         paragraphIndex: firstParagraphIndex,
         paragraphIndices,
+        paragraphMappingVersion: DOCX_PARAGRAPH_MAPPING_VERSION,
 
         data: {
             originalText: originalContent,

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import JSZip from "jszip";
+import { exportDocxWithTranslations } from "./docxExporter";
+import { DOCX_PARAGRAPH_MAPPING_VERSION } from "./cellMetadata";
+
+const textBoxParagraph =
+    `<w:p><w:r><w:drawing><mc:AlternateContent>` +
+    `<mc:Choice Requires="wps"><wps:txbx><w:txbxContent>` +
+    `<w:p><w:r><w:t>Box line one.</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Box line two.</w:t></w:r></w:p>` +
+    `</w:txbxContent></wps:txbx></mc:Choice>` +
+    `<mc:Fallback><w:pict><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>Box line one.</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Box line two.</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></w:pict></mc:Fallback>` +
+    `</mc:AlternateContent></w:drawing></w:r></w:p>`;
+
+async function makeDocx(body: string): Promise<ArrayBuffer> {
+    const zip = new JSZip();
+    zip.file(
+        "word/document.xml",
+        `<?xml version="1.0"?><w:document><w:body>${body}</w:body></w:document>`,
+    );
+    return zip.generateAsync({ type: "arraybuffer" });
+}
+
+async function getDocumentXml(docx: ArrayBuffer): Promise<string> {
+    const zip = await JSZip.loadAsync(docx);
+    return zip.file("word/document.xml")!.async("string");
+}
+
+function cell(paragraphIndex: number, sourceText: string, value: string, metadata: Record<string, unknown> = {}) {
+    return {
+        kind: 2,
+        value,
+        metadata: {
+            id: `cell-${paragraphIndex}`,
+            paragraphIndex,
+            data: { originalText: sourceText },
+            ...metadata,
+        },
+    };
+}
+
+describe("DOCX exporter paragraph compatibility", () => {
+    it("exports legacy coordinates and removes the duplicated fallback branch", async () => {
+        const original = await makeDocx(
+            `<w:p><w:r><w:t>Before</w:t></w:r></w:p>` +
+            textBoxParagraph +
+            `<w:p><w:r><w:t>After</w:t></w:r></w:p>`,
+        );
+
+        // Under the <=0.31 scanner, the paragraph after the textbox was index 5.
+        const exported = await exportDocxWithTranslations(original, [
+            cell(1, "Box line one.", "Línea uno."),
+            cell(2, "Box line two.", "Línea dos."),
+            cell(5, "After", "Después"),
+        ]);
+        const xml = await getDocumentXml(exported);
+
+        expect(xml).toContain("Línea uno.");
+        expect(xml).toContain("Línea dos.");
+        expect(xml).toContain("Después");
+        expect(xml).not.toContain("Box line one.");
+        expect(xml).not.toContain("Box line two.");
+        expect(xml).not.toContain("<mc:Fallback");
+        expect(xml.match(/Línea uno\./g)).toHaveLength(1);
+    });
+
+    it("uses the current coordinate model when the importer version is explicit", async () => {
+        const original = await makeDocx(
+            `<w:p><w:r><w:t>Before</w:t></w:r></w:p>` +
+            textBoxParagraph +
+            `<w:p><w:r><w:t>After</w:t></w:r></w:p>`,
+        );
+        const exported = await exportDocxWithTranslations(original, [
+            cell(2, "After", "Después", {
+                paragraphMappingVersion: DOCX_PARAGRAPH_MAPPING_VERSION,
+            }),
+        ]);
+        const xml = await getDocumentXml(exported);
+
+        expect(xml).toContain("Después");
+        expect(xml).not.toContain("After");
+        expect(xml).not.toContain("<mc:Fallback");
+    });
+
+    it("ignores re-import tombstones instead of concatenating their text", async () => {
+        const original = await makeDocx(`<w:p><w:r><w:t>Heading</w:t></w:r></w:p>`);
+        const exported = await exportDocxWithTranslations(original, [
+            cell(0, "Heading", "Encabezado", {
+                paragraphMappingVersion: DOCX_PARAGRAPH_MAPPING_VERSION,
+            }),
+            cell(0, "Heading", "Encabezado", {
+                paragraphMappingVersion: DOCX_PARAGRAPH_MAPPING_VERSION,
+                data: { originalText: "Heading", deleted: true },
+            }),
+        ]);
+        const xml = await getDocumentXml(exported);
+
+        expect(xml.match(/Encabezado/g)).toHaveLength(1);
+    });
+
+    it("coalesces an active untranslated alias sharing the same segment index", async () => {
+        const original = await makeDocx(`<w:p><w:r><w:t>Heading</w:t></w:r></w:p>`);
+        const exported = await exportDocxWithTranslations(original, [
+            cell(0, "Heading", "Encabezado"),
+            cell(0, "Heading", ""),
+        ]);
+        const xml = await getDocumentXml(exported);
+
+        expect(xml.match(/Encabezado/g)).toHaveLength(1);
+        expect(xml).not.toContain("Heading");
+    });
+
+    it("collapses a verified Choice/Fallback segment cycle without dropping real splits", async () => {
+        const original = await makeDocx(
+            `<w:p><w:r><w:t>First</w:t></w:r><w:r><w:t> Second</w:t></w:r></w:p>`,
+        );
+        const segments = [
+            { index: 0, source: "First", value: "Primero" },
+            { index: 1, source: "Second", value: "Segundo" },
+            // Historical fallback aliases: same sources, no translations.
+            { index: 2, source: "First", value: "" },
+            { index: 3, source: "Second", value: "" },
+        ].map((segment) => ({
+            kind: 2,
+            value: segment.value,
+            metadata: {
+                id: `segment-${segment.index}`,
+                paragraphIndex: 0,
+                segmentIndex: segment.index,
+                segmentCount: 4,
+                data: { originalText: segment.source },
+            },
+        }));
+
+        const exported = await exportDocxWithTranslations(original, segments);
+        const xml = await getDocumentXml(exported);
+        const text = [...xml.matchAll(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g)]
+            .map((match) => match[1])
+            .join("");
+
+        expect(text).toBe("Primero Segundo");
+        expect(text.match(/Primero/g)).toHaveLength(1);
+        expect(text).not.toContain("First");
+    });
+
+    it("refuses an ambiguous stale coordinate instead of writing to a guessed paragraph", async () => {
+        const original = await makeDocx(
+            `<w:p><w:r><w:t>Repeated</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>Repeated</w:t></w:r></w:p>`,
+        );
+
+        await expect(exportDocxWithTranslations(original, [
+            cell(99, "Repeated", "Repetido"),
+        ])).rejects.toThrow(/matched 2 export destinations/);
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import JSZip from "jszip";
 import { exportDocxWithTranslations } from "./docxExporter";
 import { DOCX_PARAGRAPH_MAPPING_VERSION } from "./cellMetadata";
+import { tryDeterministicStructureFix } from "../../../../../../sharedUtils/htmlStructureUtils";
 
 const textBoxParagraph =
     `<w:p><w:r><w:drawing><mc:AlternateContent>` +
@@ -43,6 +44,20 @@ function cell(paragraphIndex: number, sourceText: string, value: string, metadat
 }
 
 describe("DOCX exporter paragraph compatibility", () => {
+    it("exports identical XML before and after a formatting-only cell repair", async () => {
+        const original = await makeDocx('<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+            '<w:r><w:rPr><w:u w:val="single"/><w:sz w:val="36"/></w:rPr><w:t>Le</w:t></w:r>' +
+            '<w:r><w:rPr><w:u w:val="single"/><w:sz w:val="36"/></w:rPr><w:t>sson #6</w:t></w:r></w:p>');
+        const source = '<p style="text-align: center"><span style="font-size: 18pt"><u>Le</u></span>' +
+            '<span style="font-size: 18pt"><u>sson #6</u></span></p>';
+        const target = cell(0, "Lesson #6", "<p>Lección #6</p>");
+        const repaired = tryDeterministicStructureFix(source, target.value, { importerType: "docx" });
+        expect(repaired).not.toBeNull();
+        const before = await exportDocxWithTranslations(original, [target]);
+        const after = await exportDocxWithTranslations(original, [{ ...target, value: repaired! }]);
+        expect(await getDocumentXml(after)).toBe(await getDocumentXml(before));
+    });
+
     it("exports legacy coordinates and removes the duplicated fallback branch", async () => {
         const original = await makeDocx(
             `<w:p><w:r><w:t>Before</w:t></w:r></w:p>` +

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxExporter.ts
@@ -11,9 +11,18 @@ import {
     DocxExportError,
 } from './docxTypes';
 import {
+    extractLegacyParagraphRanges,
     extractOutermostParagraphRanges,
     stripFallbackElements,
 } from './utils/ooxmlScanner';
+import {
+    buildRepeatedSourceAliasVariants,
+    deduplicateDocxSegments,
+    normalizeDocxWitness,
+    resolveDocxTranslations,
+    selectParagraphMappingMode,
+    type ParagraphTranslation,
+} from './utils/docxExportMapping';
 
 /**
  * NOTE:
@@ -70,13 +79,14 @@ export async function exportDocxWithTranslations(
         console.log('[DOCX Exporter] Extracted document.xml');
 
         // Collect translations from cells
-        const translationMap = collectTranslations(codexCells);
-        console.log(`[DOCX Exporter] Collected ${translationMap.size} translations`);
+        const { translations: translationPlans, witnesses } = collectTranslations(codexCells);
+        console.log(`[DOCX Exporter] Collected ${translationPlans.size} translations`);
 
         // Replace content in document.xml
         const updatedXml = await replaceContentInXml(
             documentXml,
-            translationMap,
+            translationPlans,
+            witnesses,
             exportConfig
         );
         console.log('[DOCX Exporter] Updated document.xml with translations');
@@ -115,9 +125,14 @@ export async function exportDocxWithTranslations(
  *     segments are all untranslated produces no entry and is left byte-untouched.
  *  3. Normal cells – one Codex cell ↔ one DOCX paragraph (paragraphIndex only).
  */
+type TranslationCollection = {
+    translations: Map<number, ParagraphTranslation>;
+    witnesses: Map<number, ParagraphTranslation>;
+};
+
 function collectTranslations(
     codexCells: Array<{ kind: number; value: string; metadata: any; }>
-): Map<number, string> {
+): TranslationCollection {
     console.log(`[Exporter] Processing ${codexCells.length} cells for translations`);
 
     // Accumulate per-paragraph segments: paragraphIndex → list of {segmentIndex, text, source}.
@@ -125,9 +140,15 @@ function collectTranslations(
     // Keeping untranslated segments (empty `text`) lets us fall back to `source` so that a
     // partially translated split paragraph preserves its untranslated portions instead of
     // dropping them.
-    const segmentsByParagraph = new Map<number, Array<{ segmentIndex: number; text: string; source: string; }>>();
+    const segmentsByParagraph = new Map<number, Array<{
+        segmentIndex: number;
+        text: string;
+        source: string;
+        mappingVersion?: string;
+    }>>();
     // Table cells bypass the segment system entirely
-    const tableTranslations = new Map<number, string>();
+    const tableTranslations = new Map<number, ParagraphTranslation>();
+    const tableWitnesses = new Map<number, ParagraphTranslation>();
 
     for (const cell of codexCells) {
         const meta = cell.metadata;
@@ -154,8 +175,6 @@ function collectTranslations(
 
         if (Array.isArray(paragraphIndices) && paragraphIndices.length > 0) {
             // Table-cell case: map lines of translation to each paragraph index.
-            // A fully-untranslated table cell is left byte-untouched (no map entries).
-            if (!translated) continue;
             // Fall back to the matching original line so a partially-translated table cell
             // doesn't blank the untranslated paragraphs.
             const originalLines = String(meta?.data?.originalText ?? '').split(/\r?\n/);
@@ -163,7 +182,22 @@ function collectTranslations(
             for (let j = 0; j < paragraphIndices.length; j++) {
                 const idx = paragraphIndices[j];
                 if (typeof idx !== 'number') continue;
-                tableTranslations.set(idx, parts[j] ?? originalLines[j] ?? '');
+                const plan = {
+                    paragraphIndex: idx,
+                    translation: parts[j] ?? originalLines[j] ?? '',
+                    sourceText: originalLines[j] ?? '',
+                    mappingVersion: meta?.paragraphMappingVersion,
+                };
+                tableWitnesses.set(idx, { ...plan, translation: '' });
+                if (!translated) continue;
+                const existing = tableTranslations.get(idx);
+                if (existing && (
+                    existing.translation !== plan.translation ||
+                    normalizeDocxWitness(existing.sourceText) !== normalizeDocxWitness(plan.sourceText)
+                )) {
+                    throw new Error(`Conflicting table-cell translations map to DOCX paragraph ${idx}.`);
+                }
+                tableTranslations.set(idx, plan);
             }
             continue;
         }
@@ -192,24 +226,38 @@ function collectTranslations(
             segmentIndex: segmentIndex ?? 0,
             text: translated,
             source,
+            mappingVersion: meta?.paragraphMappingVersion,
         });
     }
 
     // Build the final map: for split paragraphs, join segments in order, falling back to each
     // segment's original source text when it has no translation.
-    const translations = new Map<number, string>(tableTranslations);
+    const translations = new Map<number, ParagraphTranslation>(tableTranslations);
+    const witnesses = new Map<number, ParagraphTranslation>(tableWitnesses);
 
     for (const [paraIdx, segments] of segmentsByParagraph) {
-        // Leave a fully-untranslated paragraph byte-untouched (no map entry). This preserves the
-        // existing correct behavior and avoids overwriting the original with source text.
-        if (!segments.some(s => s.text)) continue;
-        segments.sort((a, b) => a.segmentIndex - b.segmentIndex);
-        const combined = segments.map(s => s.text || s.source).join(' ');
-        translations.set(paraIdx, combined);
+        const uniqueSegments = deduplicateDocxSegments(segments);
+        uniqueSegments.sort((a, b) => a.segmentIndex - b.segmentIndex);
+        const combinedSource = uniqueSegments.map(s => s.source).join(' ');
+        const aliasVariants = buildRepeatedSourceAliasVariants(uniqueSegments);
+        const witness: ParagraphTranslation = {
+            paragraphIndex: paraIdx,
+            translation: '',
+            sourceText: combinedSource,
+            mappingVersion: uniqueSegments.find((segment) => segment.mappingVersion)?.mappingVersion,
+            aliasVariants: aliasVariants.map((variant) => ({ ...variant, translation: '' })),
+        };
+        witnesses.set(paraIdx, witness);
+
+        // Untranslated paragraphs remain byte-untouched, but their witnesses
+        // still help classify the file's historical coordinate system.
+        if (!uniqueSegments.some(s => s.text)) continue;
+        const combined = uniqueSegments.map(s => s.text || s.source).join(' ');
+        translations.set(paraIdx, { ...witness, translation: combined, aliasVariants });
     }
 
     console.log(`[Exporter] Collected ${translations.size} translations total`);
-    return translations;
+    return { translations, witnesses };
 }
 
 /**
@@ -235,7 +283,8 @@ function removeHtmlTags(html: string): string {
  */
 async function replaceContentInXml(
     documentXml: string,
-    translations: Map<number, string>,
+    translations: Map<number, ParagraphTranslation>,
+    witnesses: Map<number, ParagraphTranslation>,
     _config: DocxExportConfig
 ): Promise<string> {
     const bodyOpenIdx = documentXml.indexOf('<w:body');
@@ -254,16 +303,20 @@ async function replaceContentInXml(
     const bodyXmlRaw = documentXml.slice(bodyStart + 1, bodyCloseIdx);
     const after = documentXml.slice(bodyCloseIdx);
 
-    // Remove mc:Fallback branches: they duplicate the mc:Choice content, so
-    // keeping them would leave the untranslated source text in the exported
-    // file (legacy renderers would show it). Word regenerates fallbacks on the
-    // next save. This also keeps paragraph indices aligned with the importer,
-    // which scans a Fallback-stripped body.
-    const bodyXml = stripFallbackElements(bodyXmlRaw);
-
-    // Canonical paragraph enumeration shared with the importer: outermost
-    // <w:p> elements only (text-box paragraphs belong to their anchor).
-    const ranges = extractOutermostParagraphRanges(bodyXml);
+    const currentBodyXml = stripFallbackElements(bodyXmlRaw);
+    const currentRanges = extractOutermostParagraphRanges(currentBodyXml);
+    const legacyRanges = extractLegacyParagraphRanges(bodyXmlRaw);
+    const mode = selectParagraphMappingMode(
+        witnesses,
+        currentBodyXml,
+        currentRanges,
+        bodyXmlRaw,
+        legacyRanges,
+    );
+    const bodyXml = mode === 'legacy' ? bodyXmlRaw : currentBodyXml;
+    const ranges = mode === 'legacy' ? legacyRanges : currentRanges;
+    const resolvedTranslations = resolveDocxTranslations(bodyXml, ranges, translations);
+    console.log(`[Exporter] Using ${mode} DOCX paragraph coordinates`);
     let out = '';
     let last = 0;
     let replacedCount = 0;
@@ -273,8 +326,13 @@ async function replaceContentInXml(
         out += bodyXml.slice(last, start);
 
         const paragraphXml = bodyXml.slice(start, end);
-        const translation = translations.get(paraIndex);
+        const translation = resolvedTranslations.get(paraIndex);
         if (translation) {
+            if (paragraphXml.indexOf('<w:t') < 0) {
+                throw new Error(
+                    `Cannot safely export DOCX paragraph ${paraIndex}: destination has no text node.`
+                );
+            }
             out += replaceParagraphTextXml(paragraphXml, translation);
             replacedCount++;
             console.log(`[Exporter] ✓ Replaced paragraph ${paraIndex}: "${translation.substring(0, 50)}..."`);
@@ -285,6 +343,14 @@ async function replaceContentInXml(
         last = end;
     }
     out += bodyXml.slice(last);
+
+    // Legacy coordinates are resolved against the original XML because those
+    // indices counted both AlternateContent branches.  Strip the fallback only
+    // after replacement so the authoritative Choice survives and untranslated
+    // duplicate/source branches cannot leak into the exported document.
+    if (mode === 'legacy') {
+        out = stripFallbackElements(out);
+    }
 
     console.log(`[Exporter] Found ${ranges.length} paragraphs in XML`);
     console.log(`[Exporter] Summary: ${replacedCount} replaced, ${ranges.length - replacedCount} skipped, ${ranges.length} total`);
@@ -344,7 +410,7 @@ function escapeXmlText(text: string): string {
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/\"/g, '&quot;')
+        .replace(/"/g, '&quot;')
         .replace(/'/g, '&apos;');
 }
 
@@ -353,7 +419,7 @@ function decodeBasicEntities(text: string): string {
     return (text ?? '')
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '\"')
+        .replace(/&quot;/g, '"')
         .replace(/&apos;/g, "'")
         .replace(/&amp;/g, '&');
 }
@@ -390,4 +456,3 @@ export class DocxExporter {
 
 // Export default instance
 export default new DocxExporter();
-

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.test.ts
@@ -1,0 +1,48 @@
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+import { DocxParser } from "./docxParser";
+import { parseFile } from "./index";
+
+const makeDocx = async (paragraphXml: string): Promise<File> => {
+    const zip = new JSZip();
+    zip.file("word/document.xml", '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+        `<w:body>${paragraphXml}<w:sectPr/></w:body></w:document>`);
+    const data = await zip.generateAsync({ type: "arraybuffer" });
+    return { name: "formatting.docx", size: data.byteLength, lastModified: 0, arrayBuffer: async () => data } as File;
+};
+
+describe("DOCX formatting detection", () => {
+    it.each([undefined, "1", "true", "on", "0", "false", "off"])("handles formatting toggles with value %s", async (value) => {
+        const attr = value === undefined ? "" : ` w:val="${value}"`;
+        const file = await makeDocx(`<w:p><w:r><w:rPr><w:b${attr}/><w:i${attr}/><w:strike${attr}/></w:rPr><w:t>text</w:t></w:r></w:p>`);
+        const doc = await new DocxParser().parseDocx(file);
+        const props = doc.paragraphs[0].runs[0].runProperties;
+        const enabled = value === undefined || ["1", "true", "on"].includes(value);
+        expect(Boolean(props.bold)).toBe(enabled);
+        expect(Boolean(props.italic)).toBe(enabled);
+        expect(Boolean(props.strike)).toBe(enabled);
+        expect(doc.paragraphs[0].runs[0].content).toBe("text");
+    });
+
+    it.each([undefined, "single", "double", "none"])("handles underline value %s", async (value) => {
+        const attr = value === undefined ? "" : ` w:val="${value}"`;
+        const file = await makeDocx(`<w:p><w:r><w:rPr><w:u${attr}/></w:rPr><w:t>text</w:t></w:r></w:p>`);
+        const doc = await new DocxParser().parseDocx(file);
+        expect(doc.paragraphs[0].runs[0].runProperties.underline).toBe(value === "none" ? undefined : value ?? true);
+    });
+
+    it("retains Lesson 28's genuine inline italics in source cells", async () => {
+        const file = await makeDocx('<w:p><w:pPr><w:pStyle w:val="ListParagraph"/></w:pPr>' +
+            '<w:r><w:t>But the important thing is this: </w:t></w:r>' +
+            '<w:r><w:rPr><w:i/></w:rPr><w:t>conscience depends on knowledge</w:t></w:r>' +
+            '<w:r><w:t> (italics mine).</w:t></w:r></w:p>');
+        const result = await parseFile(file);
+        expect(result.success).toBe(true);
+        const cell = result.notebookPair?.source.cells.find((cell) => cell.content.includes("conscience"));
+        expect(cell?.content).toContain("<em>conscience depends on knowledge</em>");
+        expect(cell?.metadata?.data?.originalText).toBe("But the important thing is this: conscience depends on knowledge (italics mine).");
+        expect(cell?.metadata?.paragraphIndex).toBe(0);
+        expect(cell?.metadata?.paragraphMappingVersion).toBe("outermost-no-fallback-v1");
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/docxParser.ts
@@ -423,23 +423,23 @@ export class DocxParser {
 
         try {
             // Bold
-            if (this.findElement(rPrElement, 'w:b')) {
+            if (this.isToggleElementEnabled(this.findElement(rPrElement, 'w:b'))) {
                 props.bold = true;
             }
 
             // Italic
-            if (this.findElement(rPrElement, 'w:i')) {
+            if (this.isToggleElementEnabled(this.findElement(rPrElement, 'w:i'))) {
                 props.italic = true;
             }
 
             // Underline
             const u = this.findElement(rPrElement, 'w:u');
-            if (u) {
+            if (this.isToggleElementEnabled(u)) {
                 props.underline = u['@_w:val'] || true;
             }
 
             // Strike
-            if (this.findElement(rPrElement, 'w:strike')) {
+            if (this.isToggleElementEnabled(this.findElement(rPrElement, 'w:strike'))) {
                 props.strike = true;
             }
 
@@ -544,8 +544,14 @@ export class DocxParser {
             return null;
         }
 
-        if (element[tagName]) {
-            return Array.isArray(element[tagName]) ? element[tagName][0] : element[tagName];
+        if (Object.prototype.hasOwnProperty.call(element, tagName)) {
+            const value = Array.isArray(element[tagName])
+                ? element[tagName][0]
+                : element[tagName];
+            // fast-xml-parser represents an empty OOXML toggle such as
+            // `<w:i/>` as an empty string. Preserve its presence with a
+            // truthy object so run formatting is not silently discarded.
+            return value === '' || value === null || value === undefined ? {} : value;
         }
 
         // Search in children
@@ -565,6 +571,14 @@ export class DocxParser {
         }
 
         return null;
+    }
+
+    /** Word on/off properties are enabled when present unless explicitly off. */
+    private isToggleElementEnabled(element: unknown): boolean {
+        if (!element || typeof element !== 'object') return false;
+        const value = '@_w:val' in element ? element['@_w:val'] : undefined;
+        if (value === undefined || value === null || value === '') return true;
+        return !['0', 'false', 'off', 'none'].includes(String(value).toLowerCase());
     }
 
     /**
@@ -638,4 +652,3 @@ export class DocxParser {
         }
     }
 }
-

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/docxExportMapping.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/docxExportMapping.ts
@@ -1,0 +1,179 @@
+import { DOCX_PARAGRAPH_MAPPING_VERSION } from "../cellMetadata";
+import { extractParagraphText, type ParagraphRange } from "./ooxmlScanner";
+
+export type ParagraphTranslation = {
+    paragraphIndex: number;
+    translation: string;
+    sourceText: string;
+    mappingVersion?: string;
+    /** Candidate collapsed aliases from duplicated Choice/Fallback segment cycles. */
+    aliasVariants?: Array<{ sourceText: string; translation: string }>;
+};
+
+export function normalizeDocxWitness(text: string): string {
+    return text.replace(/\s+/g, " ").trim();
+}
+
+/** Coalesce exact aliases while refusing contradictory cells at one split position. */
+export function deduplicateDocxSegments<
+    T extends { segmentIndex: number; text: string; source: string },
+>(segments: T[]): T[] {
+    const byIndex = new Map<number, T>();
+    for (const segment of segments) {
+        const existing = byIndex.get(segment.segmentIndex);
+        if (!existing) {
+            byIndex.set(segment.segmentIndex, segment);
+            continue;
+        }
+        if (normalizeDocxWitness(existing.source) !== normalizeDocxWitness(segment.source)) {
+            throw new Error(
+                `Conflicting DOCX segments share segmentIndex ${segment.segmentIndex}.`,
+            );
+        }
+        if (existing.text && segment.text && existing.text !== segment.text) {
+            throw new Error(
+                `Conflicting DOCX translations share segmentIndex ${segment.segmentIndex}.`,
+            );
+        }
+        if (!existing.text && segment.text) {
+            byIndex.set(segment.segmentIndex, segment);
+        }
+    }
+    return [...byIndex.values()];
+}
+
+/**
+ * Build an alternate witness for an old Choice/Fallback segment cycle. The
+ * exporter uses it only when the original destination matches the shorter
+ * source, so genuinely repeated paragraph text remains repeated.
+ */
+export function buildRepeatedSourceAliasVariants<
+    T extends { text: string; source: string },
+>(segments: T[]): Array<{ sourceText: string; translation: string }> {
+    for (let period = 1; period <= Math.floor(segments.length / 2); period++) {
+        if (segments.length % period !== 0) continue;
+        const repeats = segments.every(
+            (segment, index) =>
+                normalizeDocxWitness(segment.source) ===
+                normalizeDocxWitness(segments[index % period].source),
+        );
+        if (!repeats) continue;
+
+        const chosenTranslations: string[] = [];
+        let conflict = false;
+        for (let index = 0; index < period; index++) {
+            const translatedAliases = new Set(
+                segments
+                    .filter((_, segmentIndex) => segmentIndex % period === index)
+                    .map((segment) => segment.text)
+                    .filter(Boolean),
+            );
+            if (translatedAliases.size > 1) {
+                conflict = true;
+                break;
+            }
+            chosenTranslations.push([...translatedAliases][0] ?? segments[index].source);
+        }
+        if (conflict) continue;
+
+        return [{
+            sourceText: segments.slice(0, period).map((segment) => segment.source).join(" "),
+            translation: chosenTranslations.join(" "),
+        }];
+    }
+    return [];
+}
+
+const matchingPlanVariant = (
+    plan: ParagraphTranslation,
+    paragraphText: string,
+): { sourceText: string; translation: string } | undefined => {
+    if (normalizeDocxWitness(plan.sourceText) === paragraphText) return plan;
+    return plan.aliasVariants?.find(
+        (variant) => normalizeDocxWitness(variant.sourceText) === paragraphText,
+    );
+};
+
+const scoreMapping = (
+    bodyXml: string,
+    ranges: ParagraphRange[],
+    plans: Map<number, ParagraphTranslation>,
+): number => {
+    let score = 0;
+    for (const plan of plans.values()) {
+        const range = ranges[plan.paragraphIndex];
+        if (!normalizeDocxWitness(plan.sourceText) || !range) continue;
+        const source = normalizeDocxWitness(
+            extractParagraphText(bodyXml.slice(range.start, range.end)),
+        );
+        if (matchingPlanVariant(plan, source)) score++;
+    }
+    return score;
+};
+
+export type ParagraphMappingMode = "current" | "legacy";
+
+export function selectParagraphMappingMode(
+    plans: Map<number, ParagraphTranslation>,
+    currentBodyXml: string,
+    currentRanges: ParagraphRange[],
+    legacyBodyXml: string,
+    legacyRanges: ParagraphRange[],
+): ParagraphMappingMode {
+    const allPlans = [...plans.values()];
+    if (
+        allPlans.length > 0 &&
+        allPlans.every((plan) => plan.mappingVersion === DOCX_PARAGRAPH_MAPPING_VERSION)
+    ) {
+        return "current";
+    }
+
+    const currentScore = scoreMapping(currentBodyXml, currentRanges, plans);
+    const legacyScore = scoreMapping(legacyBodyXml, legacyRanges, plans);
+    console.log(`[Exporter] Coordinate witness scores: current=${currentScore}, legacy=${legacyScore}`);
+    return legacyScore > currentScore ? "legacy" : "current";
+}
+
+export function resolveDocxTranslations(
+    bodyXml: string,
+    ranges: ParagraphRange[],
+    plans: Map<number, ParagraphTranslation>,
+): Map<number, string> {
+    const paragraphTexts = ranges.map((range) =>
+        normalizeDocxWitness(extractParagraphText(bodyXml.slice(range.start, range.end))),
+    );
+    const resolved = new Map<number, string>();
+
+    for (const plan of [...plans.values()].sort((a, b) => a.paragraphIndex - b.paragraphIndex)) {
+        let destination = plan.paragraphIndex;
+        let selectedVariant = matchingPlanVariant(plan, paragraphTexts[destination]);
+
+        if (normalizeDocxWitness(plan.sourceText) && !selectedVariant) {
+            const candidates = paragraphTexts
+                .map((text, index) => matchingPlanVariant(plan, text) && !resolved.has(index) ? index : -1)
+                .filter((index) => index >= 0);
+            if (candidates.length !== 1) {
+                throw new Error(
+                    `Cannot safely map DOCX paragraph ${plan.paragraphIndex}: ` +
+                    `stored source text matched ${candidates.length} export destinations.`,
+                );
+            }
+            destination = candidates[0];
+            selectedVariant = matchingPlanVariant(plan, paragraphTexts[destination]);
+        }
+
+        if (!ranges[destination]) {
+            throw new Error(
+                `Cannot safely map DOCX paragraph ${plan.paragraphIndex}: destination is missing.`,
+            );
+        }
+        const selectedTranslation = selectedVariant?.translation ?? plan.translation;
+        const existing = resolved.get(destination);
+        if (existing !== undefined && existing !== selectedTranslation) {
+            throw new Error(`Conflicting translations map to DOCX paragraph ${destination}.`);
+        }
+        resolved.set(destination, selectedTranslation);
+    }
+
+    return resolved;
+}

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/ooxmlScanner.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/ooxmlScanner.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
     extractBodyParagraphXmls,
+    extractLegacyParagraphRanges,
     extractOutermostParagraphRanges,
+    extractParagraphText,
     stripFallbackElements,
 } from "./ooxmlScanner";
 import { extractTableCellParagraphGroups } from "./tableSegmentation";
@@ -78,6 +80,26 @@ describe("extractOutermostParagraphRanges", () => {
         expect(xml.slice(ranges[1].start, ranges[1].end)).toBe(
             "<w:p><w:r><w:t>cell</w:t></w:r></w:p>"
         );
+    });
+});
+
+describe("extractLegacyParagraphRanges", () => {
+    it("reproduces the pre-0.32 textbox coordinate drift for compatibility", () => {
+        const body =
+            `<w:p><w:r><w:t>before</w:t></w:r></w:p>` +
+            textBoxParagraph +
+            `<w:p><w:r><w:t>after</w:t></w:r></w:p>`;
+        const ranges = extractLegacyParagraphRanges(body);
+        const texts = ranges.map((range) => extractParagraphText(body.slice(range.start, range.end)));
+
+        expect(texts).toEqual([
+            "before",
+            "Box line one.",
+            "Box line two.",
+            "Box line one.",
+            "Box line two.",
+            "after",
+        ]);
     });
 });
 

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/ooxmlScanner.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/docx/utils/ooxmlScanner.ts
@@ -79,6 +79,43 @@ export type ParagraphRange = {
 };
 
 /**
+ * Paragraph enumeration used by Codex Editor <= 0.31.x.
+ *
+ * This intentionally preserves the historical non-depth-aware regular
+ * expression.  It is not suitable for importing new documents, but existing
+ * projects persist paragraph indices produced by it.  The exporter uses this
+ * scanner only as a compatibility coordinate system after verifying the
+ * stored source text at those coordinates.
+ */
+export const extractLegacyParagraphRanges = (xml: string): ParagraphRange[] => {
+    const ranges: ParagraphRange[] = [];
+    const paragraphRe = /<w:p\b[\s\S]*?<\/w:p>|<w:p\b[^>]*\/>/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = paragraphRe.exec(xml)) !== null) {
+        ranges.push({ start: match.index, end: match.index + match[0].length });
+    }
+
+    return ranges;
+};
+
+/** Return the decoded text stored in all w:t nodes in an OOXML fragment. */
+export const extractParagraphText = (paragraphXml: string): string => {
+    let text = "";
+    const textRe = /<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g;
+    let match: RegExpExecArray | null;
+    while ((match = textRe.exec(paragraphXml)) !== null) {
+        text += match[1]
+            .replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&quot;/g, '"')
+            .replace(/&apos;/g, "'")
+            .replace(/&amp;/g, "&");
+    }
+    return text;
+};
+
+/**
  * Enumerate the OUTERMOST `<w:p>` elements of an XML fragment in document
  * order, returning their full [start, end) ranges. Paragraphs nested inside
  * another paragraph (text-box content) are contained within their anchor

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/indesign/idmlExporter.ts
@@ -654,7 +654,7 @@ export async function exportIdmlRoundtrip(
         // Soft-deleted cells (e.g. retired by a re-import) keep their content
         // and stale paragraph coordinates — exporting them would write old
         // translations into the wrong paragraphs.
-        if (meta?.data?.deleted === true) continue;
+        if (meta?.data?.merged || meta?.data?.deleted || meta?.data?.hidden) continue;
 
         const translatedHtml = getTranslatedHtml(cell);
         const translated = removeHtmlTags(translatedHtml).trim();

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/markdown/markdownExporter.spec.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/markdown/markdownExporter.spec.ts
@@ -83,6 +83,44 @@ describe("exportMarkdownWithTranslations", () => {
         expect(exportMarkdownWithTranslations(source, cells as never)).toBe("keep");
     });
 
+    it("ignores inactive re-import cells", () => {
+        const source = "Keep me";
+        const cells = [{
+            kind: 2,
+            value: "<p>Wrong stale translation</p>",
+            metadata: {
+                sourceSpan: { start: 0, end: source.length },
+                data: { originalText: source, deleted: true },
+            },
+        }];
+        expect(exportMarkdownWithTranslations(source, cells as never)).toBe(source);
+    });
+
+    it("refuses a stale source span instead of replacing unrelated text", () => {
+        const cells = [{
+            kind: 2,
+            value: "<p>Translation</p>",
+            metadata: {
+                id: "stale-cell",
+                sourceSpan: { start: 0, end: 7 },
+                originalMarkdown: "Old text",
+            },
+        }];
+        expect(() => exportMarkdownWithTranslations("New text", cells as never)).toThrow(
+            /sourceSpan no longer matches/
+        );
+    });
+
+    it("refuses overlapping active source spans", () => {
+        const cells = [
+            { kind: 2, value: "<p>One</p>", metadata: { sourceSpan: { start: 0, end: 4 } } },
+            { kind: 2, value: "<p>Two</p>", metadata: { sourceSpan: { start: 3, end: 7 } } },
+        ];
+        expect(() => exportMarkdownWithTranslations("1234567", cells as never)).toThrow(
+            /source spans overlap/
+        );
+    });
+
     it("preserves line breaks between consecutive list items", () => {
         const source =
             "## 2.1 Herci\n" +

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/markdown/markdownExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/markdown/markdownExporter.ts
@@ -14,6 +14,14 @@ export interface MarkdownExportCell {
         segmentIndex?: number;
         sourceSpan?: { start: number; end: number; };
         segmentType?: string;
+        originalMarkdown?: string;
+        type?: string;
+        data?: {
+            originalText?: string;
+            merged?: boolean;
+            deleted?: boolean;
+            hidden?: boolean;
+        };
     };
 }
 
@@ -41,6 +49,10 @@ export function exportMarkdownWithTranslations(
         if (cell.kind !== 2) {
             continue;
         }
+        const data = cell.metadata?.data;
+        if (data?.merged || data?.deleted || data?.hidden || cell.metadata?.type === "milestone") {
+            continue;
+        }
         const span = cell.metadata?.sourceSpan;
         if (!span || typeof span.start !== "number" || typeof span.end !== "number") {
             continue;
@@ -52,6 +64,17 @@ export function exportMarkdownWithTranslations(
             continue;
         }
 
+        const sourceWitness = cell.metadata?.originalMarkdown ?? data?.originalText;
+        if (sourceWitness !== undefined) {
+            const normalize = (value: string) => value.replace(/\r\n/g, "\n").trimEnd();
+            const actualSource = canonicalSource.slice(span.start, span.end);
+            if (normalize(actualSource) !== normalize(sourceWitness)) {
+                throw new Error(
+                    `Cannot safely export Markdown cell ${cell.metadata?.id ?? "unknown"}: ` +
+                    `its sourceSpan no longer matches the imported source text.`
+                );
+            }
+        }
         const htmlSource = cell.value ?? cell.content ?? "";
         const translated = htmlTranslationToMarkdownForRoundTrip(htmlSource);
         if (skipEmpty && !translated) {
@@ -70,7 +93,13 @@ export function exportMarkdownWithTranslations(
         replacements.push({ start: span.start, end: span.end, text });
     }
 
-    replacements.sort((a, b) => b.start - a.start);
+    replacements.sort((a, b) => a.start - b.start);
+    for (let index = 1; index < replacements.length; index++) {
+        if (replacements[index].start < replacements[index - 1].end) {
+            throw new Error("Cannot safely export Markdown: active source spans overlap.");
+        }
+    }
+    replacements.reverse();
 
     let out = canonicalSource;
     for (const { start, end, text } of replacements) {

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/obs/obsExporter.test.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/obs/obsExporter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { collectObsTranslationsFromCells, extractObsStoryFromCells } from "./obsExporter";
+
+describe("OBS exporter active-cell filtering", () => {
+    it("does not let a re-import tombstone replace the live segment", () => {
+        const cells = [
+            {
+                kind: 2,
+                value: "<p>Traducción viva</p>",
+                metadata: { type: "text", segmentType: "text", segmentIndex: 0, data: {} },
+            },
+            {
+                kind: 2,
+                value: "<p>Traducción obsoleta</p>",
+                metadata: {
+                    type: "text",
+                    segmentType: "text",
+                    segmentIndex: 0,
+                    data: { deleted: true },
+                },
+            },
+        ];
+
+        expect(collectObsTranslationsFromCells(cells).get(0)).toBe("Traducción viva");
+        expect(extractObsStoryFromCells(cells).segments[0].text).toBe("Traducción viva");
+    });
+});

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/obs/obsExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/obs/obsExporter.ts
@@ -125,6 +125,15 @@ export function collectObsTranslationsFromCells(
     for (let i = 0; i < codexCells.length; i++) {
         const cell = codexCells[i];
         const meta = cell.metadata;
+        if (
+            meta?.data?.merged ||
+            meta?.data?.deleted ||
+            meta?.data?.hidden ||
+            meta?.type === 'milestone'
+        ) {
+            console.log(`[OBS Exporter] Skipping cell ${i} - inactive cell`);
+            continue;
+        }
 
         // Log cell info for debugging
         console.log(`[OBS Exporter] Cell ${i}: kind=${cell.kind}, segmentType=${meta?.segmentType}, segmentIndex=${meta?.segmentIndex}`);
@@ -315,6 +324,12 @@ export function extractObsStoryFromCells(
         if (cell.kind !== 2) continue;
 
         const meta = cell.metadata;
+        if (
+            meta?.data?.merged ||
+            meta?.data?.deleted ||
+            meta?.data?.hidden ||
+            meta?.type === 'milestone'
+        ) continue;
         const segmentIndex = meta?.segmentIndex ?? 0;
 
         if (!segmentMap.has(segmentIndex)) {
@@ -374,4 +389,3 @@ export function extractObsStoryFromCells(
         sourceReference,
     };
 }
-

--- a/webviews/codex-webviews/src/NewSourceUploader/importers/usfm/usfmExporter.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/importers/usfm/usfmExporter.ts
@@ -76,6 +76,12 @@ export async function exportUsfmRoundtrip(
 
     for (const cell of cells) {
         const metadata = cell.metadata as any;
+        if (
+            metadata?.data?.merged ||
+            metadata?.data?.deleted ||
+            metadata?.data?.hidden ||
+            metadata?.type === 'milestone'
+        ) continue;
         const translatedContent = cell.value.trim();
 
         // Try to get cellId from multiple possible locations
@@ -112,6 +118,12 @@ export async function exportUsfmRoundtrip(
         console.log(`[USFM Export] No cellIds in lineMappings, building fallback mapping by originalLine/originalText`);
         for (const cell of cells) {
             const metadata = cell.metadata as any;
+            if (
+                metadata?.data?.merged ||
+                metadata?.data?.deleted ||
+                metadata?.data?.hidden ||
+                metadata?.type === 'milestone'
+            ) continue;
             const translatedContent = cell.value.trim();
             if (!translatedContent) continue;
 

--- a/webviews/codex-webviews/src/NewSourceUploader/types/processedNotebookMetadata.ts
+++ b/webviews/codex-webviews/src/NewSourceUploader/types/processedNotebookMetadata.ts
@@ -83,6 +83,7 @@ export interface SpreadsheetNotebookMetadata extends ProcessedNotebookMetadataBa
     columnHeaders?: string[];
     sourceColumnIndex?: number;
     originalFileContent?: string;
+    hasHeader?: boolean;
 }
 
 export interface SmartSegmenterNotebookMetadata extends ProcessedNotebookMetadataBase {
@@ -267,4 +268,3 @@ export type ProcessedNotebookMetadataByImporter = {
     biblica: BiblicaNotebookMetadata;
     macula: MaculaNotebookMetadata;
 };
-


### PR DESCRIPTION
## Fix roundtrip cell mapping

## Summary

Fix round-trip import/export mapping that could leave English in exported documents despite existing Spanish translations, or duplicate text in DOCX headings and text boxes.

Support both older imports and updated imports without requiring users to re-import everything.

## Changes

- Fix DOCX paragraph matching using source locations and source-text verification, with compatibility for legacy imports.
- Handle Word’s alternate text-box representations without duplicating translated content.
- Reject ambiguous or conflicting DOCX mappings instead of placing translations incorrectly.
- Preserve existing cell IDs and translations during “Update Existing,” while refreshing import metadata and remapping notebook references.
- Ensure refreshed mapping metadata survives synchronization.
- Preserve format-specific notebook metadata and correctly recognize re-imported files when attachment filenames change.
- Exclude inactive cells from translation replacement across DOCX, CSV/TSV, Markdown, OBS, USFM, Biblica, and IDML exporters.
- Fix CSV/TSV handling of quoted multiline records and headerless files; preserve original line endings and BOM.
- Validate Markdown source locations and reject overlapping replacements.
- Add regression tests and fix the TypeScript error blocking packaging.

## Test Checklist

### Automated validation

- [x] Webview tests passed: 752.
- [x] Extension tests passed: 1,522.
- [x] Full prepublish and production packaging build succeeded.
- [x] Added regression coverage for legacy DOCX mapping, duplicated alternate content, re-import metadata, synchronization, and affected export paths.

### Real-project validation

- [x] Compared all 34 available exported DOCX documents against their originals.
- [x] Verified translated cells did not fall back to English.
- [x] Verified the duplicated Intro heading and text-box content were removed.
- [x] Verified embedded media remained unchanged.
- [x] Rendered originals and exports and reviewed layout differences.

### Remaining source-language content

- [x] Confirmed remaining English comes from 26 untranslated cells and unchanged original headers, footers, and bibliographic footnotes—not missed Spanish translations.
- [x] Confirmed those untranslated passages also remained English in v0.31.0.

This change fixes mapping and duplication; it does not automatically translate blank cells or template content.