### PR TITLE
fix: generate structured IDML translations in one request

### DIFF
--- a/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
+++ b/src/providers/codexCellEditorProvider/codexCellEditorProvider.ts
@@ -4401,7 +4401,11 @@ export class CodexCellEditorProvider implements vscode.CustomEditorProvider<Code
                         completionConfig,
                         cancellationToken,
                         true, // returnHTML
-                        isBatchOperation
+                        isBatchOperation,
+                        {
+                            enforceHtmlStructure:
+                                currentDocument.getNotebookMetadata().enforceHtmlStructure === true,
+                        },
                     );
 
                     // Check for cancellation before updating document - this is crucial to prevent cell population

--- a/src/providers/translationSuggestions/idmlStructuredTranslation.ts
+++ b/src/providers/translationSuggestions/idmlStructuredTranslation.ts
@@ -1,0 +1,255 @@
+import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
+
+export type IdmlSegmentSeparator = "none" | "continuation" | "line-break";
+
+export interface IdmlTranslationSegment {
+    index: number;
+    sourceText: string;
+    characterStyle?: string;
+    separatorBefore: IdmlSegmentSeparator;
+}
+
+interface LocatedIdmlTranslationSegment extends IdmlTranslationSegment {
+    contentStart: number;
+    contentEnd: number;
+}
+
+export interface IdmlStructuredSource {
+    sourceHtml: string;
+    segments: LocatedIdmlTranslationSegment[];
+}
+
+export type StructuredResponseFormat = NonNullable<
+    ChatCompletionCreateParamsNonStreaming["response_format"]
+>;
+
+interface StructuredTranslationItem {
+    index: number;
+    translation: string;
+}
+
+const readAttribute = (tag: string, name: string): string | undefined => {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = tag.match(
+        new RegExp(`\\b${escapedName}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\u0060]+))`, "i"),
+    );
+    return match?.[1] ?? match?.[2] ?? match?.[3];
+};
+
+const decodeHtmlText = (text: string): string =>
+    text
+        .replace(/&#x([0-9a-f]+);/gi, (entity, value: string) => {
+            const codePoint = Number.parseInt(value, 16);
+            try {
+                return Number.isInteger(codePoint) && codePoint <= 0x10ffff
+                    ? String.fromCodePoint(codePoint)
+                    : entity;
+            } catch {
+                return entity;
+            }
+        })
+        .replace(/&#(\d+);/g, (entity, value: string) => {
+            const codePoint = Number.parseInt(value, 10);
+            try {
+                return Number.isInteger(codePoint) && codePoint <= 0x10ffff
+                    ? String.fromCodePoint(codePoint)
+                    : entity;
+            } catch {
+                return entity;
+            }
+        })
+        .replace(/&nbsp;/gi, "\u00a0")
+        .replace(/&amp;/gi, "&")
+        .replace(/&lt;/gi, "<")
+        .replace(/&gt;/gi, ">")
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;|&apos;/gi, "'");
+
+const escapeHtmlText = (text: string): string =>
+    text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+
+const containsHtmlTag = (value: string): boolean => /<\/?[a-zA-Z][^>]*>|<!--|<!DOCTYPE/i.test(value);
+
+const separatorBetween = (html: string): IdmlSegmentSeparator => {
+    if (/<br\b[^>]*\bclass\s*=\s*(?:"[^"]*\bidml-eoc\b[^"]*"|'[^']*\bidml-eoc\b[^']*')[^>]*\/?>/i.test(html)) {
+        return "line-break";
+    }
+    return "continuation";
+};
+
+/**
+ * Extract the editable IDML text slots while retaining byte ranges into the
+ * original HTML. Returning null deliberately opts callers back into the legacy
+ * completion path when the fragment is malformed or contains unsupported
+ * nested markup.
+ */
+export const extractIdmlStructuredSource = (sourceHtml: string): IdmlStructuredSource | null => {
+    if (!sourceHtml || !sourceHtml.includes("idml-segment")) return null;
+
+    const tagRegex = /<\/?span\b[^>]*>/gi;
+    const stack: Array<{ openingTag: string; contentStart: number; isIdmlSegment: boolean; }> = [];
+    const located: LocatedIdmlTranslationSegment[] = [];
+    const seenIndexes = new Set<number>();
+    let idmlOpeningCount = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = tagRegex.exec(sourceHtml)) !== null) {
+        const tag = match[0];
+        const isClosing = /^<\s*\/span/i.test(tag);
+        const isSelfClosing = /\/\s*>$/.test(tag);
+
+        if (!isClosing) {
+            const className = readAttribute(tag, "class") ?? "";
+            const isIdmlSegment = className.split(/\s+/).includes("idml-segment");
+            if (isIdmlSegment) idmlOpeningCount++;
+            if (!isSelfClosing) {
+                stack.push({
+                    openingTag: tag,
+                    contentStart: tagRegex.lastIndex,
+                    isIdmlSegment,
+                });
+            } else if (isIdmlSegment) {
+                return null;
+            }
+            continue;
+        }
+
+        const opening = stack.pop();
+        if (!opening) return null;
+        if (!opening.isIdmlSegment) continue;
+
+        const indexText = readAttribute(opening.openingTag, "data-segment-index");
+        const index = indexText === undefined ? Number.NaN : Number(indexText);
+        const innerHtml = sourceHtml.slice(opening.contentStart, match.index);
+        if (!Number.isSafeInteger(index) || index < 0 || seenIndexes.has(index) || containsHtmlTag(innerHtml)) {
+            return null;
+        }
+
+        seenIndexes.add(index);
+        located.push({
+            index,
+            sourceText: decodeHtmlText(innerHtml),
+            characterStyle: readAttribute(opening.openingTag, "data-character-style"),
+            separatorBefore: "none",
+            contentStart: opening.contentStart,
+            contentEnd: match.index,
+        });
+    }
+
+    if (stack.length > 0 || located.length === 0 || located.length !== idmlOpeningCount) return null;
+
+    located.sort((left, right) => left.contentStart - right.contentStart);
+    for (let i = 1; i < located.length; i++) {
+        located[i].separatorBefore = separatorBetween(
+            sourceHtml.slice(located[i - 1].contentEnd, located[i].contentStart),
+        );
+    }
+
+    return { sourceHtml, segments: located };
+};
+
+export const buildIdmlStructuredResponseFormat = (
+    source: IdmlStructuredSource,
+): StructuredResponseFormat => ({
+    type: "json_schema",
+    json_schema: {
+        name: "idml_segment_translation",
+        description: "A translation for every indexed IDML text segment.",
+        strict: true,
+        schema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                segments: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        additionalProperties: false,
+                        properties: {
+                            index: {
+                                type: "integer",
+                                enum: source.segments.map((segment) => segment.index),
+                            },
+                            translation: { type: "string" },
+                        },
+                        required: ["index", "translation"],
+                    },
+                },
+            },
+            required: ["segments"],
+        },
+    },
+});
+
+const parseStructuredResponse = (content: string): unknown => {
+    const trimmed = content.trim();
+    const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/i);
+    return JSON.parse(fenced?.[1]?.trim() ?? trimmed);
+};
+
+const validateTranslations = (
+    value: unknown,
+    source: IdmlStructuredSource,
+): Map<number, string> => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("Structured translation response is not an object.");
+    }
+
+    const response = value as { segments?: unknown; };
+    if (!Array.isArray(response.segments) || response.segments.length !== source.segments.length) {
+        throw new Error("Structured translation response has the wrong segment count.");
+    }
+
+    const requiredIndexes = new Set(source.segments.map((segment) => segment.index));
+    const translations = new Map<number, string>();
+    for (const item of response.segments) {
+        if (!item || typeof item !== "object" || Array.isArray(item)) {
+            throw new Error("Structured translation response contains an invalid segment.");
+        }
+        const { index, translation } = item as Partial<StructuredTranslationItem>;
+        if (!Number.isSafeInteger(index) || !requiredIndexes.has(index!) || typeof translation !== "string") {
+            throw new Error("Structured translation response contains an unknown index or invalid text.");
+        }
+        if (translations.has(index!)) {
+            throw new Error(`Structured translation response repeats segment ${index}.`);
+        }
+        translations.set(index!, translation);
+    }
+
+    if ([...requiredIndexes].some((index) => !translations.has(index))) {
+        throw new Error("Structured translation response is missing a required segment.");
+    }
+    const sourceHasText = source.segments.some((segment) => segment.sourceText.trim().length > 0);
+    const translationHasText = [...translations.values()].some((translation) => translation.trim().length > 0);
+    if (sourceHasText && !translationHasText) {
+        throw new Error("Structured translation response is empty.");
+    }
+
+    return translations;
+};
+
+/** Rebuild translated HTML by replacing text nodes only; all source markup remains byte-for-byte intact. */
+export const reconstructIdmlTranslationHtml = (
+    source: IdmlStructuredSource,
+    responseContent: string,
+): string => {
+    const translations = validateTranslations(parseStructuredResponse(responseContent), source);
+    let result = source.sourceHtml;
+
+    for (const segment of [...source.segments].sort((left, right) => right.contentStart - left.contentStart)) {
+        const translatedText = translations.get(segment.index);
+        if (translatedText === undefined) {
+            throw new Error(`Structured translation response is missing segment ${segment.index}.`);
+        }
+        result =
+            result.slice(0, segment.contentStart) +
+            escapeHtmlText(translatedText) +
+            result.slice(segment.contentEnd);
+    }
+
+    return result;
+};

