### PR TITLE
Fixed the Cell Hiding

### DIFF
--- a/sharedUtils/index.ts
+++ b/sharedUtils/index.ts
@@ -186,20 +186,21 @@ export type CellForProgressCheck = {
         id?: string;
         type?: string;
         parentId?: string;
-        data?: { merged?: boolean; parentId?: string; type?: string; };
+        data?: { merged?: boolean; parentId?: string; type?: string; deleted?: boolean; hidden?: boolean; };
     };
 };
 
 /**
  * Returns true if the cell should be excluded from progress (not counted in totalCells).
- * Paratext and child cells (e.g. type "text" with parentId) must not count toward progress.
+ * Milestone, merged, deleted, hidden, paratext, empty-id, and child cells must not count.
+ * Hidden is a translation-completeness flag, not a view-mode flag — exclude regardless of Source Editing Mode.
  */
 export function shouldExcludeCellFromProgress(cell: CellForProgressCheck): boolean {
     const md = cell.metadata;
-    const cellData = md?.data as { merged?: boolean; parentId?: string; type?: string; deleted?: boolean; } | undefined;
+    const cellData = md?.data as { merged?: boolean; parentId?: string; type?: string; deleted?: boolean; hidden?: boolean; } | undefined;
     const cellId = (md?.id ?? "").toString();
 
-    if (md?.type === "milestone" || cellData?.merged || cellData?.deleted) {
+    if (md?.type === "milestone" || cellData?.merged || cellData?.deleted || cellData?.hidden) {
         return true;
     }
     const isParatext =
@@ -221,14 +222,15 @@ export function shouldExcludeCellFromProgress(cell: CellForProgressCheck): boole
 
 /**
  * Returns true if the cell should be excluded from progress when already in QuillCellContent form.
- * Use this to filter lists before computing validation stats so paratext/child never count.
+ * Use this to filter lists before computing validation stats so paratext/child/hidden never count.
  */
 export function shouldExcludeQuillCellFromProgress(cell: QuillCellContent): boolean {
     const cellId = (cell.cellMarkers?.[0] ?? "").toString();
     if (!cellId || cellId.trim() === "") {
         return true;
     }
-    if (cell.merged || cell.deleted) {
+    const dataHidden = Boolean((cell.data as { hidden?: boolean; } | undefined)?.hidden);
+    if (cell.merged || cell.deleted || cell.hidden || dataHidden) {
         return true;
     }
     const typeLower = (cell.cellType ?? "").toString().toLowerCase();

--- a/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorMessagehandling.ts
@@ -4644,7 +4644,11 @@ const messageHandlers: Record<string, (ctx: MessageHandlerContext) => Promise<vo
                 console.warn("No workspace folder found, skipping paired file visibility toggle");
             }
 
-            updateWebview();
+            // Refresh cells (hidden dropped from normal view) and progress in place.
+            // updateWebview() only sends refreshCurrentPage once the webview is ready,
+            // which does not push a new milestoneProgress payload.
+            await sendMilestoneRefreshToWebview(document, webviewPanel, provider);
+            provider.updateMilestoneProgressForDocument(document);
         } catch (error) {
             console.error("Error toggling cell visibility:", cellId, error);
             vscode.window.showErrorMessage(

--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -3963,15 +3963,8 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
 
             for (const [panelUri, panel] of this.webviewPanels.entries()) {
                 if (this.isMatchingFilePair(targetDocumentUri, panelUri)) {
-                    const docUri = panelUri;
-                    const rev = this.getDocumentRevision(docUri);
-                    const currentPosition = this.currentMilestoneSubsectionMap.get(docUri);
-                    safePostMessageToPanel(panel, {
-                        type: "refreshCurrentPage",
-                        rev,
-                        milestoneIndex: currentPosition?.milestoneIndex ?? 0,
-                        subsectionIndex: currentPosition?.subsectionIndex ?? 0,
-                    });
+                    await sendMilestoneRefreshToWebview(targetDocument, panel, this);
+                    this.updateMilestoneProgressForDocument(targetDocument);
                     break;
                 }
             }
@@ -4121,7 +4114,7 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
     /**
      * Updates milestone progress for a specific document
      */
-    private updateMilestoneProgressForDocument(document: CodexCellDocument) {
+    public updateMilestoneProgressForDocument(document: CodexCellDocument) {
         const config = vscode.workspace.getConfiguration("codex-project-manager");
         const validationCount = config.get("validationCount", 1);
         const validationCountAudio = config.get("validationCountAudio", 1);

--- a/src/providers/codexCellEditorProvider/codexDocument.ts
+++ b/src/providers/codexCellEditorProvider/codexDocument.ts
@@ -26,7 +26,7 @@ import { CodexContentSerializer } from "../../serializer";
 import { debounce } from "lodash";
 import { getSQLiteIndexManager, isDBShuttingDown } from "../../activationHelpers/contextAware/contentIndexes/indexes/sqliteIndexManager";
 import { getCellValueData, cellHasAudioUsingAttachments, computeValidationStats, computeProgressPercents, shouldExcludeCellFromProgress, shouldExcludeQuillCellFromProgress, countActiveValidations, hasTextContent } from "../../../sharedUtils";
-import { extractParentCellIdFromParatext, convertCellToQuillContent } from "./utils/cellUtils";
+import { extractParentCellIdFromParatext, convertCellToQuillContent, isNotebookCellHidden, isQuillCellHidden } from "./utils/cellUtils";
 import { FIRST_SUBDIVISION_KEY, findSubdivisionIndexForRoot, resolveSubdivisions } from "./utils/subdivisionUtils";
 import { buildMilestoneCellPayload } from "../../utils/milestoneCellUtils";
 import { formatJsonForNotebookFile, normalizeNotebookFileText } from "../../utils/notebookFileFormattingUtils";
@@ -1703,9 +1703,10 @@ export class CodexCellDocument implements vscode.CustomDocument {
 
     /**
      * Returns the ordered list of root content cell IDs within the given index
-     * range. Root content cells are non-milestone, non-paratext, non-deleted cells
-     * without a `parentId`. Pagination (both arithmetic and subdivision-based)
-     * operates over these roots; children and paratext are attached during slicing.
+     * range. Root content cells are non-milestone, non-paratext, non-deleted,
+     * non-hidden cells without a `parentId`. Pagination, subsection labels
+     * (e.g. "1-3"), and line numbering operate over these visible roots;
+     * children, paratext, and hidden cells are attached during slicing.
      */
     private getRootContentCellIdsInRange(
         startCellIndex: number,
@@ -1718,7 +1719,8 @@ export class CodexCellDocument implements vscode.CustomDocument {
             if (
                 cell.metadata?.type !== CodexCellTypes.MILESTONE &&
                 cell.metadata?.type !== CodexCellTypes.PARATEXT &&
-                cell.metadata?.data?.deleted !== true
+                cell.metadata?.data?.deleted !== true &&
+                !isNotebookCellHidden(cell)
             ) {
                 const parentId =
                     cell.metadata?.parentId ??
@@ -1838,12 +1840,13 @@ export class CodexCellDocument implements vscode.CustomDocument {
             // Process content cells (excluding milestones, paratext, and deleted)
             if (cellType !== CodexCellTypes.MILESTONE && cellType !== "paratext") {
                 const isDeleted = cell.metadata?.data?.deleted === true;
-                // Child cells (splits) are excluded from counts: pagination, subsection labels,
-                // and line numbering are all root-based (children display on their parent's page)
+                const isHidden = isNotebookCellHidden(cell);
+                // Child and hidden cells are excluded from counts: pagination, subsection
+                // labels (e.g. "1-3"), and line numbering are all visible-root-based.
                 const isChildCell =
                     cell.metadata?.parentId !== undefined ||
                     (cell.metadata?.data as { parentId?: string; } | undefined)?.parentId !== undefined;
-                if (!isDeleted && !isChildCell) {
+                if (!isDeleted && !isHidden && !isChildCell) {
                     totalContentCells++;
                 }
 
@@ -1857,8 +1860,8 @@ export class CodexCellDocument implements vscode.CustomDocument {
                         cell.metadata.data = {} as any;
                     }
                     (cell.metadata.data as any).milestoneIndex = currentMilestoneIndex;
-                    // Only count non-deleted root cells for milestone cell count
-                    if (!isDeleted && !isChildCell) {
+                    // Only count visible (non-deleted, non-hidden) root cells
+                    if (!isDeleted && !isHidden && !isChildCell) {
                         currentMilestoneCellCount++;
                     }
                 }
@@ -2315,16 +2318,20 @@ export class CodexCellDocument implements vscode.CustomDocument {
         const startCellIndex = milestone.cellIndex;
         const endCellIndex = nextMilestone ? nextMilestone.cellIndex : cells.length;
 
-        // Collect content cells for this milestone (excluding milestone, paratext, and merged cells)
+        // Collect the same visible-root-eligible cells as getRootContentCellIdsInRange.
+        // Hidden cells are omitted from page slots so "1-N" labels match the editor;
+        // they are dropped from counts via shouldExcludeQuillCellFromProgress.
         const contentCells: QuillCellContent[] = [];
         for (let i = startCellIndex; i < endCellIndex; i++) {
             const cell = cells[i];
-            if (shouldExcludeCellFromProgress(cell)) {
+            if (
+                cell.metadata?.type === CodexCellTypes.MILESTONE ||
+                cell.metadata?.type === CodexCellTypes.PARATEXT ||
+                cell.metadata?.data?.deleted === true
+            ) {
                 continue;
             }
-            // Convert to QuillCellContent format
-            const quillContent = convertCellToQuillContent(cell);
-            contentCells.push(quillContent);
+            contentCells.push(convertCellToQuillContent(cell));
         }
 
         // Use root-based subsections to match getCellsForMilestone pagination.
@@ -2332,7 +2339,9 @@ export class CodexCellDocument implements vscode.CustomDocument {
         // fall back to arithmetic chunks of `cellsPerPage`.
         const getContentCellParentId = (c: QuillCellContent) =>
             (c.metadata?.parentId as string | undefined) ?? (c.data?.parentId as string | undefined);
-        const rootContentCells = contentCells.filter((c) => !getContentCellParentId(c));
+        const rootContentCells = contentCells.filter(
+            (c) => !getContentCellParentId(c) && !isQuillCellHidden(c)
+        );
         const subdivisions = milestone.subdivisions ?? resolveSubdivisions({
             rootContentCellIds: rootContentCells.map((c) => c.cellMarkers[0]).filter(Boolean),
             placements: undefined,
@@ -2536,9 +2545,12 @@ export class CodexCellDocument implements vscode.CustomDocument {
             (cell.metadata?.parentId as string | undefined) ??
             (cell.data?.parentId as string | undefined);
 
-        // Paginate by root content cells only, so adding a child (e.g. to cell 44) does not bump
-        // the last root (e.g. cell 50) to the next page. Each page shows N roots + all their descendants.
-        const rootContentCells = contentCells.filter((c) => !getContentCellParentId(c));
+        // Paginate by visible root content cells only, so adding a child (e.g. to cell 44)
+        // does not bump the last root (e.g. cell 50) to the next page, and hidden cells
+        // do not inflate "1-N" labels. Each page shows N visible roots + descendants
+        // + hidden roots that sit in this page's document span (for Source Editing Mode).
+        const allRootContentCells = contentCells.filter((c) => !getContentCellParentId(c));
+        const rootContentCells = allRootContentCells.filter((c) => !isQuillCellHidden(c));
         // Subdivisions computed by buildMilestoneIndex drive both the legacy
         // arithmetic chunking (as "auto" subdivisions) and any user-defined custom
         // breaks. Using them here keeps slicing, counting, and webview rendering
@@ -2558,7 +2570,25 @@ export class CodexCellDocument implements vscode.CustomDocument {
         const activeSubdivision = subdivisions[validSubsectionIndex];
         const startRootIndex = activeSubdivision?.startRootIndex ?? 0;
         const endRootIndex = activeSubdivision?.endRootIndex ?? rootContentCells.length;
-        const rootsOnPage = rootContentCells.slice(startRootIndex, endRootIndex);
+        const visibleRootsOnPage = rootContentCells.slice(startRootIndex, endRootIndex);
+
+        const firstVisible = visibleRootsOnPage[0];
+        const nextPageFirstVisible = rootContentCells[endRootIndex];
+        const firstAllIdx =
+            startRootIndex === 0 || !firstVisible
+                ? 0
+                : allRootContentCells.findIndex(
+                    (c) => c.cellMarkers[0] === firstVisible.cellMarkers[0]
+                );
+        const endAllIdx = !nextPageFirstVisible
+            ? allRootContentCells.length
+            : allRootContentCells.findIndex(
+                (c) => c.cellMarkers[0] === nextPageFirstVisible.cellMarkers[0]
+            );
+        const rootsOnPage = allRootContentCells.slice(
+            firstAllIdx < 0 ? 0 : firstAllIdx,
+            endAllIdx < 0 ? allRootContentCells.length : endAllIdx
+        );
 
         // Include roots on this page and all their descendant content cells (children, grandchildren, etc.)
         const contentCellIdsForPage = new Set(
@@ -3464,6 +3494,9 @@ export class CodexCellDocument implements vscode.CustomDocument {
         // Check if this is a milestone cell and if we're modifying data that affects milestone index
         const isMilestoneCell = cellToUpdate.metadata?.type === CodexCellTypes.MILESTONE;
         const isModifyingDeletedFlag = 'deleted' in newData;
+        // Hiding a content cell changes visible root count / "1-N" labels, so
+        // the cached milestone index must rebuild even though cells.length is unchanged.
+        const isModifyingHiddenFlag = 'hidden' in newData;
         // Subdivision-related changes alter pagination, so the cached index must
         // be invalidated alongside the deleted-flag case. Name-only overrides
         // (both local and the source-mirror fallback) also flow through this
@@ -3474,7 +3507,8 @@ export class CodexCellDocument implements vscode.CustomDocument {
             'subdivisionNames' in newData ||
             'subdivisionNamesFromSource' in newData;
         const shouldInvalidateCache =
-            isMilestoneCell && (isModifyingDeletedFlag || isModifyingSubdivisions);
+            isModifyingHiddenFlag ||
+            (isMilestoneCell && (isModifyingDeletedFlag || isModifyingSubdivisions));
 
         // Ensure metadata exists
         if (!this._documentData.cells[indexOfCellToUpdate].metadata) {

--- a/src/providers/codexCellEditorProvider/utils/cellUtils.ts
+++ b/src/providers/codexCellEditorProvider/utils/cellUtils.ts
@@ -52,6 +52,16 @@ export function extractParentCellIdFromParatext(paratextCellId: string, cellMeta
     return null;
 }
 
+export function isNotebookCellHidden(cell: {
+    metadata?: { data?: { hidden?: boolean; }; };
+}): boolean {
+    return cell.metadata?.data?.hidden === true;
+}
+
+export function isQuillCellHidden(cell: Pick<QuillCellContent, "hidden" | "data">): boolean {
+    return Boolean(cell.hidden || (cell.data as { hidden?: boolean; } | undefined)?.hidden);
+}
+
 /**
  * Converts a CustomNotebookCellData cell to QuillCellContent format.
  * 

--- a/src/providers/navigationWebview/navigationWebviewProvider.ts
+++ b/src/providers/navigationWebview/navigationWebviewProvider.ts
@@ -495,7 +495,7 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
             const metadata = notebookData.metadata as CodexMetadata;
             const fileNameAbbr = path.basename(uri.fsPath, ".codex");
 
-            // Calculate progress based on cells with values (exclude paratext and child cells)
+            // Calculate progress based on cells with values (exclude paratext, child, and hidden cells)
             const unmergedCells = notebookData.cells.filter(
                 (cell) => !shouldExcludeCellFromProgress(cell)
             );
@@ -504,6 +504,8 @@ export class NavigationWebviewProvider extends BaseWebviewProvider {
                 cellMarkers: [cell.metadata?.id ?? ""],
                 cellType: cell.metadata?.type ?? cell.languageId,
                 merged: cell.metadata?.data?.merged,
+                deleted: cell.metadata?.data?.deleted,
+                hidden: cell.metadata?.data?.hidden,
                 metadata: { parentId: cell.metadata?.parentId },
                 data: cell.metadata?.data,
             });

--- a/src/test/suite/milestonePagination.test.ts
+++ b/src/test/suite/milestonePagination.test.ts
@@ -1211,6 +1211,380 @@ suite("Milestone-Based Pagination Test Suite", () => {
         );
     });
 
+    test("calculateMilestoneProgress excludes hidden cells from all counts", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible translated",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "cell-visible",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "cell-hidden-empty",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Hidden but has text",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "cell-hidden-translated",
+                    data: { hidden: true },
+                },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const progress = document.calculateMilestoneProgress(1, 1);
+
+        assert.strictEqual(
+            progress[1].percentTranslationsCompleted,
+            100,
+            "Hidden cells must not inflate the denominator — 1 of 1 visible cells translated"
+        );
+        assert.strictEqual(
+            progress[1].percentTextValidatedTranslations,
+            0,
+            "Hidden cells must not contribute validation counts"
+        );
+    });
+
+    test("calculateMilestoneProgress reports 0% when every cell is hidden", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Hidden 1",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "cell-hidden-1",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Hidden 2",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "cell-hidden-2",
+                    data: { hidden: true },
+                },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const progress = document.calculateMilestoneProgress(1, 1);
+
+        assert.strictEqual(progress[1].percentTranslationsCompleted, 0);
+        assert.strictEqual(progress[1].percentAudioTranslationsCompleted, 0);
+        assert.strictEqual(progress[1].percentFullyValidatedTranslations, 0);
+        assert.strictEqual(progress[1].percentAudioValidatedTranslations, 0);
+        assert.strictEqual(progress[1].percentTextValidatedTranslations, 0);
+        for (const value of Object.values(progress[1])) {
+            assert.ok(Number.isFinite(value), "All-hidden milestone must not produce NaN");
+        }
+    });
+
+    test("buildMilestoneIndex excludes hidden cells from cellCount so navigation labels match visible cells", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Genesis 23-25",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Cell 1",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-1" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Cell 2",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-2" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Cell 3 hidden",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-3",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Cell 4",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-4" },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const milestoneIndex = document.buildMilestoneIndex(50);
+
+        assert.strictEqual(
+            milestoneIndex.milestones[0].cellCount,
+            3,
+            "cellCount should be 3 so the accordion label is 1-3, not 1-4"
+        );
+        assert.strictEqual(
+            milestoneIndex.milestones[0].subdivisions?.[0]?.endRootIndex,
+            3,
+            "Single subsection should span the 3 visible roots"
+        );
+    });
+
+    test("hiding a cell invalidates the milestone index cache and shrinks cellCount", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "A",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-1" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "B",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-2" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "C",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-3" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "D",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-4" },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        assert.strictEqual(document.buildMilestoneIndex(50).milestones[0].cellCount, 4);
+
+        document.updateCellData("root-2", { hidden: true });
+
+        assert.strictEqual(
+            document.buildMilestoneIndex(50).milestones[0].cellCount,
+            3,
+            "Hiding a cell must rebuild the cached index so navigation updates without reload"
+        );
+    });
+
+    test("getCellsForMilestone still includes hidden cells for Source Editing Mode", async () => {
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible A",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-1" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Hidden",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-2",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible B",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-3" },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const page = document.getCellsForMilestone(0, 0, 50);
+        const ids = page.map((c) => c.cellMarkers[0]);
+
+        assert.ok(ids.includes("root-1"));
+        assert.ok(ids.includes("root-2"), "Hidden cells must still be on the page for Source Editing Mode");
+        assert.ok(ids.includes("root-3"));
+    });
+
+    test("calculateSubsectionProgress uses visible roots only so a hidden neighbor does not create a phantom page", async () => {
+        const cellsPerPage = 2;
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible A",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-1" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible B",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-2" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-3",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-4",
+                    data: { hidden: true },
+                },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const subsectionProgress = document.calculateSubsectionProgress(0, cellsPerPage, 1, 1);
+
+        assert.strictEqual(
+            Object.keys(subsectionProgress).length,
+            1,
+            "Two visible roots with cellsPerPage=2 is a single page"
+        );
+        assert.strictEqual(
+            subsectionProgress[0].percentTranslationsCompleted,
+            100,
+            "Both visible cells are translated; hidden cells are not a second page"
+        );
+    });
+
+    test("calculateSubsectionProgress counts only visible cells on a mixed page", async () => {
+        const cellsPerPage = 2;
+        const cells = [
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "1",
+                metadata: {
+                    type: CodexCellTypes.MILESTONE,
+                    id: "milestone-1",
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "Visible translated",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-1" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-2",
+                    data: { hidden: true },
+                },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: { type: CodexCellTypes.TEXT, id: "root-3" },
+            },
+            {
+                kind: 2,
+                languageId: "scripture",
+                value: "",
+                metadata: {
+                    type: CodexCellTypes.TEXT,
+                    id: "root-4",
+                    data: { hidden: true },
+                },
+            },
+        ];
+
+        const document = await createDocumentWithCells(cells);
+        const subsectionProgress = document.calculateSubsectionProgress(0, cellsPerPage, 1, 1);
+
+        assert.strictEqual(
+            Object.keys(subsectionProgress).length,
+            1,
+            "Two visible roots fit on one page"
+        );
+        assert.strictEqual(
+            subsectionProgress[0].percentTranslationsCompleted,
+            50,
+            "1 of 2 visible cells translated; hidden cells excluded from the denominator"
+        );
+    });
+
     test("getCellsForMilestone handles subsection index bounds correctly", async () => {
         const cellsPerPage = 5;
         const cells = [

--- a/src/test/suite/progressExclusion.test.ts
+++ b/src/test/suite/progressExclusion.test.ts
@@ -1,0 +1,135 @@
+import * as assert from "assert";
+import {
+    shouldExcludeCellFromProgress,
+    shouldExcludeQuillCellFromProgress,
+    computeProgressPercents,
+} from "../../../sharedUtils";
+import { CodexCellTypes } from "../../../types/enums";
+import type { QuillCellContent } from "../../../types";
+
+const makeNotebookCell = (overrides: {
+    id?: string;
+    type?: string;
+    parentId?: string;
+    merged?: boolean;
+    deleted?: boolean;
+    hidden?: boolean;
+    dataType?: string;
+} = {}) => ({
+    metadata: {
+        id: overrides.id ?? "GEN 1:1",
+        type: overrides.type ?? "text",
+        parentId: overrides.parentId,
+        data: {
+            merged: overrides.merged,
+            deleted: overrides.deleted,
+            hidden: overrides.hidden,
+            type: overrides.dataType,
+            parentId: overrides.parentId,
+        },
+    },
+});
+
+const makeQuillCell = (overrides: {
+    id?: string;
+    cellType?: CodexCellTypes;
+    merged?: boolean;
+    deleted?: boolean;
+    hidden?: boolean;
+    dataHidden?: boolean;
+    parentId?: string;
+    dataParentId?: string;
+} = {}): QuillCellContent => ({
+    cellMarkers: [overrides.id ?? "GEN 1:1"],
+    cellContent: "text",
+    cellType: overrides.cellType ?? CodexCellTypes.TEXT,
+    editHistory: [],
+    merged: overrides.merged,
+    deleted: overrides.deleted,
+    hidden: overrides.hidden,
+    data: {
+        hidden: overrides.dataHidden,
+        parentId: overrides.dataParentId,
+    },
+    metadata: {
+        parentId: overrides.parentId,
+    },
+});
+
+suite("Progress exclusion helpers", () => {
+    test("shouldExcludeCellFromProgress skips milestone, merged, deleted, hidden, paratext, empty-id, and child cells", () => {
+        assert.strictEqual(shouldExcludeCellFromProgress(makeNotebookCell()), false);
+        assert.strictEqual(
+            shouldExcludeCellFromProgress(makeNotebookCell({ type: "milestone" })),
+            true
+        );
+        assert.strictEqual(shouldExcludeCellFromProgress(makeNotebookCell({ merged: true })), true);
+        assert.strictEqual(shouldExcludeCellFromProgress(makeNotebookCell({ deleted: true })), true);
+        assert.strictEqual(shouldExcludeCellFromProgress(makeNotebookCell({ hidden: true })), true);
+        assert.strictEqual(
+            shouldExcludeCellFromProgress(makeNotebookCell({ type: "paratext" })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeCellFromProgress(makeNotebookCell({ id: "GEN 1:1:paratext-1" })),
+            true
+        );
+        assert.strictEqual(shouldExcludeCellFromProgress(makeNotebookCell({ id: "" })), true);
+        assert.strictEqual(
+            shouldExcludeCellFromProgress(makeNotebookCell({ parentId: "GEN 1:1" })),
+            true
+        );
+    });
+
+    test("shouldExcludeQuillCellFromProgress treats top-level and data.hidden as excluded", () => {
+        assert.strictEqual(shouldExcludeQuillCellFromProgress(makeQuillCell()), false);
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ hidden: true })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ dataHidden: true })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ merged: true })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ deleted: true })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(
+                makeQuillCell({ cellType: CodexCellTypes.MILESTONE, id: "milestone-1" })
+            ),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(
+                makeQuillCell({ cellType: CodexCellTypes.PARATEXT, id: "GEN 1:1:paratext-1" })
+            ),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ id: "" })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ parentId: "GEN 1:1" })),
+            true
+        );
+        assert.strictEqual(
+            shouldExcludeQuillCellFromProgress(makeQuillCell({ dataParentId: "GEN 1:1" })),
+            true
+        );
+    });
+
+    test("computeProgressPercents returns 0 (not NaN) when totalCells is 0", () => {
+        const percents = computeProgressPercents(0, 0, 0, 0, 0, 0);
+        for (const value of Object.values(percents)) {
+            assert.strictEqual(value, 0);
+            assert.ok(Number.isFinite(value));
+        }
+    });
+});

--- a/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
+++ b/webviews/codex-webviews/src/CodexCellEditor/CodexCellEditor.tsx
@@ -2499,7 +2499,7 @@ const CodexCellEditor: React.FC = () => {
                 if (cell.cellType === CodexCellTypes.MILESTONE) {
                     return false;
                 }
-                if (!cellId || cellId.includes(":paratext-") || cell.merged) {
+                if (!cellId || cellId.includes(":paratext-") || cell.merged || cell.hidden) {
                     return false;
                 }
                 // Exclude child cells (e.g. type "text" with parentId - they don't count toward progress)


### PR DESCRIPTION
## PR Title
1159-bug-hidden-cells-are-still-counted-in-file-and-chapter-navigation-progress

## Summary
Closes #1159 

Fixed the Cell Hiding
After exiting the source editing mode, the navigation and everything will automatically update according to the changes made. Milestones will display correct number of cells e.g. "1-4". The file translation progress will also percentually update.
When all the cells are hidden in a section, it will display "0" cells and 0% progress.

## Test Checklist
- [x] try hiding cells
- [x] the progress should change if you hide enough cells
- [x] the milestone cell count should change (e.g. from 1-4 to 1-3 if you hide one cell)
- [ ] 

## Screenshots
Only if necessary for clarity
<img width="1522" height="620" alt="image" src="https://github.com/user-attachments/assets/a5213783-f2eb-4e94-a2c1-bfa648077586" />
