### PR TITLE
feat: add to-issues and to-pr Claude Code skills

### DIFF
--- a/.claude/skills/to-issues/SKILL.md
+++ b/.claude/skills/to-issues/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: to-issues
+description: Write a GitHub issue in chat, ready to copy, using this repo's issue templates (Task, Feature Request, or Bug Report). Use this whenever the user asks for a ticket, issue, task, bug report, or feature request to be written up — including when they paste a partner report, error description, or idea and want it turned into an issue, or say things like "make a ticket for this", "write this up as an issue", or "turn this into a bug report".
+---
+
+# Writing an issue from the repo templates
+
+The goal: produce a complete issue the user can paste straight into GitHub. Write it **in the chat**, not as a file, and do not create the issue on GitHub unless the user explicitly asks.
+
+## Step 1: Pick the right template
+
+The templates live in `.github/ISSUE_TEMPLATE/`. Pick one and read it before writing, so the output always matches the current version of the template:
+
+- **`bug-report.md`** — something is broken, wrong, or slower than it used to be. If a user or partner is reporting a problem with existing behavior, it's a bug.
+- **`feature-request.md`** — a new capability or an improvement to how something works.
+- **`task.md`** — everything else: investigations, chores, upgrades, data fixes, refactors. When a problem is reported but the cause is unknown and the first job is to investigate, a Task is often a better fit than a Bug — use your judgment, but ask if unsure.
+
+If the request genuinely spans two templates, always ask; mention the choice in one sentence outside the copyable block.
+
+## Step 2: Fill it in
+
+- Keep every heading from the template, in order. Fill each section; if there is truly nothing to say for a section, write a short honest line (e.g. "None needed") rather than deleting the heading. When a template demands something you don't have — exact steps to reproduce, timings — write what the reporter actually described, prefixed with an honest caveat like "exact steps not confirmed yet", instead of inventing details or leaving the section empty.
+- Start with a title line using the prefix from the template's frontmatter (`Task: `, `Bug: `, `Feature: `) followed by a short description.
+- Only include facts you actually have. Don't invent steps to reproduce, version numbers, or causes. If the cause is unknown, make "find the cause" part of the work, and phrase suspicions as things to rule in or out, not conclusions.
+- Acceptance Criteria are observable outcomes ("the page loads in under 2 seconds"), not implementation steps. Test Checklist items are things a person can actually go and verify, ideally matching one-to-one with how the reporter would confirm the problem is gone.
+- If the report came from a specific person or partner, include confirming with them as a checklist item.
+
+## Step 3: Write in simple English
+
+These issues are read by translators, partners, and non-developers, not just the team. So:
+
+- Use short sentences and everyday words. "The editor takes a long time to open" beats "editor initialization latency has regressed".
+- Avoid jargon and internal shorthand. If a technical or internal term is unavoidable (a feature name, a file type), add a few words of plain-English explanation the first time it appears, e.g. "Sparkle (the AI translation suggestions)".
+- Write for a reader who was not in this conversation: no "as discussed above", no unexplained codenames, no abbreviations the reader may not know.
+
+## Step 4: Output
+
+Put the finished issue in one fenced markdown code block so it can be copied in a single click, with the title as the first line. Any commentary (template choice, things you left out, open questions) goes in a sentence or two outside the block.