--- a/src/providers/translationSuggestions/llmCompletion.ts
+++ b/src/providers/translationSuggestions/llmCompletion.ts
@@ -8,6 +8,11 @@ import { getAutoCompleteStatusBarItem } from "../../extension";
 import { tokenizeText } from "../../utils/nlpUtils";
 import { buildFewShotExamplesText, buildMessages, fetchFewShotExamples, getPrecedingTranslationPairs, parseFinalAnswer } from "./shared";
 import { abTestingRegistry } from "../../utils/abTestingRegistry";
+import {
+    buildIdmlStructuredResponseFormat,
+    extractIdmlStructuredSource,
+    reconstructIdmlTranslationHtml,
+} from "./idmlStructuredTranslation";
 
 // Helper function to build A/B test context object
 function buildABTestContext(
@@ -96,13 +101,18 @@ export interface LLMCompletionResult {
     generationId?: string;
 }
 
+export interface LLMCompletionOptions {
+    enforceHtmlStructure?: boolean;
+}
+
 export async function llmCompletion(
     currentNotebookReader: CodexNotebookReader, // FIXME: if we just read the file as CodexNotebookAsJSONData (or whatever it's called), we can speed this up a lot because the notebook deserializer is really slow
     currentCellId: string,
     completionConfig: CompletionConfig,
     token: vscode.CancellationToken,
     returnHTML: boolean = true,
-    isBatchOperation: boolean = false
+    isBatchOperation: boolean = false,
+    options: LLMCompletionOptions = {},
 ): Promise<LLMCompletionResult> {
     const { contextSize, numberOfFewShotExamples, debugMode, chatSystemMessage, fewShotExampleFormat } = completionConfig;
 
@@ -138,6 +148,29 @@ export async function llmCompletion(
             console.error(`[llmCompletion] No source content found for any of the cell IDs: ${currentCellIds.join(", ")}`);
             throw new Error(`No source content found for cell ${currentCellId}. The search index may be incomplete. Try running "Force Complete Rebuild" from the command palette.`);
         }
+
+        // Multi-segment IDML cells cannot usually be repaired from a single
+        // plain-text completion without a second LLM request. For enforced
+        // notebooks, translate the indexed text slots in one structured call
+        // and rebuild the exact source HTML locally. Keep all other source
+        // formats, merged/range cells, and single-segment cells on the existing
+        // path to minimize behavior changes.
+        const structuredSourceCandidate =
+            options.enforceHtmlStructure === true &&
+            returnHTML &&
+            currentCellIds.length === 1 &&
+            validSourceCells.length === 1
+                ? extractIdmlStructuredSource(
+                    validSourceCells[0]!.rawContent || validSourceCells[0]!.content || "",
+                )
+                : null;
+        const structuredSource =
+            structuredSourceCandidate && structuredSourceCandidate.segments.length > 1
+                ? structuredSourceCandidate
+                : null;
+        const promptAllowsHtml = structuredSource
+            ? false
+            : Boolean(completionConfig.allowHtmlPredictions);
 
         // Sanitize HTML content to extract plain text (handles transcription spans, etc.)
         const sanitizeHtmlContent = (html: string): string => {
@@ -196,7 +229,7 @@ export async function llmCompletion(
             currentCellId,
             currentCellIndex,
             contextSize,
-            Boolean(completionConfig.allowHtmlPredictions)
+            promptAllowsHtml
         );
 
         // Get the source and target languages
@@ -211,7 +244,7 @@ export async function llmCompletion(
             // Generate few-shot examples
             const fewShotExamples = buildFewShotExamplesText(
                 finalExamples, 
-                Boolean(completionConfig.allowHtmlPredictions), 
+                promptAllowsHtml,
                 fewShotExampleFormat || "source-and-target"
             );
             console.log(`[llmCompletion] Built few-shot examples text (${fewShotExamples.length} chars, format: ${fewShotExampleFormat}):`, fewShotExamples.substring(0, 200) + '...');
@@ -225,16 +258,19 @@ export async function llmCompletion(
                 fewShotExamples,
                 precedingTranslationPairs,
                 currentCellSourceContent,
-                Boolean(completionConfig.allowHtmlPredictions),
+                promptAllowsHtml,
                 fewShotExampleFormat || "source-and-target",
-                sourceLanguage
+                sourceLanguage,
+                structuredSource?.segments ?? null,
             );
 
             // Unified AB testing via registry with random test selection (global gating)
             // A/B testing is disabled during batch operations (chapter autocomplete, batch transcription)
             // to avoid interrupting the user with variant selection UI
             const extConfig = vscode.workspace.getConfiguration("codex-editor-extension");
-            const abEnabled = Boolean(extConfig.get("abTestingEnabled") ?? true) && !isBatchOperation;
+            const abEnabled = Boolean(extConfig.get("abTestingEnabled") ?? true) &&
+                !isBatchOperation &&
+                !structuredSource;
             const abProbabilityRaw = extConfig.get<number>("abTestingProbability");
             const abProbability = Math.max(0, Math.min(1, typeof abProbabilityRaw === "number" ? abProbabilityRaw : 0.01));
             const randomValue = Math.random();
@@ -298,8 +334,66 @@ export async function llmCompletion(
                 }
             }
 
-            // A/B testing not triggered (or failed): call LLM once, return two identical variants
-            const llmResult = await callLLM(messages, completionConfig, token);
+            if (structuredSource) {
+                try {
+                    const structuredResult = await callLLM(messages, completionConfig, token, {
+                        responseFormat: buildIdmlStructuredResponseFormat(structuredSource),
+                    });
+                    const reconstructedHtml = reconstructIdmlTranslationHtml(
+                        structuredSource,
+                        structuredResult.content,
+                    );
+                    const variants = [reconstructedHtml, reconstructedHtml];
+
+                    if (debugMode) {
+                        logDebugMessages(messages, structuredResult.content, variants);
+                    }
+
+                    return {
+                        variants,
+                        isABTest: false,
+                        generationId: structuredResult.generationId,
+                    };
+                } catch (error) {
+                    if (error instanceof vscode.CancellationError ||
+                        (error instanceof Error && (error.message.includes("Canceled") || error.name === "AbortError"))) {
+                        throw error;
+                    }
+                    // Compatibility fallback for providers that do not support
+                    // JSON schema responses, or for a malformed model response.
+                    // The existing generation + resolver path remains intact.
+                    console.warn(
+                        "[llmCompletion] Structured IDML translation failed; falling back to legacy completion",
+                        error,
+                    );
+                }
+            }
+
+            // A/B testing not triggered (or failed), or structured output was
+            // unavailable: call the established completion path.
+            const fallbackMessages = structuredSource
+                ? buildMessages(
+                    targetLanguage,
+                    chatSystemMessage,
+                    buildFewShotExamplesText(
+                        finalExamples,
+                        Boolean(completionConfig.allowHtmlPredictions),
+                        fewShotExampleFormat || "source-and-target",
+                    ),
+                    await getPrecedingTranslationPairs(
+                        currentNotebookReader,
+                        currentCellId,
+                        currentCellIndex,
+                        contextSize,
+                        Boolean(completionConfig.allowHtmlPredictions),
+                    ),
+                    currentCellSourceContent,
+                    Boolean(completionConfig.allowHtmlPredictions),
+                    fewShotExampleFormat || "source-and-target",
+                    sourceLanguage,
+                )
+                : messages;
+            const llmResult = await callLLM(fallbackMessages, completionConfig, token);
             const completion = llmResult.content;
             const allowHtml = Boolean(completionConfig.allowHtmlPredictions);
 
@@ -315,7 +409,7 @@ export async function llmCompletion(
             const variants = [singleVariant, singleVariant];
 
             if (debugMode) {
-                logDebugMessages(messages, completion, variants);
+                logDebugMessages(fallbackMessages, completion, variants);
             }
 
             return {

--- a/src/providers/translationSuggestions/shared.ts
+++ b/src/providers/translationSuggestions/shared.ts
@@ -3,6 +3,7 @@ import { ChatMessage, MinimalCellResult, TranslationPair } from "../../../types"
 import { CodexNotebookReader } from "../../serializer";
 import { CodexCellTypes } from "../../../types/enums";
 import { tokenizeText } from "../../utils/nlpUtils";
+import type { IdmlTranslationSegment } from "./idmlStructuredTranslation";
 
 export async function fetchFewShotExamples(
   sourceContent: string,
@@ -216,9 +217,11 @@ export function buildMessages(
   currentCellSourceContent: string,
   allowHtml: boolean = false,
   exampleFormat: string = "source-and-target",
-  sourceLanguage: string | null = null
+  sourceLanguage: string | null = null,
+  structuredSegments: readonly IdmlTranslationSegment[] | null = null,
 ): ChatMessage[] {
   let systemMessage = chatSystemMessage || `You are a helpful assistant`;
+  const usesStructuredSegments = Boolean(structuredSegments?.length);
 
   if (exampleFormat === "target-only") {
     systemMessage += `\n\nReference translations are provided in XML <target> tags. Use these as examples of the translation style and patterns you should follow.`;
@@ -226,7 +229,9 @@ export function buildMessages(
     systemMessage += `\n\nInput sections for examples and context are provided in XML. Only use values within <source> and <target> tags.`;
   }
   // Preserve line breaks and specify output format
-  if (allowHtml) {
+  if (usesStructuredSegments) {
+    systemMessage += `\n\nTranslate all segments as one connected passage. Return only a JSON object matching the required response schema, with exactly one {index, translation} item for every source segment. Do not return HTML, XML, Markdown fences, or commentary. Keep wording in its corresponding segment when natural, but you may redistribute wording between segment translations when target-language grammar requires it. Empty segment translations are allowed only when wording has been moved to another required segment.`;
+  } else if (allowHtml) {
     systemMessage += `\n\nYou may include inline HTML tags when appropriate (e.g., <span>, <i>, <b>) consistent with examples. Preserve original line breaks from <currentTask><source> by returning text with the same number of lines separated by newline characters.`;
   } else {
     systemMessage += `\n\nReturn plain text only (no XML/HTML). Preserve original line breaks from <currentTask><source> by returning text with the same number of lines separated by newline characters.`;
@@ -238,20 +243,34 @@ export function buildMessages(
   systemMessage += `\n\n1. Analyze the provided reference data to understand the translation patterns and style.`;
   systemMessage += `\n2. Complete the partial or complete translation of the line.`;
   systemMessage += `\n3. Ensure your translation fits seamlessly with the existing partial translation.`;
-  systemMessage += `\n4. Provide only the completed translation without any additional commentary or metadata.`;
+  systemMessage += usesStructuredSegments
+    ? `\n4. Provide only the completed segment translations in the required JSON structure.`
+    : `\n4. Provide only the completed translation without any additional commentary or metadata.`;
   systemMessage += `\n5. Translate only into the target language ${targetLanguage || ""}.`;
   systemMessage += `\n6. Pay careful attention to the provided reference data.`;
   systemMessage += `\n7. If in doubt, err on the side of literalness.`;
-  if (allowHtml) {
+  if (allowHtml && !usesStructuredSegments) {
     systemMessage += `\n8. If the project has any styles, return HTML with the appropriate tags or classes as per the examples in the translation memory.`;
   }
 
-  systemMessage += `\n\nWrap your final translation in <final_answer>...</final_answer> XML tags. Do not include any other XML tags in your response outside of these tags.`;
+  if (!usesStructuredSegments) {
+    systemMessage += `\n\nWrap your final translation in <final_answer>...</final_answer> XML tags. Do not include any other XML tags in your response outside of these tags.`;
+  }
 
   const contextXml = `<context>\n${precedingContextPairs.filter(Boolean).join("\n")}\n</context>`;
-  const currentTaskXml = allowHtml
-    ? `<currentTask><source>${wrapCdata(currentCellSourceContent)}</source></currentTask>`
-    : `<currentTask><source>${xmlEscape(currentCellSourceContent)}</source></currentTask>`;
+  const currentTask = usesStructuredSegments
+    ? JSON.stringify({
+      fullSourceText: currentCellSourceContent,
+      segments: structuredSegments!.map((segment) => ({
+        index: segment.index,
+        sourceText: segment.sourceText,
+        characterStyle: segment.characterStyle ?? null,
+        separatorBefore: segment.separatorBefore,
+      })),
+    }, null, 2)
+    : allowHtml
+      ? `<currentTask><source>${wrapCdata(currentCellSourceContent)}</source></currentTask>`
+      : `<currentTask><source>${xmlEscape(currentCellSourceContent)}</source></currentTask>`;
 
   const userMessage = [
     "## Instructions",
@@ -260,8 +279,8 @@ export function buildMessages(
     fewShotExamples,
     "## Current Context (XML)",
     contextXml,
-    "## Current Task (XML)",
-    currentTaskXml,
+    usesStructuredSegments ? "## Current Task (JSON)" : "## Current Task (XML)",
+    currentTask,
   ].join("\n\n");
 
   return [
@@ -305,4 +324,3 @@ export async function writeDebugMessages(messages: ChatMessage[], response: stri
     new TextEncoder().encode(messagesContent + "\n\nAPI Response:\n" + response)
   );
 }
-

--- a/src/test/suite/unit/idmlStructuredCompletion.test.ts
+++ b/src/test/suite/unit/idmlStructuredCompletion.test.ts
@@ -1,0 +1,199 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import type { CodexNotebookReader } from "../../../serializer";
+import type { CompletionConfig } from "../../../utils/llmUtils";
+import { llmCompletion } from "../../../providers/translationSuggestions/llmCompletion";
+
+const cellId = "dictionary-cell-1";
+const sourceHtml =
+    '<p class="indesign-paragraph" data-story-id="story-1">' +
+    '<span class="idml-segment" data-segment-index="0" data-character-style="Bold">Reference</span>' +
+    '<span class="idml-eoc" data-eoc="1" aria-hidden="true"></span>' +
+    '<span class="idml-segment" data-segment-index="1" data-character-style="Body">Dictionary explanation</span>' +
+    "</p>";
+
+const config: CompletionConfig = {
+    endpoint: "https://example.test/api/v1",
+    apiKey: "test-key",
+    model: "default",
+    contextSize: "small",
+    additionalResourceDirectory: "",
+    contextOmission: false,
+    sourceBookWhitelist: "",
+    temperature: 0.2,
+    mainChatLanguage: "English",
+    chatSystemMessage: "Translate accurately.",
+    numberOfFewShotExamples: 2,
+    debugMode: false,
+    useOnlyValidatedExamples: false,
+    abTestingEnabled: false,
+    allowHtmlPredictions: false,
+    fewShotExampleFormat: "source-and-target",
+};
+
+const reader = {
+    getCellIndex: async () => 0,
+    getCellIds: async () => [cellId],
+    cellsUpTo: async () => [],
+    getEffectiveCellContent: async () => "",
+} as unknown as CodexNotebookReader;
+
+suite("IDML structured LLM completion", () => {
+    let executeCommandStub: sinon.SinonStub;
+    let callLLMStub: sinon.SinonStub;
+    let statusStub: sinon.SinonStub;
+
+    setup(async () => {
+        executeCommandStub = sinon.stub(vscode.commands, "executeCommand").callsFake(
+            async (command: string) => {
+                if (command === "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells") {
+                    return { cellId, content: sourceHtml };
+                }
+                if (command === "codex-editor-extension.getTranslationPairsFromSourceCellQuery") {
+                    return [];
+                }
+                return undefined;
+            },
+        );
+
+        const llmUtils = await import("../../../utils/llmUtils");
+        callLLMStub = sinon.stub(llmUtils, "callLLM");
+
+        const extension = await import("../../../extension");
+        statusStub = sinon.stub(extension, "getAutoCompleteStatusBarItem").returns({
+            show: () => undefined,
+            hide: () => undefined,
+        } as vscode.StatusBarItem);
+    });
+
+    teardown(() => {
+        executeCommandStub.restore();
+        callLLMStub.restore();
+        statusStub.restore();
+    });
+
+    test("uses one structured request and returns deterministically reconstructed HTML", async () => {
+        callLLMStub.resolves({
+            content: JSON.stringify({
+                segments: [
+                    { index: 0, translation: "Referencia" },
+                    { index: 1, translation: "Explicación del diccionario" },
+                ],
+            }),
+            generationId: "generation-structured",
+        });
+
+        const result = await llmCompletion(
+            reader,
+            cellId,
+            config,
+            new vscode.CancellationTokenSource().token,
+            true,
+            false,
+            { enforceHtmlStructure: true },
+        );
+
+        assert.strictEqual(callLLMStub.callCount, 1);
+        assert.strictEqual(result.generationId, "generation-structured");
+        assert.strictEqual(result.variants[0], sourceHtml
+            .replace("Reference", "Referencia")
+            .replace("Dictionary explanation", "Explicación del diccionario"));
+
+        const [messages, , , options] = callLLMStub.firstCall.args;
+        const systemMessage = messages.find((message: { role: string; }) => message.role === "system");
+        const userMessage = messages.find((message: { role: string; }) => message.role === "user");
+        assert.ok(systemMessage.content.includes("JSON object"));
+        assert.ok(!systemMessage.content.includes("<final_answer>"));
+        assert.ok(userMessage.content.includes('"index": 0'));
+        assert.ok(userMessage.content.includes('"sourceText": "Reference"'));
+        assert.strictEqual(options.responseFormat.type, "json_schema");
+    });
+
+    test("falls back to the established completion when structured output is malformed", async () => {
+        callLLMStub.onFirstCall().resolves({ content: "not-json", generationId: "bad-generation" });
+        callLLMStub.onSecondCall().resolves({
+            content: "<final_answer>Legacy translation</final_answer>",
+            generationId: "legacy-generation",
+        });
+
+        const result = await llmCompletion(
+            reader,
+            cellId,
+            config,
+            new vscode.CancellationTokenSource().token,
+            true,
+            false,
+            { enforceHtmlStructure: true },
+        );
+
+        assert.strictEqual(callLLMStub.callCount, 2);
+        assert.strictEqual(callLLMStub.firstCall.args[3].responseFormat.type, "json_schema");
+        assert.strictEqual(callLLMStub.secondCall.args[3], undefined);
+        assert.deepStrictEqual(result.variants, ["Legacy translation", "Legacy translation"]);
+        assert.strictEqual(result.generationId, "legacy-generation");
+    });
+
+    test("does not turn cancellation into a legacy retry", async () => {
+        callLLMStub.rejects(new vscode.CancellationError());
+
+        await assert.rejects(
+            llmCompletion(
+                reader,
+                cellId,
+                config,
+                new vscode.CancellationTokenSource().token,
+                true,
+                false,
+                { enforceHtmlStructure: true },
+            ),
+            (error: unknown) => error instanceof vscode.CancellationError,
+        );
+        assert.strictEqual(callLLMStub.callCount, 1);
+    });
+
+    test("keeps the legacy request for single-segment IDML", async () => {
+        const singleSegmentSource =
+            '<p><span class="idml-segment" data-segment-index="0">Only segment</span></p>';
+        executeCommandStub.callsFake(async (command: string) => {
+            if (command === "codex-editor-extension.getSourceCellByCellIdFromAllSourceCells") {
+                return { cellId, content: singleSegmentSource };
+            }
+            if (command === "codex-editor-extension.getTranslationPairsFromSourceCellQuery") return [];
+            return undefined;
+        });
+        callLLMStub.resolves({ content: "<final_answer>Translation</final_answer>" });
+
+        const result = await llmCompletion(
+            reader,
+            cellId,
+            config,
+            new vscode.CancellationTokenSource().token,
+            true,
+            false,
+            { enforceHtmlStructure: true },
+        );
+
+        assert.strictEqual(callLLMStub.callCount, 1);
+        assert.strictEqual(callLLMStub.firstCall.args[3], undefined);
+        assert.deepStrictEqual(result.variants, ["Translation", "Translation"]);
+    });
+
+    test("keeps the legacy request when structure enforcement is disabled", async () => {
+        callLLMStub.resolves({ content: "<final_answer>Translation</final_answer>" });
+
+        const result = await llmCompletion(
+            reader,
+            cellId,
+            config,
+            new vscode.CancellationTokenSource().token,
+            true,
+            false,
+            { enforceHtmlStructure: false },
+        );
+
+        assert.strictEqual(callLLMStub.callCount, 1);
+        assert.strictEqual(callLLMStub.firstCall.args[3], undefined);
+        assert.deepStrictEqual(result.variants, ["Translation", "Translation"]);
+    });
+});

--- a/src/test/suite/unit/idmlStructuredTranslation.test.ts
+++ b/src/test/suite/unit/idmlStructuredTranslation.test.ts
@@ -1,0 +1,142 @@
+import * as assert from "assert";
+import {
+    buildIdmlStructuredResponseFormat,
+    extractIdmlStructuredSource,
+    reconstructIdmlTranslationHtml,
+} from "../../../providers/translationSuggestions/idmlStructuredTranslation";
+import { compareHtmlStructure } from "../../../../sharedUtils/htmlStructureUtils";
+
+const sourceHtml =
+    '<p class="indesign-paragraph" data-story-id="story-1">' +
+    '<span class="idml-segment selected" data-segment-index="4" data-character-style="Bold">Reference &amp; title</span>' +
+    '<span class="idml-eoc" data-eoc="1" aria-hidden="true"></span>' +
+    "<span data-character-style='Body' data-segment-index='7' class='extra idml-segment'>Dictionary text</span>" +
+    '<br class="idml-eoc" data-eoc="1" />' +
+    '<span class="idml-segment" data-segment-index="9">Final line</span>' +
+    "</p>";
+
+suite("IDML structured translation", () => {
+    test("extracts indexed text, styles, and separators in document order", () => {
+        const source = extractIdmlStructuredSource(sourceHtml);
+
+        assert.ok(source);
+        assert.deepStrictEqual(
+            source.segments.map(({ index, sourceText, characterStyle, separatorBefore }) => ({
+                index,
+                sourceText,
+                characterStyle,
+                separatorBefore,
+            })),
+            [
+                {
+                    index: 4,
+                    sourceText: "Reference & title",
+                    characterStyle: "Bold",
+                    separatorBefore: "none",
+                },
+                {
+                    index: 7,
+                    sourceText: "Dictionary text",
+                    characterStyle: "Body",
+                    separatorBefore: "continuation",
+                },
+                {
+                    index: 9,
+                    sourceText: "Final line",
+                    characterStyle: undefined,
+                    separatorBefore: "line-break",
+                },
+            ],
+        );
+    });
+
+    test("replaces text by index while preserving all source markup exactly", () => {
+        const source = extractIdmlStructuredSource(sourceHtml);
+        assert.ok(source);
+
+        const result = reconstructIdmlTranslationHtml(source, JSON.stringify({
+            // Deliberately return segments out of source order: indexes, not array
+            // positions, are the stable reconstruction contract.
+            segments: [
+                { index: 9, translation: "Línea final" },
+                { index: 4, translation: 'Referencia <principal> & "título"' },
+                { index: 7, translation: "Texto del diccionario" },
+            ],
+        }));
+
+        assert.strictEqual(
+            result,
+            sourceHtml
+                .replace("Reference &amp; title", "Referencia &lt;principal&gt; &amp; &quot;título&quot;")
+                .replace("Dictionary text", "Texto del diccionario")
+                .replace("Final line", "Línea final"),
+        );
+        assert.strictEqual(compareHtmlStructure(sourceHtml, result).isMatch, true);
+    });
+
+    test("accepts a JSON response wrapped in a markdown fence for compatibility", () => {
+        const source = extractIdmlStructuredSource(sourceHtml);
+        assert.ok(source);
+
+        const result = reconstructIdmlTranslationHtml(
+            source,
+            '```json\n{"segments":[{"index":4,"translation":"A"},{"index":7,"translation":"B"},{"index":9,"translation":"C"}]}\n```',
+        );
+
+        assert.ok(result.includes('data-segment-index="4" data-character-style="Bold">A</span>'));
+        assert.ok(result.includes("data-segment-index='7' class='extra idml-segment'>B</span>"));
+        assert.ok(result.includes('data-segment-index="9">C</span>'));
+    });
+
+    test("builds a strict schema constrained to the source indexes", () => {
+        const source = extractIdmlStructuredSource(sourceHtml);
+        assert.ok(source);
+
+        const format = buildIdmlStructuredResponseFormat(source);
+        assert.strictEqual(format.type, "json_schema");
+        if (format.type !== "json_schema") return;
+        assert.strictEqual(format.json_schema.strict, true);
+
+        const schema = format.json_schema.schema as any;
+        assert.deepStrictEqual(schema.properties.segments.items.properties.index.enum, [4, 7, 9]);
+    });
+
+    test("rejects duplicate, missing, unknown, and empty translations", () => {
+        const source = extractIdmlStructuredSource(sourceHtml);
+        assert.ok(source);
+
+        const invalidResponses = [
+            { segments: [{ index: 4, translation: "A" }, { index: 4, translation: "B" }, { index: 9, translation: "C" }] },
+            { segments: [{ index: 4, translation: "A" }, { index: 7, translation: "B" }] },
+            { segments: [{ index: 4, translation: "A" }, { index: 7, translation: "B" }, { index: 100, translation: "C" }] },
+            { segments: [{ index: 4, translation: "" }, { index: 7, translation: " " }, { index: 9, translation: "" }] },
+        ];
+
+        for (const response of invalidResponses) {
+            assert.throws(() => reconstructIdmlTranslationHtml(source, JSON.stringify(response)));
+        }
+    });
+
+    test("opts out safely for malformed or unsupported source fragments", () => {
+        assert.strictEqual(extractIdmlStructuredSource("<p>Plain source</p>"), null);
+        assert.strictEqual(
+            extractIdmlStructuredSource(
+                '<p><span class="idml-segment" data-segment-index="1"><em>Nested</em></span></p>',
+            ),
+            null,
+        );
+        assert.strictEqual(
+            extractIdmlStructuredSource(
+                '<p><span class="idml-segment" data-segment-index="1">A</span>' +
+                '<span class="idml-segment" data-segment-index="1">B</span></p>',
+            ),
+            null,
+        );
+        assert.strictEqual(
+            extractIdmlStructuredSource(
+                '<p><span class="idml-segment" data-segment-index="1">Unclosed</p>',
+            ),
+            null,
+        );
+    });
+});

--- a/src/utils/llmUtils.ts
+++ b/src/utils/llmUtils.ts
@@ -1,6 +1,9 @@
 import OpenAI from "openai";
 import { ChatMessage } from "../../types";
-import { ChatCompletionMessageParam } from "openai/resources";
+import {
+    ChatCompletionCreateParamsNonStreaming,
+    ChatCompletionMessageParam,
+} from "openai/resources/chat/completions";
 import { getAuthApi } from "../extension";
 import * as vscode from "vscode";
 import { MetadataManager } from "./metadataManager";
@@ -19,10 +22,15 @@ export interface LLMCallResult {
     generationId?: string;
 }
 
+export interface LLMCallOptions {
+    responseFormat?: ChatCompletionCreateParamsNonStreaming["response_format"];
+}
+
 export async function callLLM(
     messages: ChatMessage[],
     config: CompletionConfig,
-    cancellationToken?: vscode.CancellationToken
+    cancellationToken?: vscode.CancellationToken,
+    options?: LLMCallOptions,
 ): Promise<LLMCallResult> {
     try {
         // Check for cancellation before starting
@@ -82,6 +90,18 @@ export async function callLLM(
                 throw new vscode.CancellationError();
             }
 
+            const request: ChatCompletionCreateParamsNonStreaming = {
+                model,
+                messages: messages as ChatCompletionMessageParam[],
+                // Let the server decide temperature for the default model.
+                ...(model.toLowerCase() === "default"
+                    ? {}
+                    : model.toLowerCase() === "gpt-5"
+                        ? { temperature: 1 }
+                        : { temperature: config.temperature }),
+                ...(options?.responseFormat ? { response_format: options.responseFormat } : {}),
+            };
+
             // Create an AbortController for the fetch request if cancellation token is provided
             let abortController: AbortController | undefined;
             if (cancellationToken) {
@@ -97,12 +117,7 @@ export async function callLLM(
 
                 // Wrap the completion call to ensure cleanup
                 try {
-                    const completion = await openai.chat.completions.create({
-                        model,
-                        messages: messages as ChatCompletionMessageParam[],
-                        // Let the server decide temperature for the default model.
-                        ...(model.toLowerCase() === "default" ? {} : (model.toLowerCase() === "gpt-5" ? { temperature: 1 } : { temperature: config.temperature })),
-                    }, {
+                    const completion = await openai.chat.completions.create(request, {
                         signal: abortController.signal
                     });
 
@@ -134,11 +149,7 @@ export async function callLLM(
                 }
             } else {
                 // No cancellation token provided, use the original logic
-                const completion = await openai.chat.completions.create({
-                    model,
-                    messages: messages as ChatCompletionMessageParam[],
-                    ...(model.toLowerCase() === "default" ? {} : (model.toLowerCase() === "gpt-5" ? { temperature: 1 } : { temperature: config.temperature })),
-                });
+                const completion = await openai.chat.completions.create(request);
 
                 if (
                     completion.choices &&


### PR DESCRIPTION
## fix: generate structured IDML translations in one request

## Summary

Addresses an identified cause of slow Sparkle generation in multi-segment IDML cells: plain-text translations could not preserve the imported structure, triggering an additional LLM request to repair the HTML.

Eligible cells now request indexed JSON translations and reconstruct the original HTML locally, avoiding the repair request on successful structured responses.

Related to #1160. Broader project-wide performance verification remains pending.

## Changes

- Extract source text segments and their `data-segment-index` values.
- Request schema-constrained JSON translations through `response_format`.
- Validate segment counts, indexes, duplicates, and translation types before reconstruction.
- Reinsert escaped translations while preserving original tags, attributes, styles, and separators.
- Retain the legacy fallback for unsupported providers or invalid responses; cancellation does not trigger a retry.
- Limit the new path to supported multi-segment IDML cells with HTML structure enforcement enabled. Other formats, single-segment cells, and merged/range cells retain existing behavior.
- Add regression coverage for reconstruction, validation, fallback, cancellation, and compatibility.

## Test Checklist

### Automated verification

- [x] Extension build passes.
- [x] ESLint passes.
- [x] Full extension test suite passes: 1,530 passing, 10 pending.
- [x] Valid structured output completes with one LLM request.
- [x] Reconstruction preserves markup and correctly maps out-of-order segment responses.
- [x] Invalid responses are rejected and the legacy fallback remains functional.
- [x] Cancellation does not start a fallback request.
- [x] Single-segment cells and disabled structure enforcement retain the legacy path.

### Performance and acceptance verification

- [x] Reviewed the supplied IDML recording: translation appears after approximately 13–14 seconds, without the additional HTML-repair stage.
- [x] Verify generation speed in NEW ACT–REV.
- [x] Verify representative front/back matter and Bible Dictionary cells.
- [x] Confirm whether recent migration edits contributed to the reported slowdown.
- [ ] Confirm normal generation speed with the partner and Patrice.