### PR TITLE
fix: converge identical-file syncs and safely preserve merged content

### DIFF
--- a/src/projectManager/utils/merge/conflictSynthesis.ts
+++ b/src/projectManager/utils/merge/conflictSynthesis.ts
@@ -1,7 +1,7 @@
 /**
- * Last-resort self-heal for the remote-changed/conflict-list invariant
- * (issue #991, enforced in merge/index.ts): every remote-changed file must
- * appear in the conflict list, or the merge commit would silently drop it.
+ * Recover remote changes missing from Frontier's conflict list (issue #991).
+ * A history change is not necessarily a content conflict: paths already
+ * present with identical committed AND working bytes need no resolution.
  *
  * A mismatch is first treated as transient — the sync retries with a fresh
  * fetch. But if it persists on the final attempt (a path-classification bug
@@ -17,13 +17,20 @@
  */
 import * as vscode from "vscode";
 import * as dugiteGit from "../../../utils/dugiteGit";
-import { ConflictFile } from "./types";
+import type { ConflictFile } from "./types";
 import { TransientSyncError } from "./transientSyncError";
 
 /** Git operations the synthesis needs; injectable for tests. */
 export interface ConflictSynthesisGitOps {
     resolveRef: (dir: string, ref: string) => Promise<string>;
     readBlobAtRef: (dir: string, ref: string, filepath: string) => Promise<Buffer>;
+    currentBranch?: (dir: string) => Promise<string | undefined>;
+}
+
+export interface MergeSnapshot {
+    localHead: string;
+    remoteHead: string;
+    baseHead?: string;
 }
 
 /**
@@ -56,10 +63,18 @@ async function findRemoteRef(
     workspaceDir: string,
     gitOps: ConflictSynthesisGitOps
 ): Promise<string | null> {
+    // Prefer the checked-out branch, not origin/HEAD (which can name another branch).
+    if (gitOps.currentBranch) {
+        const branch = await gitOps.currentBranch(workspaceDir);
+        if (branch) {
+            try {
+                return await gitOps.resolveRef(workspaceDir, `refs/remotes/origin/${branch}`);
+            } catch { /* Older checkouts may only have FETCH_HEAD. */ }
+        }
+    }
     for (const ref of REMOTE_REF_CANDIDATES) {
         try {
-            await gitOps.resolveRef(workspaceDir, ref);
-            return ref;
+            return await gitOps.resolveRef(workspaceDir, ref);
         } catch {
             // try the next candidate
         }
@@ -69,6 +84,7 @@ async function findRemoteRef(
 
 export interface ConflictSynthesisResult {
     synthesized: ConflictFile[];
+    unchanged: string[];
     /** Paths whose remote content could not be read — the caller must keep failing loudly for these. */
     unsynthesizable: string[];
 }
@@ -78,30 +94,31 @@ export interface ConflictSynthesisResult {
  * missed. Content sources:
  *  - theirs: the fetched remote ref (required — no remote blob, no synthesis);
  *  - ours: the working tree, falling back to HEAD;
- *  - base: HEAD (there is no merge-base helper; for a file only the remote
- *    changed, ours == HEAD makes the 3-way resolve to theirs, and the `.codex`
- *    custom merge is edit-history-driven and ignores base entirely).
+ *  - base: the analysed common ancestor when supplied by Frontier. Older
+ *    versions fall back to HEAD for text, but never guess ancestry for media
+ *    pointers. Matching HEAD and working bytes are excluded before synthesis.
  */
 export async function synthesizeConflictsForPaths(
     workspaceDir: string,
     filepaths: string[],
-    gitOps: ConflictSynthesisGitOps = dugiteGit
+    gitOps: ConflictSynthesisGitOps = dugiteGit,
+    snapshot?: MergeSnapshot
 ): Promise<ConflictSynthesisResult> {
     const synthesized: ConflictFile[] = [];
+    const unchanged: string[] = [];
     const unsynthesizable: string[] = [];
 
-    const remoteRef = await findRemoteRef(workspaceDir, gitOps);
+    const remoteRef = snapshot?.remoteHead ?? await findRemoteRef(workspaceDir, gitOps);
     if (remoteRef === null) {
-        return { synthesized, unsynthesizable: [...filepaths] };
+        return { synthesized, unchanged, unsynthesizable: [...filepaths] };
     }
 
     for (const filepath of filepaths) {
         const normalized = normalizeSyncPath(filepath);
 
-        let theirs: string;
+        let remoteBytes: Buffer;
         try {
-            const blob = await gitOps.readBlobAtRef(workspaceDir, remoteRef, normalized);
-            theirs = blob.toString("utf-8");
+            remoteBytes = await gitOps.readBlobAtRef(workspaceDir, remoteRef, normalized);
         } catch (error) {
             console.warn(
                 `[Sync] Could not read remote content for ${normalized} at ${remoteRef}:`,
@@ -111,30 +128,60 @@ export async function synthesizeConflictsForPaths(
             continue;
         }
 
-        let headContent: string | null = null;
+        let headBytes: Buffer | null = null;
         try {
-            const blob = await gitOps.readBlobAtRef(workspaceDir, "HEAD", normalized);
-            headContent = blob.toString("utf-8");
+            headBytes = await gitOps.readBlobAtRef(workspaceDir, snapshot?.localHead ?? "HEAD", normalized);
         } catch {
             // not in HEAD — the file is new from the remote's perspective
         }
 
-        let workingContent: string | null = null;
+        let workingBytes: Buffer | null = null;
         try {
             const target = vscode.Uri.joinPath(
                 vscode.Uri.file(workspaceDir),
                 ...normalized.split("/")
             );
-            workingContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(target));
+            workingBytes = Buffer.from(await vscode.workspace.fs.readFile(target));
         } catch {
             // not in the working tree
         }
 
+        // Check bytes, not UTF-8 strings: distinct binary blobs can decode to
+        // the same replacement characters. HEAD must match too, otherwise the
+        // working file still needs staging before creating the merge commit.
+        if (headBytes?.equals(remoteBytes) && workingBytes?.equals(remoteBytes)) {
+            unchanged.push(normalized);
+            continue;
+        }
+
+        if ([remoteBytes, headBytes, workingBytes].some(
+            (bytes) => bytes !== null && !Buffer.from(bytes.toString("utf8")).equals(bytes)
+        )) {
+            // The text resolver cannot safely round-trip arbitrary binary data.
+            unsynthesizable.push(normalized);
+            continue;
+        }
+
+        const theirs = remoteBytes.toString("utf-8");
+        const headContent = headBytes?.toString("utf-8") ?? null;
+        const workingContent = workingBytes?.toString("utf-8") ?? null;
+        let base = headContent ?? "";
+        if (snapshot?.baseHead) {
+            try {
+                base = (await gitOps.readBlobAtRef(workspaceDir, snapshot.baseHead, normalized)).toString("utf-8");
+            } catch {
+                // Unknown ancestry must not turn two different pointers into a
+                // one-sided change. An empty base makes that conflict explicit.
+                base = "";
+            }
+        } else if (normalized.startsWith(".project/attachments/pointers/")) {
+            base = "";
+        }
         synthesized.push({
             filepath: normalized,
             ours: workingContent ?? headContent ?? "",
             theirs,
-            base: headContent ?? "",
+            base,
             isDeleted: false,
             // Keyed off DISK presence, not HEAD: the resolvers' existing-file
             // branch stats the working tree and fails for a missing file, so
@@ -144,7 +191,7 @@ export async function synthesizeConflictsForPaths(
         });
     }
 
-    return { synthesized, unsynthesizable };
+    return { synthesized, unchanged, unsynthesizable };
 }
 
 export interface ConflictListInvariantOptions {
@@ -155,6 +202,7 @@ export interface ConflictListInvariantOptions {
     /** Current sync attempt (the outer retry layer caps at 2 retries). */
     retryCount: number;
     workspaceDir: string;
+    snapshot?: MergeSnapshot;
     /**
      * Sink for the self-heal log entry (defaults to console.warn). Injectable
      * because the extension host defines console methods as non-writable, so
@@ -164,8 +212,8 @@ export interface ConflictListInvariantOptions {
 }
 
 /**
- * Enforces the #991 invariant: every remote-changed file must appear in the
- * conflict list, or the merge commit would silently drop it. Both sides are
+ * Every remote-changed file must be resolved OR already present unchanged.
+ * Missing/different content still follows the recovery/retry path. Both sides are
  * normalized before comparing so a formatting mismatch (separators, "./",
  * Unicode form) can't fake a violation.
  *
@@ -191,10 +239,17 @@ export async function enforceConflictListInvariant(
             .filter((p): p is string => typeof p === "string")
             .map(normalizeSyncPath)
     );
-    const missingFromConflicts = changedPaths
+    const missingFromConflicts = [...new Set(changedPaths
         .filter((p): p is string => typeof p === "string" && p.length > 0)
-        .filter((p) => !conflictPaths.has(normalizeSyncPath(p)));
+        .map(normalizeSyncPath)
+        .filter((p) => !conflictPaths.has(p)))];
     if (missingFromConflicts.length === 0) return [];
+
+    const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
+        workspaceDir, missingFromConflicts, gitOps, options.snapshot
+    );
+    if (synthesized.length === 0 && unsynthesizable.length === 0) return [];
+    const unresolvedPaths = [...synthesized.map((file) => file.filepath), ...unsynthesizable];
 
     const describeMissing = (paths: string[]) => {
         const sample = paths.slice(0, 5).join(", ");
@@ -204,16 +259,11 @@ export async function enforceConflictListInvariant(
 
     if (retryCount < 2) {
         throw new TransientSyncError(
-            `${missingFromConflicts.length} remote-changed file(s) were not in the conflict list. Missing: ${describeMissing(missingFromConflicts)}`,
-            missingFromConflicts
+            `${unresolvedPaths.length} remote-changed file(s) were not in the conflict list. Missing: ${describeMissing(unresolvedPaths)}`,
+            unresolvedPaths
         );
     }
 
-    const { synthesized, unsynthesizable } = await synthesizeConflictsForPaths(
-        workspaceDir,
-        missingFromConflicts,
-        gitOps
-    );
     if (unsynthesizable.length > 0) {
         throw new TransientSyncError(
             `${unsynthesizable.length} remote-changed file(s) were not in the conflict list and could not be recovered from the fetched remote. Missing: ${describeMissing(unsynthesizable)}`,
@@ -225,4 +275,20 @@ export async function enforceConflictListInvariant(
         synthesized.map((c) => c.filepath)
     );
     return synthesized;
+}
+
+/** Older Frontier versions also report matching files as actual conflicts. */
+export async function excludeUnchangedConflicts(
+    conflicts: ConflictFile[],
+    workspaceDir: string,
+    snapshot?: MergeSnapshot,
+    gitOps: ConflictSynthesisGitOps = dugiteGit
+): Promise<ConflictFile[]> {
+    const candidates = conflicts.filter((c) => !c.isDeleted && c.ours === c.theirs);
+    if (candidates.length === 0) return conflicts;
+    const { unchanged } = await synthesizeConflictsForPaths(
+        workspaceDir, candidates.map((c) => c.filepath), gitOps, snapshot
+    );
+    const paths = new Set(unchanged);
+    return conflicts.filter((c) => !paths.has(normalizeSyncPath(c.filepath)));
 }

--- a/src/projectManager/utils/merge/index.ts
+++ b/src/projectManager/utils/merge/index.ts
@@ -32,7 +32,7 @@ import {
     notifyEmptiedCodexFilesRestored,
     notifyEmptiedCodexFilesBlockedSync,
 } from "../syncSafetyGuard";
-import { enforceConflictListInvariant } from "./conflictSynthesis";
+import { enforceConflictListInvariant, excludeUnchangedConflicts } from "./conflictSynthesis";
 
 const DEBUG_MODE = false;
 function debug(...args: any[]): void {
@@ -198,16 +198,8 @@ export async function stageAndCommitAllAndSync(
             return syncResult;
         }
 
-        // Invariant (issue #991): every remote-changed file MUST appear in the
-        // conflict list — proceeding otherwise would create a merge commit
-        // missing those files. Unlike the old diagnostic, this checks ALL
-        // paths, not just `.codex`, because the gan-ji-an regression involved
-        // .webm pointer files too. On early attempts a mismatch throws a
-        // TransientSyncError so the retry layer below refetches; on the FINAL
-        // attempt the missing paths are synthesized from local git state and
-        // merged normally, so a persistent upstream mismatch degrades to a
-        // normal merge instead of a permanent sync outage. See
-        // enforceConflictListInvariant for the full decision logic.
+        // History changes can already be present with identical content. Only
+        // genuinely missing/different paths need conflict recovery (issue #991).
         const conflictsArr = Array.isArray(conflictsResponse?.conflicts)
             ? (conflictsResponse.conflicts as Array<{ filepath?: string; }>)
             : [];
@@ -222,6 +214,7 @@ export async function stageAndCommitAllAndSync(
                     : [],
             retryCount,
             workspaceDir: workspaceFolder,
+            snapshot: conflictsResponse.mergeSnapshot,
         });
 
         // Capture uploaded LFS files from the sync operation
@@ -230,7 +223,11 @@ export async function stageAndCommitAllAndSync(
         }
 
         if (conflictsResponse?.hasConflicts || synthesizedConflicts.length > 0) {
-            const conflicts = [...(conflictsResponse.conflicts || []), ...synthesizedConflicts];
+            const conflicts = await excludeUnchangedConflicts(
+                [...(conflictsResponse.conflicts || []), ...synthesizedConflicts],
+                workspaceFolder,
+                conflictsResponse.mergeSnapshot
+            );
             debug(`🔧 Processing ${conflicts.length} file conflicts from git sync...`);
 
             // Track which files are being modified
@@ -246,7 +243,9 @@ export async function stageAndCommitAllAndSync(
                 }
             }
 
-            const { resolved: resolvedFiles, failed: failedConflicts } = await resolveConflictFiles(conflicts, workspaceFolder);
+            const { resolved: resolvedFiles, failed: failedConflicts } = conflicts.length > 0
+                ? await resolveConflictFiles(conflicts, workspaceFolder)
+                : { resolved: [], failed: [] };
 
             // Reconcile with actual resolutions: a conflict flagged isDeleted may
             // have been restored by the deletion guard. Downstream consumers treat
@@ -300,33 +299,33 @@ export async function stageAndCommitAllAndSync(
                 ));
             }
 
-            if (resolvedFiles.length > 0) {
-                try {
-                    await authApi.completeMerge(resolvedFiles, undefined);
-                    debug(`✅ Resolved ${resolvedFiles.length} file conflicts`);
-                } catch (completeMergeError) {
-                    const errorMessage = completeMergeError instanceof Error ? completeMergeError.message : String(completeMergeError);
-                    debug("completeMerge error:", errorMessage);
+            // Divergent histories still need a two-parent commit even when all
+            // file contents match. Otherwise every later sync repeats the merge.
+            try {
+                await authApi.completeMerge(resolvedFiles, undefined, conflictsResponse.mergeSnapshot);
+                debug(`✅ Resolved ${resolvedFiles.length} file conflicts`);
+            } catch (completeMergeError) {
+                const errorMessage = completeMergeError instanceof Error ? completeMergeError.message : String(completeMergeError);
+                debug("completeMerge error:", errorMessage);
 
-                    // Use the shared classifier so completeMerge retries stay aligned
-                    // with the outer transient-error policy (single source of truth).
-                    if (isRetriableSyncError(completeMergeError) && retryCount < 3) {
-                        debug(`⚠️ Transient completeMerge failure, retrying... (attempt ${retryCount + 1}/3)`);
+                // Use the shared classifier so completeMerge retries stay aligned
+                // with the outer transient-error policy (single source of truth).
+                if (isRetriableSyncError(completeMergeError) && retryCount < 3) {
+                    debug(`⚠️ Transient completeMerge failure, retrying... (attempt ${retryCount + 1}/3)`);
 
-                        const backoffMs = 5 * Math.pow(2, retryCount) * 1000;
-                        debug(`⏳ Waiting ${backoffMs / 1000} seconds before retrying...`);
-                        await new Promise(resolve => setTimeout(resolve, backoffMs));
+                    const backoffMs = 5 * Math.pow(2, retryCount) * 1000;
+                    debug(`⏳ Waiting ${backoffMs / 1000} seconds before retrying...`);
+                    await new Promise(resolve => setTimeout(resolve, backoffMs));
 
-                        return stageAndCommitAllAndSync(commitMessage, showCompletionMessage, retryCount + 1);
-                    }
-
-                    if (retryCount >= 3) {
-                        vscode.window.showErrorMessage(
-                            `Sync couldn't complete after multiple attempts. Please check your internet connection and try again.`
-                        );
-                    }
-                    throw completeMergeError;
+                    return stageAndCommitAllAndSync(commitMessage, showCompletionMessage, retryCount + 1);
                 }
+
+                if (retryCount >= 3) {
+                    vscode.window.showErrorMessage(
+                        `Sync couldn't complete after multiple attempts. Please check your internet connection and try again.`
+                    );
+                }
+                throw completeMergeError;
             }
         }
 

--- a/src/projectManager/utils/merge/pointerConflict.ts
+++ b/src/projectManager/utils/merge/pointerConflict.ts
@@ -1,0 +1,12 @@
+import type { ConflictFile } from "./types";
+
+/** Pointer IDs refer to immutable media; choosing one arbitrarily can lose audio. */
+export function resolvePointerConflict(conflict: ConflictFile): string {
+    if (conflict.ours === conflict.theirs) return conflict.ours;
+    if (conflict.ours === conflict.base) return conflict.theirs;
+    if (conflict.theirs === conflict.base) return conflict.ours;
+    throw new Error(
+        `Both sides changed media pointer ${conflict.filepath}. ` +
+        "Sync stopped without choosing or overwriting either recording."
+    );
+}

--- a/src/projectManager/utils/merge/resolvers.ts
+++ b/src/projectManager/utils/merge/resolvers.ts
@@ -1,5 +1,7 @@
 import { CodexCellDocument } from './../../../providers/codexCellEditorProvider/codexDocument';
 import * as vscode from "vscode";
+import { resolvePointerConflict } from "./pointerConflict";
+import { atomicWriteUriText } from "../../../utils/notebookSafeSaveUtils";
 import * as path from "path";
 import { ConflictResolutionStrategy, ConflictFile } from "./types";
 import { determineStrategy } from "./strategies";
@@ -578,6 +580,9 @@ export async function resolveConflictFile(
         }
 
         switch (strategy) {
+            case ConflictResolutionStrategy.LFS_POINTER:
+                resolvedContent = resolvePointerConflict(conflict);
+                break;
             case ConflictResolutionStrategy.IGNORE:
                 debugLog("Ignoring conflict for:", conflict.filepath);
                 resolvedContent = conflict.ours; // Keep our version
@@ -630,7 +635,7 @@ export async function resolveConflictFile(
 
         const targetPath = vscode.Uri.file(resolvedTarget);
         debugLog("Writing resolved content to:", targetPath.fsPath);
-        await vscode.workspace.fs.writeFile(targetPath, Buffer.from(resolvedContent));
+        await atomicWriteUriText(targetPath, resolvedContent);
         debugLog("Successfully wrote content for:", conflict.filepath);
 
         return conflict.filepath;
@@ -2754,9 +2759,9 @@ export async function resolveConflictFiles(
                                 } catch {
                                     existedOnDisk = false;
                                 }
-                                await vscode.workspace.fs.writeFile(
+                                await atomicWriteUriText(
                                     filePath,
-                                    Buffer.from(survivingContent)
+                                    survivingContent
                                 );
                                 resolvedFiles.push({
                                     filepath: conflict.filepath,
@@ -2844,7 +2849,7 @@ export async function resolveConflictFiles(
                                 });
                                 return;
                             }
-                            await vscode.workspace.fs.writeFile(filePath, Buffer.from(content));
+                            await atomicWriteUriText(filePath, content);
                             resolvedFiles.push({
                                 filepath: conflict.filepath,
                                 resolution: "created",

--- a/src/projectManager/utils/merge/strategies.ts
+++ b/src/projectManager/utils/merge/strategies.ts
@@ -2,6 +2,7 @@ import { ConflictResolutionStrategy } from "./types";
 
 // Define which files use which strategies
 export const filePatternsToResolve: Record<ConflictResolutionStrategy, string[]> = {
+    [ConflictResolutionStrategy.LFS_POINTER]: [".project/attachments/pointers/*"],
     // Codex notebook files - special merge process for cell arrays
     [ConflictResolutionStrategy.CODEX_CUSTOM_MERGE]: [
         "files/target/*.codex",

--- a/src/projectManager/utils/merge/transientSyncError.ts
+++ b/src/projectManager/utils/merge/transientSyncError.ts
@@ -39,6 +39,7 @@ export function isRetriableSyncError(err: unknown): boolean {
     const msg = err.message;
     return (
         msg.startsWith(BLOB_READ_FAILED_PREFIX) ||
+        msg.includes("MERGE_STATE_CHANGED:") ||
         msg.includes("non-fast-forward") ||
         msg.includes("failed to push") ||
         msg.includes("Failed to push") ||

--- a/src/projectManager/utils/merge/types.ts
+++ b/src/projectManager/utils/merge/types.ts
@@ -7,6 +7,7 @@ export enum ConflictResolutionStrategy {
     SPECIAL = "special", // Merge based on timestamps/rules
     CODEX_CUSTOM_MERGE = "codex", // Special merge process for cell arrays
     JSON_MERGE_3WAY = "json-merge-3way", // 3-way merge for JSON settings with chatSystemMessage tie-breaker
+    LFS_POINTER = "lfs-pointer", // Preserve one-sided pointer changes; reject ambiguous replacements
 }
 
 export interface ConflictFile {

--- a/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
+++ b/src/providers/NewSourceUploader/NewSourceUploaderProvider.ts
@@ -994,6 +994,10 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
         const metadata: CustomNotebookMetadata = {
             id: processedNotebook.metadata.id,
             originalName: processedNotebook.metadata.originalFileName,
+            originalFileName: processedNotebook.metadata.originalFileName,
+            originalFileHash: processedNotebook.metadata.originalFileHash,
+            originalFileRequestedName: processedNotebook.metadata.originalFileRequestedName,
+            importContext: processedNotebook.metadata.importContext,
             sourceFsPath: "",
             codexFsPath: "",
             navigation: [],
@@ -1169,14 +1173,17 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                     originalFileHashes.set(pairIdx, result.hash);
 
                     // Store the file hash in metadata for integrity verification and deduplication tracking
-                    (pair.source.metadata as any).originalFileHash = result.hash;
+                    pair.source.metadata.originalFileHash = result.hash;
+                    pair.source.metadata.originalFileRequestedName = requestedFileName;
+                    pair.source.metadata.originalFileName = result.fileName;
                     if (pair.codex?.metadata) {
-                        (pair.codex.metadata as any).originalFileHash = result.hash;
+                        pair.codex.metadata.originalFileHash = result.hash;
+                        pair.codex.metadata.originalFileRequestedName = requestedFileName;
+                        pair.codex.metadata.originalFileName = result.fileName;
                     }
 
-                    // IMPORTANT: Preserve user's original filename as fileDisplayName before updating originalFileName
-                    // This ensures the display name reflects what the user imported, while originalFileName
-                    // points to the actual deduplicated file in attachments/files/originals
+                    // Keep the user's requested name for display; originalFileName
+                    // now points to the actual deduplicated file in attachments/files/originals.
                     if (result.fileName !== requestedFileName) {
                         // Set fileDisplayName to user's original name (without extension) if not already set
                         if (!pair.source.metadata.fileDisplayName) {
@@ -1189,11 +1196,6 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                             (pair.codex.metadata as any).fileDisplayName = displayName;
                         }
 
-                        // Update originalFileName to point to the actual stored file (deduplicated)
-                        pair.source.metadata.originalFileName = result.fileName;
-                        if (pair.codex?.metadata) {
-                            pair.codex.metadata.originalFileName = result.fileName;
-                        }
                         console.log(`[NewSourceUploader] Updated originalFileName to deduplicated file: "${result.fileName}"`);
                     }
 
@@ -1277,7 +1279,8 @@ export class NewSourceUploaderProvider implements vscode.CustomTextEditorProvide
                     // re-import detection.
                 }
 
-                const fileName = message.notebookPairs[pairIdx].source.metadata.originalFileName;
+                // Match the user's filename, not the suffixed storage name assigned above.
+                const fileName = message.notebookPairs[pairIdx].source.metadata.originalFileRequestedName;
                 const matches = await findExistingImportPairs(workspaceFolder, hash, fileName);
                 if (!matches) continue;
 

--- a/src/providers/NewSourceUploader/reimportMerge.ts
+++ b/src/providers/NewSourceUploader/reimportMerge.ts
@@ -30,6 +30,7 @@
 import { CodexCellTypes, EditType } from "../../../types/enums";
 import { EditMapUtils } from "../../utils/editMapUtils";
 import { extractPlainTextFromHtml } from "../../../sharedUtils/htmlStructureUtils";
+import { mergeReimportedMetadata, reimportTimestamp } from "./reimportMetadata";
 
 export interface ReimportEdit {
     editMap: readonly string[];
@@ -88,21 +89,6 @@ const PRESERVED_TARGET_METADATA_KEYS = [
     "isLocked",
 ] as const;
 
-/** Notebook metadata that identifies the existing pair and must not change. */
-const PRESERVED_NOTEBOOK_METADATA_KEYS = [
-    "id",
-    "fileDisplayName",
-    "sourceFsPath",
-    "codexFsPath",
-    "navigation",
-    "sourceCreatedAt",
-    "corpusMarker",
-    "textDirection",
-    "videoUrl",
-    "lineNumbersEnabled",
-    "lineNumbersEnabledSource",
-] as const;
-
 const normalizeText = (html: string | undefined): string =>
     extractPlainTextFromHtml(html ?? "");
 
@@ -132,19 +118,6 @@ interface OldCellEntry {
 
 const hasTranslation = (entry: OldCellEntry): boolean =>
     Boolean(entry.targetCell?.value && entry.targetCell.value.trim() !== "");
-
-const mergeNotebookMetadata = (
-    existing: Record<string, unknown> | undefined,
-    incoming: Record<string, unknown> | undefined,
-): Record<string, unknown> => {
-    const merged: Record<string, unknown> = { ...(existing ?? {}), ...(incoming ?? {}) };
-    for (const key of PRESERVED_NOTEBOOK_METADATA_KEYS) {
-        if (existing && existing[key] !== undefined) {
-            merged[key] = existing[key];
-        }
-    }
-    return merged;
-};
 
 const REIMPORT_AUTHOR = "system";
 
@@ -228,7 +201,7 @@ export const mergeReimportedNotebookPair = (
     newSource: ReimportNotebook,
     newCodex: ReimportNotebook,
 ): ReimportMergeResult => {
-    const now = Date.now();
+    const now = reimportTimestamp(existingSource.metadata, existingCodex.metadata);
 
     const oldTargetById = new Map<string, ReimportCell>();
     for (const cell of existingCodex.cells ?? []) {
@@ -540,11 +513,11 @@ export const mergeReimportedNotebookPair = (
     return {
         mergedSource: {
             cells: mergedSourceCells,
-            metadata: mergeNotebookMetadata(existingSource.metadata, newSource.metadata),
+            metadata: mergeReimportedMetadata(existingSource.metadata, newSource.metadata, now, stats),
         },
         mergedCodex: {
             cells: mergedCodexCells,
-            metadata: mergeNotebookMetadata(existingCodex.metadata, newCodex.metadata),
+            metadata: mergeReimportedMetadata(existingCodex.metadata, newCodex.metadata, now, stats),
         },
         stats,
     };

--- a/src/providers/NewSourceUploader/reimportMetadata.ts
+++ b/src/providers/NewSourceUploader/reimportMetadata.ts
@@ -1,0 +1,78 @@
+import type { FileEditHistory } from "../../../types";
+import { EditType } from "../../../types/enums";
+import { EditMapUtils } from "../../utils/editMapUtils";
+import type { ReimportMergeStats } from "./reimportMerge";
+
+/** Keep the existing pair's identity and the user's presentation settings. */
+const PRESERVED_KEYS = new Set([
+    "id", "fileDisplayName", "sourceFsPath", "codexFsPath", "navigation",
+    "sourceCreatedAt", "corpusMarker", "textDirection", "videoUrl",
+    "lineNumbersEnabled", "lineNumbersEnabledSource",
+]);
+
+const ORIGINAL_REFERENCE_KEYS = [
+    "originalName", "originalFileName", "originalFileHash", "originalFileRequestedName",
+] as const;
+
+/** A local reimport must follow edits already observed, even after clock skew. */
+export function reimportTimestamp(...metadata: (Record<string, unknown> | undefined)[]): number {
+    return metadata.reduce((latest, item) => {
+        const edits: FileEditHistory[] = Array.isArray(item?.edits) ? item.edits : [];
+        return edits.reduce((time, edit) => Number.isFinite(edit?.timestamp)
+            ? Math.max(time, edit.timestamp + 1) : time, latest);
+    }, Date.now());
+}
+
+/** Record file metadata changes in the same history used by notebook sync. */
+export function mergeReimportedMetadata(
+    existing: Record<string, unknown> = {},
+    incoming: Record<string, unknown> = {},
+    timestamp: number,
+    stats: ReimportMergeStats,
+): Record<string, unknown> {
+    const merged = { ...existing };
+    for (const [key, value] of Object.entries(incoming)) {
+        if (key === "edits" || value === undefined) continue;
+        if (PRESERVED_KEYS.has(key) && existing[key] !== undefined) continue;
+        merged[key] = value;
+    }
+
+    // Both names are read by exporters and legacy notebooks. They must agree.
+    const originalName = incoming.originalFileName || incoming.originalName;
+    if (typeof originalName === "string") {
+        merged.originalName = merged.originalFileName = originalName;
+        // A legacy caller can supply a changed name without a hash. Do not
+        // associate the new original with the previous original's known hash.
+        const oldName = existing.originalFileName || existing.originalName;
+        if (originalName !== oldName && !incoming.originalFileHash) {
+            merged.originalFileHash = "";
+        }
+    }
+    merged.importContext = {
+        ...((existing.importContext as Record<string, unknown>) ?? {}),
+        ...((incoming.importContext as Record<string, unknown>) ?? {}),
+        lastReimport: { timestamp: new Date(timestamp).toISOString(), stats },
+    };
+
+    // Incoming parse history describes a new notebook; preserve the existing
+    // notebook's history and append only the changes actually applied to it.
+    const edits: FileEditHistory[] = Array.isArray(existing.edits) ? [...existing.edits] : [];
+    const changed = (key: string) => JSON.stringify(existing[key]) !== JSON.stringify(merged[key]);
+    const referenceChanged = ORIGINAL_REFERENCE_KEYS.some(changed);
+    const referenceKeys = new Set<string>(ORIGINAL_REFERENCE_KEYS);
+    for (const [key, value] of Object.entries(merged)) {
+        if (key === "edits" || value === undefined) continue;
+        // Stamp the whole reference together, including unchanged members:
+        // an older filename edit must not win alongside this new hash.
+        if (!changed(key) && !(referenceChanged && referenceKeys.has(key))) continue;
+        edits.push({
+            editMap: EditMapUtils.metadataField(key),
+            value: value as FileEditHistory["value"],
+            timestamp,
+            type: EditType.MIGRATION,
+            author: "system",
+        });
+    }
+    merged.edits = edits;
+    return merged;
+}

--- a/src/providers/NewSourceUploader/updateExistingImport.ts
+++ b/src/providers/NewSourceUploader/updateExistingImport.ts
@@ -27,6 +27,7 @@ export interface ExistingImportPair {
 const resolvePairForBaseName = async (
     workspaceFolder: vscode.WorkspaceFolder,
     baseName: string,
+    expectedOriginal?: { hash: string; fileName: string },
 ): Promise<ExistingImportPair | null> => {
     const sourceUri = vscode.Uri.joinPath(
         workspaceFolder.uri,
@@ -51,10 +52,20 @@ const resolvePairForBaseName = async (
     try {
         const content = await vscode.workspace.fs.readFile(sourceUri);
         const notebook = JSON.parse(new TextDecoder().decode(content));
+        if (expectedOriginal) {
+            // Registry references can outlive an Update Existing operation.
+            // A previous original must not masquerade as a current hash match.
+            const { originalFileHash, originalFileName, originalName } = notebook.metadata ?? {};
+            const matches = originalFileHash
+                ? originalFileHash === expectedOriginal.hash
+                : (originalFileName || originalName) === expectedOriginal.fileName;
+            if (!matches) return null;
+        }
         if (typeof notebook?.metadata?.fileDisplayName === "string") {
             displayName = notebook.metadata.fileDisplayName;
         }
     } catch {
+        if (expectedOriginal) return null;
         // Display name is cosmetic; fall back to the base name.
     }
 
@@ -101,7 +112,8 @@ const scanSourceMetadata = async (
                 } else if (
                     originalFileName &&
                     (metadata.originalName === originalFileName ||
-                        metadata.originalFileName === originalFileName)
+                        metadata.originalFileName === originalFileName ||
+                        metadata.originalFileRequestedName === originalFileName)
                 ) {
                     nameBaseNames.push(baseName);
                 }
@@ -126,13 +138,16 @@ export const findExistingImportPairs = async (
     originalFileHash: string,
     originalFileName?: string,
 ): Promise<ExistingImportMatches | null> => {
-    const resolveAll = async (baseNames: Iterable<string>): Promise<ExistingImportPair[]> => {
+    const resolveAll = async (
+        baseNames: Iterable<string>,
+        expectedOriginal?: { hash: string; fileName: string },
+    ): Promise<ExistingImportPair[]> => {
         const pairs: ExistingImportPair[] = [];
         const seen = new Set<string>();
         for (const baseName of baseNames) {
             if (seen.has(baseName)) continue;
             seen.add(baseName);
-            const pair = await resolvePairForBaseName(workspaceFolder, baseName);
+            const pair = await resolvePairForBaseName(workspaceFolder, baseName, expectedOriginal);
             if (pair) pairs.push(pair);
         }
         return pairs;
@@ -141,7 +156,7 @@ export const findExistingImportPairs = async (
     // Fast path: the registry answers the common cases without touching any
     // notebook files (a first-time import should not pay for a full scan).
     const entry = await findOriginalFileByHash(workspaceFolder, originalFileHash);
-    const registryHashPairs = await resolveAll(entry?.referencedBy ?? []);
+    const registryHashPairs = await resolveAll(entry?.referencedBy ?? [], entry ?? undefined);
     if (registryHashPairs.length > 0) {
         return { matchedBy: "content", pairs: registryHashPairs };
     }
@@ -214,18 +229,6 @@ export const updateExistingImportPair = async (
         newSource as unknown as ReimportNotebook,
         newCodex as unknown as ReimportNotebook,
     );
-
-    const reimportContext = {
-        timestamp: new Date().toISOString(),
-        stats,
-    };
-    for (const merged of [mergedSource, mergedCodex]) {
-        const metadata = (merged.metadata ??= {});
-        metadata.importContext = {
-            ...((metadata.importContext as Record<string, unknown>) ?? {}),
-            lastReimport: reimportContext,
-        };
-    }
 
     await writeNotebook(pair.sourceUri, mergedSource as unknown as CodexNotebookAsJSONData);
     await writeNotebook(pair.codexUri, mergedCodex as unknown as CodexNotebookAsJSONData);

--- a/src/test/suite/conflictSynthesis.test.ts
+++ b/src/test/suite/conflictSynthesis.test.ts
@@ -43,7 +43,7 @@ function fakeGitOps(
     return {
         resolveRef: async (_dir: string, ref: string) => {
             if (!refs.includes(ref)) throw new Error(`unknown ref ${ref}`);
-            return "0000000000000000000000000000000000000000";
+            return ref;
         },
         readBlobAtRef: async (_dir: string, ref: string, filepath: string) => {
             const key = `${ref}:${filepath}`;

--- a/src/test/suite/reimportOriginalReferences.test.ts
+++ b/src/test/suite/reimportOriginalReferences.test.ts
@@ -1,0 +1,206 @@
+import * as assert from "assert";
+import * as os from "os";
+import * as vscode from "vscode";
+import sinon from "sinon";
+import type { NotebookPreview } from "../../../types";
+import type { ProcessedNotebook, NotebookPair } from "../../../webviews/codex-webviews/src/NewSourceUploader/types/common";
+import type { WriteNotebooksMessage } from "../../../webviews/codex-webviews/src/NewSourceUploader/types/plugin";
+import { NewSourceUploaderProvider } from "../../providers/NewSourceUploader/NewSourceUploaderProvider";
+import { findExistingImportPairs } from "../../providers/NewSourceUploader/updateExistingImport";
+import { computeFileHash, loadOriginalFilesRegistry, resolveOriginalFileUri } from "../../providers/NewSourceUploader/originalFileUtils";
+import { resolveCodexCustomMerge } from "../../projectManager/utils/merge/resolvers";
+import { MetadataManager } from "../../utils/metadataManager";
+import { NotebookMetadataManager } from "../../utils/notebookMetadataManager";
+import { GlobalProvider } from "../../globalProvider";
+import { createMockExtensionContext } from "../testUtils";
+
+// Exercise the real provider -> original storage -> lookup -> create/update ->
+// serialization path. Stub only UI, workspace discovery and background indexing.
+type ProviderUnderTest = {
+    handleWriteNotebooksForced(message: WriteNotebooksMessage, token: vscode.CancellationToken,
+        panel: vscode.WebviewPanel): Promise<void>;
+    convertToNotebookPreview(notebook: ProcessedNotebook): Promise<NotebookPreview>;
+    migrateLocalizedBooksToMetadata: () => Promise<void>;
+    removeLocalizedBooksJsonIfPresent: () => Promise<void>;
+    fetchProjectInventory: () => Promise<unknown>;
+};
+
+const originalBytes = Buffer.from("PK\x03\x04old document template");
+const changedBytes = Buffer.from("PK\x03\x04new document template");
+
+function processedPair(id: string, bytes: Buffer, filename = "document.docx"): NotebookPair {
+    const makeNotebook = (target: boolean): ProcessedNotebook => ({
+        name: "document",
+        cells: [{ id: `${id}-cell`, content: target ? "" : "<p>Hello</p>", images: [], metadata: { type: "text" } }],
+        metadata: {
+            id, originalFileName: filename, sourceFile: filename, importerType: "docx",
+            createdAt: new Date(0).toISOString(), fileDisplayName: "Document",
+            originalFileData: Uint8Array.from(bytes).buffer,
+            importContext: { documentVersion: id },
+        },
+    });
+    return { source: makeNotebook(false), codex: makeNotebook(true) };
+}
+
+suite("reimport original references", () => {
+    let sandbox: sinon.SinonSandbox;
+    let workspace: vscode.WorkspaceFolder;
+    let provider: ProviderUnderTest;
+    let choice: "Update Existing" | "Import as New Copy" | undefined;
+    let info: sinon.SinonStub;
+    let tokenSource: vscode.CancellationTokenSource;
+
+    const read = async (uri: vscode.Uri) => JSON.parse(Buffer.from(await vscode.workspace.fs.readFile(uri)).toString());
+    const write = async (uri: vscode.Uri, value: unknown) => vscode.workspace.fs.writeFile(uri, Buffer.from(JSON.stringify(value)));
+    const sourceDir = () => vscode.Uri.joinPath(workspace.uri, ".project", "sourceTexts");
+    const sourceFiles = async () => (await vscode.workspace.fs.readDirectory(sourceDir()))
+        .filter(([name]) => name.endsWith(".source")).map(([name]) => vscode.Uri.joinPath(sourceDir(), name));
+    const codexFor = (uri: vscode.Uri) => vscode.Uri.joinPath(workspace.uri, "files", "target", uri.path.split("/").pop()!.replace(/\.source$/, ".codex"));
+
+    async function importPair(pair: NotebookPair): Promise<void> {
+        const postMessage = sandbox.stub().resolves(true);
+        await provider.handleWriteNotebooksForced(
+            { command: "writeNotebooks", notebookPairs: [pair] } as WriteNotebooksMessage,
+            tokenSource.token,
+            { webview: { postMessage } } as unknown as vscode.WebviewPanel,
+        );
+        assert.ok(postMessage.args.some(([message]) => message.command === "importComplete" || message.command === "importCancelled"));
+    }
+
+    async function exportTemplateBytes(notebook: { metadata: { originalFileName?: string; originalName: string } }): Promise<Buffer> {
+        // Same filename precedence and resolver used by the DOCX exporter.
+        const name = notebook.metadata.originalFileName || notebook.metadata.originalName;
+        const uri = await resolveOriginalFileUri(workspace, name);
+        return Buffer.from(await vscode.workspace.fs.readFile(uri));
+    }
+
+    setup(async () => {
+        sandbox = sinon.createSandbox();
+        tokenSource = new vscode.CancellationTokenSource();
+        workspace = {
+            uri: vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), `codex-reimport-${Date.now()}-${Math.random().toString(36).slice(2)}`),
+            name: "reimport-test", index: 0,
+        };
+        await vscode.workspace.fs.createDirectory(sourceDir());
+        await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(workspace.uri, "files", "target"));
+        await write(vscode.Uri.joinPath(workspace.uri, "metadata.json"), {});
+        sandbox.stub(vscode.workspace, "workspaceFolders").value([workspace]);
+        sandbox.stub(vscode.workspace, "findFiles").callsFake(async () => sourceFiles());
+        sandbox.stub(vscode.commands, "executeCommand").resolves();
+        choice = "Update Existing";
+        info = sandbox.stub(vscode.window, "showInformationMessage");
+        info.callsFake(async (_message: string, options: unknown) =>
+            typeof options === "object" ? choice : undefined);
+        sandbox.stub(vscode.window, "showWarningMessage").resolves();
+        sandbox.stub(MetadataManager, "getAIInstructionsCompleted").resolves(true);
+        sandbox.stub(NotebookMetadataManager, "getManager").returns({ loadMetadata: async () => {} } as NotebookMetadataManager);
+        sandbox.stub(GlobalProvider.getInstance(), "getProvider").returns(undefined);
+        provider = new NewSourceUploaderProvider(createMockExtensionContext()) as unknown as ProviderUnderTest;
+        sandbox.stub(provider, "migrateLocalizedBooksToMetadata").resolves();
+        sandbox.stub(provider, "removeLocalizedBooksJsonIfPresent").resolves();
+        sandbox.stub(provider, "fetchProjectInventory").resolves([]);
+    });
+
+    teardown(async () => {
+        sandbox.restore();
+        tokenSource.dispose();
+        await vscode.workspace.fs.delete(workspace.uri, { recursive: true, useTrash: false });
+    });
+
+    test("Update Existing finds a renamed original, preserves work and resolves the new export template after sync in either direction", async () => {
+        await importPair(processedPair("first", originalBytes));
+        const [sourceUri] = await sourceFiles();
+        const codexUri = codexFor(sourceUri);
+        const staleSource = await read(sourceUri);
+        const staleCodex = await read(codexUri);
+        staleCodex.cells[0].value = "<p>Translated</p>";
+        staleCodex.cells[0].metadata.edits = [{ editMap: ["value"], value: "<p>Translated</p>", timestamp: 1, type: "user-edit", author: "translator" }];
+        staleCodex.cells[0].metadata.attachments = { audio: { url: "old-audio.wav", type: "audio" } };
+        staleCodex.cells[0].metadata.selectedAudioId = "audio";
+        await write(codexUri, staleCodex);
+        const oldSourceId = staleSource.metadata.id;
+
+        await importPair(processedPair("second", changedBytes));
+        assert.ok(info.args.some(([message]) => message.includes("content has changed")), "provider must offer Update Existing after storage renames the file");
+        assert.strictEqual((await sourceFiles()).length, 1, "reuse the existing pair");
+        const updatedSource = await read(sourceUri);
+        const updatedCodex = await read(codexUri);
+        assert.strictEqual(updatedSource.metadata.id, oldSourceId);
+        assert.strictEqual(updatedCodex.cells[0].value, "<p>Translated</p>");
+        assert.deepStrictEqual(updatedCodex.cells[0].metadata.attachments, staleCodex.cells[0].metadata.attachments);
+        assert.strictEqual(updatedCodex.cells[0].metadata.selectedAudioId, "audio");
+
+        for (const [oldNotebook, updatedNotebook] of [[staleSource, updatedSource], [staleCodex, updatedCodex]]) {
+            for (const [ours, theirs] of [[oldNotebook, updatedNotebook], [updatedNotebook, oldNotebook]]) {
+                const synced = JSON.parse(await resolveCodexCustomMerge(JSON.stringify(ours), JSON.stringify(theirs)));
+                assert.strictEqual(synced.metadata.originalName, "document(1).docx");
+                assert.strictEqual(synced.metadata.originalFileName, "document(1).docx");
+                assert.strictEqual(synced.metadata.originalFileRequestedName, "document.docx");
+                assert.strictEqual(synced.metadata.originalFileHash, computeFileHash(changedBytes));
+                assert.strictEqual(synced.metadata.importContext.documentVersion, "second");
+                assert.ok(synced.metadata.importContext.lastReimport);
+                assert.deepStrictEqual(await exportTemplateBytes(synced), changedBytes);
+            }
+        }
+        assert.deepStrictEqual(await exportTemplateBytes(staleCodex), originalBytes, "old original remains available");
+        assert.ok(!JSON.stringify(updatedCodex).includes("originalFileData"));
+        // Stale registry entries are retained for safety, but must not be
+        // mistaken for a current content match after Update Existing.
+        const match = await findExistingImportPairs(workspace, computeFileHash(originalBytes), "document.docx");
+        assert.strictEqual(match?.matchedBy, "fileName");
+    });
+
+    test("Import as New Copy leaves the old pair byte-identical and links the new pair to the new original", async () => {
+        await importPair(processedPair("first", originalBytes));
+        const [oldSourceUri] = await sourceFiles();
+        const oldCodexUri = codexFor(oldSourceUri);
+        const before = await Promise.all([oldSourceUri, oldCodexUri].map(uri => vscode.workspace.fs.readFile(uri)));
+        choice = "Import as New Copy";
+        await importPair(processedPair("second", changedBytes));
+        const sources = await sourceFiles();
+        assert.strictEqual(sources.length, 2);
+        const newSourceUri = sources.find(uri => uri.path !== oldSourceUri.path)!;
+        for (const [index, uri] of [oldSourceUri, oldCodexUri].entries()) {
+            assert.deepStrictEqual(await vscode.workspace.fs.readFile(uri), before[index]);
+            assert.deepStrictEqual(await exportTemplateBytes(await read(uri)), originalBytes);
+        }
+        for (const uri of [newSourceUri, codexFor(newSourceUri)]) {
+            const notebook = await read(uri);
+            assert.strictEqual(notebook.metadata.originalFileHash, computeFileHash(changedBytes));
+            assert.deepStrictEqual(await exportTemplateBytes(notebook), changedBytes);
+        }
+        const registry = await loadOriginalFilesRegistry(workspace);
+        assert.strictEqual(Object.keys(registry.files).length, 2);
+    });
+
+    test("identical bytes under another requested name reuse the original and still match by content", async () => {
+        await importPair(processedPair("first", originalBytes));
+        await importPair(processedPair("second", originalBytes, "renamed.docx"));
+        assert.strictEqual((await sourceFiles()).length, 1);
+        const [uri] = await sourceFiles();
+        const notebook = await read(uri);
+        assert.strictEqual(notebook.metadata.originalFileName, "document.docx");
+        assert.strictEqual(notebook.metadata.originalFileRequestedName, "renamed.docx");
+        assert.strictEqual(Object.keys((await loadOriginalFilesRegistry(workspace)).files).length, 1);
+        assert.deepStrictEqual(await exportTemplateBytes(notebook), originalBytes);
+    });
+
+    test("requested filename fallback still finds a second update when the registry is missing", async () => {
+        await importPair(processedPair("first", originalBytes));
+        await importPair(processedPair("second", changedBytes));
+        await write(vscode.Uri.joinPath(workspace.uri, "metadata.json"), {});
+        const match = await findExistingImportPairs(workspace, computeFileHash(Buffer.from("third version")), "document.docx");
+        assert.strictEqual(match?.matchedBy, "fileName");
+        assert.strictEqual(match?.pairs.length, 1);
+    });
+
+    test("cancelling the reimport prompt leaves the existing notebooks untouched", async () => {
+        await importPair(processedPair("first", originalBytes));
+        const [uri] = await sourceFiles();
+        const before = await vscode.workspace.fs.readFile(uri);
+        choice = undefined;
+        await importPair(processedPair("second", changedBytes));
+        assert.strictEqual((await sourceFiles()).length, 1);
+        assert.deepStrictEqual(await vscode.workspace.fs.readFile(uri), before);
+    });
+});

--- a/src/test/suite/syncIdenticalFiles.test.ts
+++ b/src/test/suite/syncIdenticalFiles.test.ts
@@ -1,0 +1,144 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os from "os";
+import {
+    enforceConflictListInvariant, excludeUnchangedConflicts, synthesizeConflictsForPaths,
+    type ConflictSynthesisGitOps, type MergeSnapshot,
+} from "../../projectManager/utils/merge/conflictSynthesis";
+import { resolvePointerConflict } from "../../projectManager/utils/merge/pointerConflict";
+import { resolveConflictFiles } from "../../projectManager/utils/merge/resolvers";
+import { determineStrategy } from "../../projectManager/utils/merge/strategies";
+import { ConflictResolutionStrategy, type ConflictFile } from "../../projectManager/utils/merge/types";
+import { isRetriableSyncError } from "../../projectManager/utils/merge/transientSyncError";
+
+const pointer = (letter: string) => `version https://git-lfs.github.com/spec/v1\noid sha256:${letter.repeat(64)}\nsize 4096\n`;
+const snapshot: MergeSnapshot = { localHead: "local", remoteHead: "remote", baseHead: "base" };
+const audioPath = ".project/attachments/pointers/BOOK/audio.wav";
+
+suite("Sync: identical files and media pointers", () => {
+    let dir: string;
+    let blobs: Map<string, Buffer>;
+    let gitOps: ConflictSynthesisGitOps;
+
+    async function write(filepath: string, content: string | Buffer): Promise<void> {
+        const uri = vscode.Uri.file(path.join(dir, filepath));
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(uri.fsPath)));
+        await vscode.workspace.fs.writeFile(uri, Buffer.from(content));
+    }
+    function blob(ref: string, filepath: string, content: string | Buffer): void {
+        blobs.set(`${ref}:${filepath}`, Buffer.from(content));
+    }
+    function conflict(ours: string, theirs: string, base = ""): ConflictFile {
+        return { filepath: audioPath, ours, theirs, base, isNew: false, isDeleted: false };
+    }
+
+    setup(async () => {
+        dir = path.join(os.tmpdir(), `sync-identical-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+        blobs = new Map();
+        gitOps = {
+            resolveRef: async (_dir, ref) => ref,
+            readBlobAtRef: async (_dir, ref, filepath) => {
+                const bytes = blobs.get(`${ref}:${filepath}`);
+                if (!bytes) throw new Error(`Missing blob: ${ref}:${filepath}`);
+                return bytes;
+            },
+        };
+    });
+    teardown(async () => vscode.workspace.fs.delete(vscode.Uri.file(dir), { recursive: true }));
+
+    test("1,500 identical added pointers need no synthesis or retry on the first attempt", async function () {
+        this.timeout(60000);
+        const paths: string[] = [];
+        for (let i = 0; i < 1500; i++) {
+            const filepath = `.project/attachments/pointers/BOOK/audio-${i}.wav`;
+            paths.push(filepath);
+            blob("local", filepath, pointer("a"));
+            blob("remote", filepath, pointer("a"));
+            await write(filepath, pointer("a"));
+        }
+        const result = await enforceConflictListInvariant({
+            conflicts: [], changedPaths: paths, retryCount: 0, workspaceDir: dir, snapshot,
+            log: () => assert.fail("Matching files must not trigger recovery warnings"),
+        }, gitOps);
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(Buffer.from(await vscode.workspace.fs.readFile(
+            vscode.Uri.file(path.join(dir, paths[1499]))
+        )).toString(), pointer("a"));
+    });
+
+    test("real missing files remain protected among identical files", async () => {
+        blob("local", audioPath, pointer("a"));
+        blob("remote", audioPath, pointer("a"));
+        await write(audioPath, pointer("a"));
+        blob("remote", "new.txt", "remote addition");
+        const options = { conflicts: [], changedPaths: [audioPath, "new.txt"], retryCount: 0, workspaceDir: dir, snapshot };
+        await assert.rejects(enforceConflictListInvariant(options, gitOps), /1 remote-changed.*new.txt/);
+        const recovered = await enforceConflictListInvariant({ ...options, retryCount: 2, log: () => {} }, gitOps);
+        assert.deepStrictEqual(recovered.map((file) => file.filepath), ["new.txt"]);
+        assert.strictEqual(recovered[0].theirs, "remote addition");
+    });
+
+    test("working bytes alone are insufficient: unstaged content must still be resolved", async () => {
+        blob("local", audioPath, pointer("a"));
+        blob("remote", audioPath, pointer("b"));
+        blob("base", audioPath, pointer("a"));
+        await write(audioPath, pointer("b"));
+        const result = await synthesizeConflictsForPaths(dir, [audioPath], gitOps, snapshot);
+        assert.deepStrictEqual(result.unchanged, []);
+        assert.strictEqual(result.synthesized.length, 1);
+    });
+
+    test("new working edits and missing working files are never classified as unchanged", async () => {
+        blob("local", audioPath, pointer("a"));
+        blob("remote", audioPath, pointer("a"));
+        await write(audioPath, pointer("b"));
+        assert.strictEqual((await synthesizeConflictsForPaths(dir, [audioPath], gitOps, snapshot)).synthesized[0].ours, pointer("b"));
+        await vscode.workspace.fs.delete(vscode.Uri.file(path.join(dir, audioPath)));
+        const missing = await synthesizeConflictsForPaths(dir, [audioPath], gitOps, snapshot);
+        assert.strictEqual(missing.synthesized[0].isNew, true);
+    });
+
+    test("different binary bytes cannot pass equality through UTF-8 replacement characters", async () => {
+        blob("local", "binary.bin", Buffer.from([0xff]));
+        blob("remote", "binary.bin", Buffer.from([0xfe]));
+        await write("binary.bin", Buffer.from([0xff]));
+        const result = await synthesizeConflictsForPaths(dir, ["binary.bin"], gitOps, snapshot);
+        assert.deepStrictEqual(result.unchanged, []);
+        assert.deepStrictEqual(result.unsynthesizable, ["binary.bin"]);
+    });
+
+    test("matching conflicts from older Frontier versions are filtered, deletions are not", async () => {
+        blob("local", audioPath, pointer("a"));
+        blob("remote", audioPath, pointer("a"));
+        await write(audioPath, pointer("a"));
+        assert.deepStrictEqual(await excludeUnchangedConflicts([conflict(pointer("a"), pointer("a"))], dir, snapshot, gitOps), []);
+        const deletion = { ...conflict("", ""), isDeleted: true };
+        assert.deepStrictEqual(await excludeUnchangedConflicts([deletion], dir, snapshot, gitOps), [deletion]);
+    });
+
+    test("reads the analysed remote commit even if FETCH_HEAD changes", async () => {
+        blob("local", audioPath, pointer("a"));
+        blob("remote", audioPath, pointer("a"));
+        blob("FETCH_HEAD", audioPath, pointer("b"));
+        await write(audioPath, pointer("a"));
+        assert.deepStrictEqual((await synthesizeConflictsForPaths(dir, [audioPath], gitOps, snapshot)).unchanged, [audioPath]);
+    });
+
+    test("pointer strategy applies one-sided changes and preserves competing recordings", async () => {
+        assert.strictEqual(determineStrategy(audioPath), ConflictResolutionStrategy.LFS_POINTER);
+        assert.strictEqual(resolvePointerConflict(conflict(pointer("a"), pointer("b"), pointer("a"))), pointer("b"));
+        assert.strictEqual(resolvePointerConflict(conflict(pointer("b"), pointer("a"), pointer("a"))), pointer("b"));
+        assert.throws(() => resolvePointerConflict(conflict(pointer("b"), pointer("c"), pointer("a"))), /Both sides changed/);
+        await write(audioPath, pointer("a"));
+        const resolved = await resolveConflictFiles([conflict(pointer("a"), pointer("b"), pointer("a"))], dir);
+        assert.deepStrictEqual(resolved.failed, []);
+        assert.strictEqual(Buffer.from(await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(dir, audioPath)))).toString(), pointer("b"));
+    });
+
+    test("cross-extension snapshot changes trigger bounded sync retry", () => {
+        assert.strictEqual(isRetriableSyncError(new Error("Complete merge operation failed: MERGE_STATE_CHANGED: remote advanced")), true);
+    });
+
+});

--- a/src/test/suite/unit/reimportMetadata.test.ts
+++ b/src/test/suite/unit/reimportMetadata.test.ts
@@ -1,0 +1,60 @@
+import * as assert from "assert";
+import type { FileEditHistory } from "../../../../types";
+import { EditType } from "../../../../types/enums";
+import { mergeReimportedNotebookPair, type ReimportNotebook } from "../../../providers/NewSourceUploader/reimportMerge";
+import { resolveCodexCustomMerge } from "../../../projectManager/utils/merge/resolvers";
+
+const notebook = (metadata: Record<string, unknown>): ReimportNotebook => ({ cells: [], metadata });
+const edit = (field: string, value: string, timestamp: number): FileEditHistory => ({
+    editMap: ["metadata", field], value, timestamp, type: EditType.USER_EDIT, author: "translator",
+});
+
+suite("reimport metadata sync", () => {
+    test("keeps existing file edits and user settings, versions changed import metadata, and does not mutate inputs", async () => {
+        const history = [edit("fileDisplayName", "My name", 10), edit("originalName", "old.docx", Date.now() + 100000)];
+        const old = notebook({ id: "old-id", fileDisplayName: "My name", textDirection: "rtl", originalName: "old.docx", originalFileName: "old.docx", originalFileHash: "old-hash", edits: history });
+        const fresh = notebook({ id: "new-id", fileDisplayName: "Reset name", textDirection: "ltr", originalName: "new.docx", originalFileHash: "new-hash", wordCount: 2, edits: [edit("fileDisplayName", "Reset name", Date.now() + 200000)] });
+        const before = JSON.stringify([old, fresh]);
+        const { mergedCodex } = mergeReimportedNotebookPair(old, old, fresh, fresh);
+        assert.strictEqual(JSON.stringify([old, fresh]), before);
+        assert.strictEqual(mergedCodex.metadata?.id, "old-id");
+        assert.strictEqual(mergedCodex.metadata?.fileDisplayName, "My name");
+        assert.strictEqual(mergedCodex.metadata?.textDirection, "rtl");
+        const edits = mergedCodex.metadata?.edits as FileEditHistory[];
+        assert.deepStrictEqual(edits.slice(0, history.length), history);
+        assert.ok(edits.slice(history.length).every(item => item.timestamp > history[1].timestamp));
+        for (const [ours, theirs] of [[old, mergedCodex], [mergedCodex, old]]) {
+            const result = JSON.parse(await resolveCodexCustomMerge(JSON.stringify(ours), JSON.stringify(theirs)));
+            assert.strictEqual(result.metadata.originalName, "new.docx");
+            assert.strictEqual(result.metadata.originalFileName, "new.docx");
+            assert.strictEqual(result.metadata.originalFileHash, "new-hash");
+            assert.strictEqual(result.metadata.wordCount, 2);
+            assert.strictEqual(result.metadata.fileDisplayName, "My name");
+        }
+    });
+
+    test("a legacy reimport with no hash cannot carry the old hash to a different original", async () => {
+        const old = notebook({ originalName: "old.docx", originalFileHash: "old-hash", edits: [edit("originalFileHash", "old-hash", 10)] });
+        const fresh = notebook({ originalName: "new.docx" });
+        const { mergedCodex } = mergeReimportedNotebookPair(old, old, fresh, fresh);
+        const result = JSON.parse(await resolveCodexCustomMerge(JSON.stringify(old), JSON.stringify(mergedCodex)));
+        assert.strictEqual(result.metadata.originalFileName, "new.docx");
+        assert.strictEqual(result.metadata.originalFileHash, "");
+    });
+
+    test("a new hash stamps unchanged filename aliases too, preventing an older edit from splitting the reference", async () => {
+        const old = notebook({ originalName: "current.docx", originalFileName: "current.docx", originalFileHash: "old-hash", edits: [edit("originalFileName", "stale.docx", 10)] });
+        const fresh = notebook({ originalName: "current.docx", originalFileHash: "new-hash" });
+        const { mergedCodex } = mergeReimportedNotebookPair(old, old, fresh, fresh);
+        const result = JSON.parse(await resolveCodexCustomMerge(JSON.stringify(old), JSON.stringify(mergedCodex)));
+        assert.strictEqual(result.metadata.originalFileName, "current.docx");
+        assert.strictEqual(result.metadata.originalFileHash, "new-hash");
+    });
+
+    test("reimport with an unchanged original does not append redundant reference edits", () => {
+        const old = notebook({ originalName: "same.docx", originalFileName: "same.docx", originalFileHash: "hash" });
+        const { mergedCodex } = mergeReimportedNotebookPair(old, old, old, old);
+        const edits = mergedCodex.metadata?.edits as FileEditHistory[];
+        assert.deepStrictEqual(edits.map(item => item.editMap), [["metadata", "importContext"]]);
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1090,10 +1090,14 @@ export interface CustomNotebookMetadata {
     edits?: FileEditHistory[];
     importerType?: FileImporterType;
     /**
-     * The original filename of the imported artifact (if any).
-     * Example: "MAT.idml", "mydoc.docx"
+     * Stored filename of the imported original (if any), including any
+     * deduplication suffix. Example: "MAT.idml", "mydoc(1).docx".
      */
     originalFileName?: string;
+    /** SHA-256 of the stored original's bytes (not the notebook JSON). */
+    originalFileHash?: string;
+    /** Name supplied at import, before storage deduplication adds a suffix. */
+    originalFileRequestedName?: string;
     /**
      * Canonical source identifier for the imported artifact.
      * Stored at notebook-level (not per-cell). For most importers this matches originalFileName.
@@ -1170,6 +1174,8 @@ export type NotebookImportMetadataCore = Pick<
     CustomNotebookMetadata,
     | "id"
     | "originalFileName"
+    | "originalFileHash"
+    | "originalFileRequestedName"
     | "sourceFile"
     | "importerType"
     | "importContext"

--- a/webviews/codex-webviews/src/StartupFlow/types.ts
+++ b/webviews/codex-webviews/src/StartupFlow/types.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { ConflictFile } from "../../../../src/projectManager/utils/merge/types";
 import { ResolvedFile } from "../../../../src/projectManager/utils/merge/resolvers";
+import type { MergeSnapshot } from "../../../../src/projectManager/utils/merge/conflictSynthesis";
 
 // Add ImportType type
 export type ImportType = "source" | "translation" | "bible-download";
@@ -163,8 +164,9 @@ export interface FrontierAPI {
         allChangedFilePaths?: string[];
         remoteChangedFilePaths?: string[];
         uploadedLfsFiles?: string[];
+        mergeSnapshot?: MergeSnapshot;
     }>;
-    completeMerge: (resolvedFiles: ResolvedFile[], workspacePath: string | undefined) => Promise<void>;
+    completeMerge: (resolvedFiles: ResolvedFile[], workspacePath: string | undefined, snapshot?: MergeSnapshot) => Promise<void>;
     onSyncStatusChange: (
         callback: (status: { status: 'started' | 'completed' | 'error' | 'skipped', message?: string; }) => void
     ) => vscode.Disposable;


### PR DESCRIPTION
## fix: converge identical-file syncs and safely preserve merged content

## Summary

Sync could repeatedly process thousands of unchanged media pointers because it treated changes in Git history as content conflicts.

This PR skips verified identical files while still completing the history merge, so subsequent syncs can finish cleanly.

## Changes

- Compare committed, working, and remote bytes before recovering missing conflicts.
- Preserve safeguards for genuinely missing changes and unsupported binary content.
- Complete divergent histories even when no files need rewriting.
- Pass the analysed commit snapshot to Frontier and retry if history changes.
- Apply three-way pointer resolution and reject competing replacements.
- Write merged content atomically to prevent readers seeing partial files.

### Companion changes in frontier-authentication

The complete fix spans both repositories. The companion `fix-streaming-sync` branch:

- Prevents unnecessary media downloads during staging.
- Stages the resolved pointer instead of retaining the old pointer.
- Prevents empty local commits.
- Validates merge snapshots and downloaded media.
- Limits concurrent conflict reads.

Both sets of changes should ship together for the complete fix.

## Test Checklist

- [x] 97 editor tests pass.
- [x] TypeScript, webpack build, and focused lint checks pass.
- [x] Regression coverage includes 1,500 identical pointers.
- [x] Genuine missing changes, unstaged edits, binary differences, and older Frontier responses remain protected.
- [x] Pointer resolution and atomic notebook writes are covered.
- [ ] Verify with an affected production project.