--- a/.claude/skills/to-pr/SKILL.md
+++ b/.claude/skills/to-pr/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: to-pr
+description: Write a pull request title and description in chat, ready to copy, using this repo's PR template. Use this whenever the user asks for a PR description, PR summary, or pull request write-up for their branch or changes — including "write the PR for this", "make a PR description", or "get this ready for a PR". If the user asks to actually open the PR on GitHub, still use this skill to write the body first.
+---
+
+# Writing a PR description from the repo template
+
+The goal: produce a complete PR title and description the user can paste into GitHub. Write it **in the chat**, not as a file, and do not open the PR with `gh` unless the user explicitly asks.
+
+## Step 1: Read the template and the actual changes
+
+- Read `.github/pull-request-template.md` so the output always matches the current version of the template.
+- Describe what actually changed, not what was intended. Look at the real diff first: `git log` and `git diff` against `main` for the current branch (or whatever branch/changes the user points at). Every claim in the Summary and Changes sections should be backed by something in the diff.
+
+## Step 2: Title and linked issue
+
+The title is the issue number, a dash, then the issue's full title, e.g. `1147-Task: Pin pnpm version in CI and add build-script approvals (pnpm 12 breaks installs)`. Branch names in this repo usually start with the issue number, so check the branch name first; commit messages often carry it too. If you can't find an issue number in the branch name, commits, or conversation, ask the user for it rather than guessing — the Summary's `Closes #...` line depends on it.
+
+Fetch the issue to get its exact title and its Acceptance Criteria: use `gh issue view <number>` if `gh` is available, otherwise the public API (`curl https://api.github.com/repos/genesis-ai-dev/codex-editor/issues/<number>`). If the issue can't be fetched, ask the user to paste it.
+
+## Step 3: Fill in the template
+
+- The template's `## PR Title` section is instructions for the title, not a heading to reproduce — GitHub keeps the title in its own field. Put the bare title on the first line of your output, then keep every remaining heading from the template (Summary, Changes, Test Checklist, Screenshots), in order.
+- **Summary**: the `Closes #[number]` line, then a short plain-English description of what the change does and why.
+- **Changes**: a list that mirrors the linked issue's Acceptance Criteria where possible. Each entry describes a change a reviewer can find in the diff. When the implementation deliberately deviates from an acceptance criterion, describe what actually changed and call out the deviation and its reason as its own entry — reviewers should learn about it from the PR, not discover it in the diff.
+- **Test Checklist**: the template asks Claude to do the checklist itself before submitting. Take that seriously: only check `[x]` items you have actually verified (ran the build, ran the tests, exercised the feature). Leave anything unverified as `[ ]` and say plainly, outside the block, what still needs a human to check. Group with sub-headers when there are several areas, as the template shows.
+- **Screenshots**: keep the section, but only note a screenshot is needed when the change is visual; otherwise write "Not needed".
+
+## Step 4: Write in simple English
+
+PRs here are read by reviewers with different backgrounds, so:
+
+- Short sentences, everyday words. "Makes the editor open faster by loading the dictionary in the background" beats "defers dictionary hydration off the critical path".
+- Avoid jargon and internal shorthand. When a technical term is unavoidable, add a few words of plain-English explanation the first time it appears.
+- Write for a reviewer who hasn't read this conversation: no unexplained codenames or abbreviations.
+
+## Step 5: Output
+
+Put the finished PR description in one fenced markdown code block so it can be copied in a single click, with the title as the first line. Any commentary (unverified checklist items, missing issue number, open questions) goes in a sentence or two outside the block.

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ webviews/codex-webviews/vite.config.ts.timestamp-*.mjs
 # .project/ files should not be created here — if they exist, it's a bug that must be fixed (see PR #714)
 # .project/
 
-# AI coding agents
-.claude/
+# AI coding agents (local state ignored; shared skills are tracked)
+.claude/*
+!.claude/skills/
 
 # Glance memory shards
 .glance/


### PR DESCRIPTION
## Summary
Adds two Claude Code project skills that anyone working in this repo can use:

- `/to-issues` — writes a GitHub issue in chat, ready to copy, using our issue templates (Task, Feature Request, or Bug Report). It picks the right template for what's being described, keeps every heading, and never invents facts — unknown causes become things to investigate.
- `/to-pr` — writes a PR title and description in chat, ready to copy, using our PR template. It reads the actual diff before writing, links the issue, and only ticks Test Checklist boxes for things that were actually verified.

Both skills write in simple English and explain any unavoidable technical term in plain words, so issues and PRs stay readable for translators and partners, not just developers.

## Changes
- Add `.claude/skills/to-issues/SKILL.md`
- Add `.claude/skills/to-pr/SKILL.md`
- Update `.gitignore` so `.claude/skills/` is tracked while local Claude state (settings, worktrees) stays ignored

## Test Checklist

### Skills
- [x] Ran `/to-issues` on a real partner report in a fresh session — it chose the Bug Report template, kept all headings, and produced one copyable block with a plain-English explanation of "Sparkle"
- [x] Ran `/to-pr` against the real change from #1147 in a fresh session — it found the issue number from the commit, mirrored the issue's acceptance criteria, and left unverified checklist items unchecked
- [x] Confirmed both skills appear in Claude Code's skill list for this project

### Gitignore
- [x] Confirmed `.claude/settings.local.json` and `.claude/worktrees/` are still ignored after the change
- [x] Pre-push hook ran the full extension test suite (compile, lint, VS Code tests) and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)